### PR TITLE
Fix supplier invoice filters and calup modal handling

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -88,9 +88,7 @@ class PlataCalupController extends Controller
         $facturi = $payload['facturi'] ?? [];
         unset($payload['facturi']);
 
-        if (isset($payload['status']) && $payload['status'] !== PlataCalup::STATUS_DESCHIS) {
-            $payload['status'] = PlataCalup::STATUS_DESCHIS;
-        }
+        $payload['status'] = PlataCalup::STATUS_DESCHIS;
 
         if ($request->hasFile('fisier_pdf')) {
             $payload['fisier_pdf'] = $this->uploadFisierPdf($request->file('fisier_pdf'));
@@ -106,7 +104,11 @@ class PlataCalupController extends Controller
         }
 
         return redirect()
-            ->route('facturi-furnizori.plati-calupuri.show', $calup)
+            ->route('facturi-furnizori.facturi.index', array_filter([
+                'status' => $request->input('status', FacturaFurnizor::STATUS_NEPLATITA),
+                'calup' => $calup->denumire_calup,
+                'calup_data_plata' => optional($calup->data_plata)?->format('Y-m-d'),
+            ], fn ($value) => !is_null($value) && $value !== ''))
             ->with('status', 'Calupul a fost creat cu succes.');
     }
 

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -4,7 +4,7 @@
 
 <div class="row">
     <div class="col-lg-6 mb-3">
-        <label for="denumire_furnizor" class="mb-0 ps-2">Denumire furnizor</label>
+        <label for="denumire_furnizor" class="mb-0 ps-2">Denumire furnizor<span class="text-danger">*</span></label>
         <input
             type="text"
             name="denumire_furnizor"
@@ -18,7 +18,7 @@
         <datalist id="furnizor-suggestions"></datalist>
     </div>
     <div class="col-lg-6 mb-3">
-        <label for="numar_factura" class="mb-0 ps-2">Număr factură</label>
+        <label for="numar_factura" class="mb-0 ps-2">Număr factură<span class="text-danger">*</span></label>
         <input
             type="text"
             name="numar_factura"
@@ -32,7 +32,7 @@
 
 <div class="row">
     <div class="col-lg-3 mb-3">
-        <label for="data_factura" class="mb-0 ps-2">Data factură</label>
+        <label for="data_factura" class="mb-0 ps-2">Data factură<span class="text-danger">*</span></label>
         <input
             type="date"
             name="data_factura"
@@ -43,7 +43,7 @@
         >
     </div>
     <div class="col-lg-3 mb-3">
-        <label for="data_scadenta" class="mb-0 ps-2">Data scadență</label>
+        <label for="data_scadenta" class="mb-0 ps-2">Data scadență<span class="text-danger">*</span></label>
         <input
             type="date"
             name="data_scadenta"
@@ -54,7 +54,7 @@
         >
     </div>
     <div class="col-lg-3 mb-3">
-        <label for="suma" class="mb-0 ps-2">Sumă</label>
+        <label for="suma" class="mb-0 ps-2">Sumă<span class="text-danger">*</span></label>
         <input
             type="number"
             name="suma"
@@ -67,7 +67,7 @@
         >
     </div>
     <div class="col-lg-3 mb-3">
-        <label for="moneda" class="mb-0 ps-2">Monedă</label>
+        <label for="moneda" class="mb-0 ps-2">Monedă<span class="text-danger">*</span></label>
         <input
             type="text"
             name="moneda"


### PR DESCRIPTION
## Summary
- treat empty "scadente in zile" inputs as null so supplier invoice search works as expected
- move the "Pregătește calup" action under "Adaugă factură", ensure the warning uses a bootstrap modal, and keep the calup modal functional with the selected invoices
- highlight required fields in the add/edit invoice form with an asterisk

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5286bc22883268d52e35a40cb3563