### PR TITLE
Simplify supplier invoice status workflow

### DIFF
--- a/app/Models/FacturiFurnizori/FacturaFurnizor.php
+++ b/app/Models/FacturiFurnizori/FacturaFurnizor.php
@@ -30,7 +30,6 @@ class FacturaFurnizor extends Model
     ];
 
     public const STATUS_NEPLATITA = 'neplatita';
-    public const STATUS_IN_CALUP = 'in_calup';
     public const STATUS_PLATITA = 'platita';
 
     /**

--- a/app/Services/FacturiFurnizori/PlataCalupService.php
+++ b/app/Services/FacturiFurnizori/PlataCalupService.php
@@ -32,11 +32,11 @@ class PlataCalupService
             $facturi->each(function (FacturaFurnizor $factura) {
                 if ($factura->status === FacturaFurnizor::STATUS_PLATITA) {
                     throw ValidationException::withMessages([
-                        'facturi' => "Factura {$factura->numar_factura} este deja platita.",
+                        'facturi' => "Factura {$factura->numar_factura} este deja atasata unui calup.",
                     ]);
                 }
 
-                if ($factura->status === FacturaFurnizor::STATUS_IN_CALUP) {
+                if ($factura->calupuri()->exists()) {
                     throw ValidationException::withMessages([
                         'facturi' => "Factura {$factura->numar_factura} este deja atasata unui calup.",
                     ]);
@@ -53,7 +53,7 @@ class PlataCalupService
 
             FacturaFurnizor::query()
                 ->whereIn('id', $facturaIds)
-                ->update(['status' => FacturaFurnizor::STATUS_IN_CALUP]);
+                ->update(['status' => FacturaFurnizor::STATUS_PLATITA]);
         });
     }
 
@@ -65,9 +65,7 @@ class PlataCalupService
         $this->db->transaction(function () use ($calup, $factura) {
             $calup->facturi()->where('ff_facturi.id', $factura->id)->detach();
 
-            if ($factura->status === FacturaFurnizor::STATUS_IN_CALUP) {
-                $factura->update(['status' => FacturaFurnizor::STATUS_NEPLATITA]);
-            }
+            $factura->update(['status' => FacturaFurnizor::STATUS_NEPLATITA]);
         });
     }
 
@@ -113,7 +111,7 @@ class PlataCalupService
             if ($facturiIds->isNotEmpty()) {
                 FacturaFurnizor::query()
                     ->whereIn('id', $facturiIds)
-                    ->update(['status' => FacturaFurnizor::STATUS_IN_CALUP]);
+                    ->update(['status' => FacturaFurnizor::STATUS_PLATITA]);
             }
         });
     }

--- a/database/factories/FacturaFurnizorFactory.php
+++ b/database/factories/FacturaFurnizorFactory.php
@@ -38,6 +38,6 @@ class FacturaFurnizorFactory extends Factory
 
     public function inCalup(): self
     {
-        return $this->state(fn () => ['status' => FacturaFurnizor::STATUS_IN_CALUP]);
+        return $this->state(fn () => ['status' => FacturaFurnizor::STATUS_PLATITA]);
     }
 }

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -5,7 +5,6 @@
     $calupStatusLabels = $statusOptions;
     $facturaStatusLabels = [
         \App\Models\FacturiFurnizori\FacturaFurnizor::STATUS_NEPLATITA => 'Neplătită',
-        \App\Models\FacturiFurnizori\FacturaFurnizor::STATUS_IN_CALUP => 'Programată la plată',
         \App\Models\FacturiFurnizori\FacturaFurnizor::STATUS_PLATITA => 'Plătită',
     ];
 @endphp

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -68,11 +68,6 @@
                                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
                                     </a>
                                 </li>
-                                <li>
-                                    <a class="dropdown-item" href="{{ route('facturi-furnizori.plati-calupuri.index') }}">
-                                        <i class="fa-solid fa-layer-group me-1"></i>Calupuri plati furnizori
-                                    </a>
-                                </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     <a class="dropdown-item" href="/file-manager-personalizat" title="File Explorer">
@@ -252,11 +247,6 @@
                                 <li>
                                     <a class="dropdown-item" href="{{ route('facturi-furnizori.facturi.index') }}">
                                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" href="{{ route('facturi-furnizori.plati-calupuri.index') }}">
-                                        <i class="fa-solid fa-layer-group me-1"></i>Calupuri plati furnizori
                                     </a>
                                 </li>
                                 <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
## Summary
- default the supplier invoice index to unpaid invoices with quick tabs for paid and all results
- reduce the invoice workflow to unpaid/paid statuses and update batch operations to keep those in sync
- allow creating payment batches from the invoice list via a modal and drop navigation links to the separate batches area

## Testing
- Not run (PHPUnit binary not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e51c7ef6408326a67a655cf0051ffb