### PR TITLE
Improve supplier invoice filtering and calup flow

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -88,9 +88,7 @@ class PlataCalupController extends Controller
         $facturi = $payload['facturi'] ?? [];
         unset($payload['facturi']);
 
-        if (isset($payload['status']) && $payload['status'] !== PlataCalup::STATUS_DESCHIS) {
-            $payload['status'] = PlataCalup::STATUS_DESCHIS;
-        }
+        $payload['status'] = PlataCalup::STATUS_DESCHIS;
 
         if ($request->hasFile('fisier_pdf')) {
             $payload['fisier_pdf'] = $this->uploadFisierPdf($request->file('fisier_pdf'));
@@ -106,7 +104,11 @@ class PlataCalupController extends Controller
         }
 
         return redirect()
-            ->route('facturi-furnizori.plati-calupuri.show', $calup)
+            ->route('facturi-furnizori.facturi.index', array_filter([
+                'status' => $request->input('status', FacturaFurnizor::STATUS_NEPLATITA),
+                'calup' => $calup->denumire_calup,
+                'calup_data_plata' => optional($calup->data_plata)?->format('Y-m-d'),
+            ], fn ($value) => !is_null($value) && $value !== ''))
             ->with('status', 'Calupul a fost creat cu succes.');
     }
 


### PR DESCRIPTION
## Summary
- extend the supplier invoice listing filters to include calup name and payment date while keeping the search defaults intact
- restyle the “Pregătește calup” modal, remove the unused status field, and add a Bootstrap warning modal when no invoices are selected
- default new calup records to “deschis” and redirect back to the invoice list with the new calup pre-selected after creation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5286bc22883268d52e35a40cb3563