### PR TITLE
Remove calup status logic from supplier invoices

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
@@ -75,7 +75,7 @@ class FacturaFurnizorController extends Controller
         }
 
         $facturi = $query
-            ->with('calupuri:id,denumire_calup,status,data_plata')
+            ->with('calupuri:id,denumire_calup,data_plata')
             ->orderBy('data_scadenta')
             ->orderBy('denumire_furnizor')
             ->paginate(25)

--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -22,17 +22,12 @@ class PlataCalupController extends Controller
     public function index(Request $request)
     {
         $filters = [
-            'status' => $request->string('status')->toString() ?: null,
             'data_plata_de_la' => $request->string('data_plata_de_la')->toString() ?: null,
             'data_plata_pana' => $request->string('data_plata_pana')->toString() ?: null,
             'cauta' => $request->string('cauta')->toString() ?: null,
         ];
 
         $query = PlataCalup::query()->withCount('facturi');
-
-        if ($filters['status']) {
-            $query->where('status', $filters['status']);
-        }
 
         if ($filters['data_plata_de_la']) {
             $query->whereDate('data_plata', '>=', Carbon::parse($filters['data_plata_de_la']));
@@ -57,7 +52,6 @@ class PlataCalupController extends Controller
         return view('facturiFurnizori.calupuri.index', [
             'calupuri' => $calupuri,
             'filters' => $filters,
-            'statusOptions' => $this->statusOptions(),
         ]);
     }
 
@@ -76,7 +70,6 @@ class PlataCalupController extends Controller
             ->get();
 
         return view('facturiFurnizori.calupuri.create', [
-            'statusOptions' => $this->statusOptions(),
             'facturiDisponibile' => $facturiDisponibile,
             'facturiSelectate' => $facturiSelectate,
         ]);
@@ -87,8 +80,6 @@ class PlataCalupController extends Controller
         $payload = $request->validated();
         $facturi = $payload['facturi'] ?? [];
         unset($payload['facturi']);
-
-        $payload['status'] = PlataCalup::STATUS_DESCHIS;
 
         if ($request->hasFile('fisier_pdf')) {
             $payload['fisier_pdf'] = $this->uploadFisierPdf($request->file('fisier_pdf'));
@@ -121,7 +112,6 @@ class PlataCalupController extends Controller
         return view('facturiFurnizori.calupuri.show', [
             'calup' => $plataCalup,
             'facturiDisponibile' => $facturiDisponibile,
-            'statusOptions' => $this->statusOptions(),
         ]);
     }
 
@@ -145,20 +135,7 @@ class PlataCalupController extends Controller
             unset($payload['fisier_pdf']);
         }
 
-        $statusCurent = $plataCalup->status;
-        $statusNou = $payload['status'] ?? $statusCurent;
-
-        if ($statusCurent !== PlataCalup::STATUS_PLATIT && $statusNou === PlataCalup::STATUS_PLATIT) {
-            $this->plataCalupService->markAsPaid($plataCalup, isset($payload['data_plata']) ? Carbon::parse($payload['data_plata']) : null);
-            $plataCalup->refresh();
-            unset($payload['status'], $payload['data_plata']);
-        } elseif ($statusCurent === PlataCalup::STATUS_PLATIT && $statusNou === PlataCalup::STATUS_DESCHIS) {
-            $this->plataCalupService->reopen($plataCalup);
-            $plataCalup->refresh();
-            unset($payload['status']);
-        } else {
-            $plataCalup->update($payload);
-        }
+        $plataCalup->update($payload);
 
         if (is_array($facturi)) {
             $idsCurente = $plataCalup->facturi()->pluck('ff_facturi.id')->toArray();
@@ -186,10 +163,6 @@ class PlataCalupController extends Controller
 
     public function destroy(PlataCalup $plataCalup)
     {
-        if ($plataCalup->status === PlataCalup::STATUS_PLATIT) {
-            return back()->with('error', 'Un calup platit nu poate fi sters.');
-        }
-
         $plataCalup->load('facturi');
 
         foreach ($plataCalup->facturi as $factura) {
@@ -225,25 +198,6 @@ class PlataCalupController extends Controller
         return back()->with('status', 'Factura a fost eliminata din calup.');
     }
 
-    public function marcheazaPlatit(Request $request, PlataCalup $plataCalup)
-    {
-        $dataPlata = $request->string('data_plata')->toString();
-        $this->plataCalupService->markAsPaid($plataCalup, $dataPlata ? Carbon::parse($dataPlata) : null);
-
-        return redirect()
-            ->route('facturi-furnizori.plati-calupuri.show', $plataCalup)
-            ->with('status', 'Calupul a fost marcat ca platit.');
-    }
-
-    public function redeschide(PlataCalup $plataCalup)
-    {
-        $this->plataCalupService->reopen($plataCalup);
-
-        return redirect()
-            ->route('facturi-furnizori.plati-calupuri.show', $plataCalup)
-            ->with('status', 'Calupul a fost redeschis.');
-    }
-
     public function descarcaFisier(PlataCalup $plataCalup)
     {
         if (!$plataCalup->fisier_pdf || !Storage::exists($plataCalup->fisier_pdf)) {
@@ -269,15 +223,6 @@ class PlataCalupController extends Controller
         Storage::putFileAs($folder, $file, $filename);
 
         return $path;
-    }
-
-    private function statusOptions(): array
-    {
-        return [
-            PlataCalup::STATUS_DESCHIS => 'Deschis',
-            PlataCalup::STATUS_PLATIT => 'Plătit',
-            PlataCalup::STATUS_ANULAT => 'Anulat',
-        ];
     }
 }
 

--- a/app/Models/FacturiFurnizori/PlataCalup.php
+++ b/app/Models/FacturiFurnizori/PlataCalup.php
@@ -16,16 +16,11 @@ class PlataCalup extends Model
         'data_plata',
         'fisier_pdf',
         'observatii',
-        'status',
     ];
 
     protected $casts = [
         'data_plata' => 'date',
     ];
-
-    public const STATUS_DESCHIS = 'deschis';
-    public const STATUS_PLATIT = 'platit';
-    public const STATUS_ANULAT = 'anulat';
 
     /**
      * Invoices linked to this payment batch.

--- a/app/Services/FacturiFurnizori/PlataCalupService.php
+++ b/app/Services/FacturiFurnizori/PlataCalupService.php
@@ -4,9 +4,7 @@ namespace App\Services\FacturiFurnizori;
 
 use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\FacturiFurnizori\PlataCalup;
-use Carbon\CarbonInterface;
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
 class PlataCalupService
@@ -48,48 +46,12 @@ class PlataCalupService
     }
 
     /**
-     * Detach an invoice from the batch and revert its status.
+     * Detach an invoice from the batch.
      */
     public function detachFactura(PlataCalup $calup, FacturaFurnizor $factura): void
     {
         $this->db->transaction(function () use ($calup, $factura) {
             $calup->facturi()->where('ff_facturi.id', $factura->id)->detach();
-        });
-    }
-
-    /**
-     * Mark the batch as paid, update payment date and invoice statuses.
-     */
-    public function markAsPaid(PlataCalup $calup, ?CarbonInterface $dataPlata = null): void
-    {
-        $dataPlata = $dataPlata ?? now();
-
-        $this->db->transaction(function () use ($calup, $dataPlata) {
-            $calup->update([
-                'status' => PlataCalup::STATUS_PLATIT,
-                'data_plata' => $dataPlata,
-            ]);
-
-            $facturiIds = $calup->facturi()->pluck('ff_facturi.id');
-
-            if ($facturiIds->isEmpty()) {
-                Log::warning('Calup marcat ca platit fara facturi atasate', ['calup_id' => $calup->id]);
-                return;
-            }
-        });
-    }
-
-    /**
-     * Reopen a paid batch turning invoices back to unpaid.
-     */
-    public function reopen(PlataCalup $calup): void
-    {
-        $this->db->transaction(function () use ($calup) {
-            $calup->update([
-                'status' => PlataCalup::STATUS_DESCHIS,
-                'data_plata' => null,
-            ]);
-
         });
     }
 }

--- a/database/factories/PlataCalupFactory.php
+++ b/database/factories/PlataCalupFactory.php
@@ -20,7 +20,6 @@ class PlataCalupFactory extends Factory
             'data_plata' => null,
             'fisier_pdf' => null,
             'observatii' => $this->faker->optional()->sentence(),
-            'status' => PlataCalup::STATUS_DESCHIS,
         ];
     }
 
@@ -28,7 +27,6 @@ class PlataCalupFactory extends Factory
     {
         return $this->state(function () {
             return [
-                'status' => PlataCalup::STATUS_PLATIT,
                 'data_plata' => Carbon::now()->subDays($this->faker->numberBetween(0, 15)),
             ];
         });

--- a/database/migrations/2025_10_05_182212_create_ff_plati_calupuri_table.php
+++ b/database/migrations/2025_10_05_182212_create_ff_plati_calupuri_table.php
@@ -17,10 +17,8 @@ return new class extends Migration
             $table->date('data_plata')->nullable();
             $table->string('fisier_pdf')->nullable();
             $table->text('observatii')->nullable();
-            $table->string('status', 20)->default('deschis');
             $table->timestamps();
-
-            $table->index(['status', 'data_plata']);
+            $table->index('data_plata');
         });
     }
 

--- a/database/migrations/2025_10_05_182217_drop_status_from_ff_plati_calupuri_table.php
+++ b/database/migrations/2025_10_05_182217_drop_status_from_ff_plati_calupuri_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (!Schema::hasTable('ff_plati_calupuri') || !Schema::hasColumn('ff_plati_calupuri', 'status')) {
+            return;
+        }
+
+        Schema::table('ff_plati_calupuri', function (Blueprint $table) {
+            $table->dropIndex('ff_plati_calupuri_status_data_plata_index');
+            $table->dropColumn('status');
+        });
+
+        Schema::table('ff_plati_calupuri', function (Blueprint $table) {
+            $table->index('data_plata');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (!Schema::hasTable('ff_plati_calupuri') || Schema::hasColumn('ff_plati_calupuri', 'status')) {
+            return;
+        }
+
+        Schema::table('ff_plati_calupuri', function (Blueprint $table) {
+            $table->string('status', 20)->default('deschis')->after('observatii');
+            $table->index(['status', 'data_plata']);
+        });
+    }
+};

--- a/resources/views/facturiFurnizori/calupuri/_form.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/_form.blade.php
@@ -1,7 +1,5 @@
 @php
     $calup ??= null;
-    $disableStatus ??= false;
-    $statusValue = old('status', $calup->status ?? \App\Models\FacturiFurnizori\PlataCalup::STATUS_DESCHIS);
 @endphp
 
 <div class="row">
@@ -25,22 +23,6 @@
             class="form-control bg-white rounded-3 {{ $errors->has('data_plata') ? 'is-invalid' : '' }}"
             value="{{ old('data_plata', optional($calup?->data_plata)->format('Y-m-d')) }}"
         >
-    </div>
-    <div class="col-lg-3 mb-3">
-        <label for="status" class="mb-0 ps-2">Status</label>
-        <select
-            name="status"
-            id="status"
-            class="form-select bg-white rounded-3 {{ $errors->has('status') ? 'is-invalid' : '' }}"
-            @disabled($disableStatus)
-        >
-            @foreach ($statusOptions as $key => $label)
-                <option value="{{ $key }}" @selected($statusValue === $key)>{{ $label }}</option>
-            @endforeach
-        </select>
-        @if ($disableStatus)
-            <input type="hidden" name="status" value="{{ $statusValue }}">
-        @endif
     </div>
 </div>
 <div class="mb-3">

--- a/resources/views/facturiFurnizori/calupuri/create.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/create.blade.php
@@ -21,7 +21,7 @@
         <div class="px-3">
             <form action="{{ route('facturi-furnizori.plati-calupuri.store') }}" method="POST" enctype="multipart/form-data" id="calup-create-form" class="border border-dark rounded-3 p-3 bg-white">
                 @csrf
-                @include('facturiFurnizori.calupuri._form', ['calup' => null, 'disableStatus' => true])
+                @include('facturiFurnizori.calupuri._form', ['calup' => null])
 
                 <div class="border border-dark rounded-3 p-3 mb-3">
                     <div class="d-flex flex-column flex-lg-row justify-content-lg-between align-items-lg-center mb-3">

--- a/resources/views/facturiFurnizori/calupuri/index.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/index.blade.php
@@ -18,24 +18,15 @@
         </div>
         <div class="col-12 mt-3">
             <form method="GET" action="{{ url()->current() }}" class="row g-2 g-md-3 align-items-end">
-                <div class="col-12 col-md-6 col-xl-3">
-                    <label for="filter-status" class="mb-0 ps-2">Status</label>
-                    <select name="status" id="filter-status" class="form-select bg-white rounded-3">
-                        <option value="">Toate</option>
-                        @foreach ($statusOptions as $key => $label)
-                            <option value="{{ $key }}" @selected($filters['status'] === $key)>{{ $label }}</option>
-                        @endforeach
-                    </select>
-                </div>
-                <div class="col-12 col-md-6 col-xl-3">
+                <div class="col-12 col-md-6 col-xl-4">
                     <label for="filter-data-de" class="mb-0 ps-2">Data plată de la</label>
                     <input type="date" name="data_plata_de_la" id="filter-data-de" class="form-control bg-white rounded-3" value="{{ $filters['data_plata_de_la'] }}">
                 </div>
-                <div class="col-12 col-md-6 col-xl-3">
+                <div class="col-12 col-md-6 col-xl-4">
                     <label for="filter-data-pana" class="mb-0 ps-2">Data plată până la</label>
                     <input type="date" name="data_plata_pana" id="filter-data-pana" class="form-control bg-white rounded-3" value="{{ $filters['data_plata_pana'] }}">
                 </div>
-                <div class="col-12 col-md-6 col-xl-3">
+                <div class="col-12 col-md-6 col-xl-4">
                     <label for="filter-cauta" class="mb-0 ps-2">Caută</label>
                     <input type="text" name="cauta" id="filter-cauta" class="form-control bg-white rounded-3" placeholder="Denumire sau observații" value="{{ $filters['cauta'] }}">
                 </div>
@@ -59,7 +50,6 @@
                 <thead class="text-white rounded culoare2">
                     <tr>
                         <th>Denumire</th>
-                        <th>Status</th>
                         <th>Data plată</th>
                         <th class="text-center">Facturi</th>
                         <th>Observații</th>
@@ -70,11 +60,6 @@
                     @forelse ($calupuri as $calup)
                         <tr>
                             <td>{{ $calup->denumire_calup }}</td>
-                            <td>
-                                <span class="badge bg-white border border-dark rounded-pill text-dark fw-normal">
-                                    <small>{{ $statusOptions[$calup->status] ?? \Illuminate\Support\Str::title(str_replace('_', ' ', $calup->status)) }}</small>
-                                </span>
-                            </td>
                             <td>{{ $calup->data_plata?->format('d.m.Y') ?: '-' }}</td>
                             <td class="text-center">{{ $calup->facturi_count }}</td>
                             <td class="text-muted">{{ \Illuminate\Support\Str::limit($calup->observatii, 60) }}</td>
@@ -91,7 +76,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="6" class="text-center text-muted py-4">Nu există calupuri înregistrate.</td>
+                            <td colspan="5" class="text-center text-muted py-4">Nu există calupuri înregistrate.</td>
                         </tr>
                     @endforelse
                 </tbody>

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -1,17 +1,11 @@
 @extends('layouts.app')
 
 @section('content')
-@php
-    $calupStatusLabels = $statusOptions;
-@endphp
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
         <div class="col-lg-6">
             <span class="badge culoare1 fs-5">
                 <i class="fa-solid fa-layer-group me-1"></i>Calup: {{ $calup->denumire_calup }}
-            </span>
-            <span class="badge bg-white border border-dark rounded-pill text-dark ms-2">
-                <small>Status: {{ $calupStatusLabels[$calup->status] ?? \Illuminate\Support\Str::title(str_replace('_', ' ', $calup->status)) }}</small>
             </span>
         </div>
         <div class="col-lg-6 text-end">
@@ -40,7 +34,7 @@
             <form action="{{ route('facturi-furnizori.plati-calupuri.update', $calup) }}" method="POST" enctype="multipart/form-data" class="border border-dark rounded-3 p-3 mb-3 bg-white">
                 @csrf
                 @method('PUT')
-                @include('facturiFurnizori.calupuri._form', ['calup' => $calup, 'disableStatus' => false])
+                @include('facturiFurnizori.calupuri._form', ['calup' => $calup])
                 <div class="d-flex justify-content-end">
                     <button type="submit" class="btn btn-sm btn-primary text-white border border-dark rounded-3">
                         <i class="fa-solid fa-floppy-disk me-1"></i>Actualizează calup
@@ -72,15 +66,11 @@
                                         <td>{{ $factura->data_scadenta?->format('d.m.Y') }}</td>
                                         <td class="text-end">{{ number_format($factura->suma, 2) }} {{ $factura->moneda }}</td>
                                         <td class="text-end">
-                                            @if ($calup->status !== \App\Models\FacturiFurnizori\PlataCalup::STATUS_PLATIT)
-                                                <form action="{{ route('facturi-furnizori.plati-calupuri.detaseaza-factura', [$calup, $factura]) }}" method="POST" onsubmit="return confirm('Elimini factura din calup?');">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="badge bg-danger text-white border-0 rounded-3 px-3 py-2">Elimină</button>
-                                                </form>
-                                            @else
-                                                <span class="text-muted">-</span>
-                                            @endif
+                                            <form action="{{ route('facturi-furnizori.plati-calupuri.detaseaza-factura', [$calup, $factura]) }}" method="POST" onsubmit="return confirm('Elimini factura din calup?');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="badge bg-danger text-white border-0 rounded-3 px-3 py-2">Elimină</button>
+                                            </form>
                                         </td>
                                     </tr>
                                 @endforeach

--- a/resources/views/facturiFurnizori/facturi/show.blade.php
+++ b/resources/views/facturiFurnizori/facturi/show.blade.php
@@ -1,13 +1,6 @@
 @extends('layouts.app')
 
 @section('content')
-@php
-    $calupStatusLabels = [
-        \App\Models\FacturiFurnizori\PlataCalup::STATUS_DESCHIS => 'Deschis',
-        \App\Models\FacturiFurnizori\PlataCalup::STATUS_PLATIT => 'Plătit',
-        \App\Models\FacturiFurnizori\PlataCalup::STATUS_ANULAT => 'Anulat',
-    ];
-@endphp
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
         <div class="col-lg-6">
@@ -60,7 +53,6 @@
                             <thead class="text-white rounded culoare2">
                                 <tr>
                                     <th>Denumire</th>
-                                    <th>Status</th>
                                     <th>Data plată</th>
                                     <th class="text-end">Acțiuni</th>
                                 </tr>
@@ -69,11 +61,6 @@
                                 @foreach ($factura->calupuri as $calup)
                                     <tr>
                                         <td>{{ $calup->denumire_calup }}</td>
-                                        <td>
-                                            <span class="badge bg-white border border-dark rounded-pill text-dark fw-normal">
-                                                <small>{{ $calupStatusLabels[$calup->status] ?? \Illuminate\Support\Str::title(str_replace('_', ' ', $calup->status)) }}</small>
-                                            </span>
-                                        </td>
                                         <td>{{ $calup->data_plata?->format('d.m.Y') ?: '-' }}</td>
                                         <td class="text-end">
                                             <a href="{{ route('facturi-furnizori.plati-calupuri.show', $calup) }}" class="badge bg-secondary text-dark text-decoration-none rounded-3 px-3 py-2">Vezi calup</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -199,12 +199,6 @@ Route::group(['middleware' => 'auth'], function () {
             Route::delete('plati-calupuri/{plataCalup}/facturi/{factura}', [PlataCalupController::class, 'detaseazaFactura'])
                 ->name('plati-calupuri.detaseaza-factura');
 
-            Route::post('plati-calupuri/{plataCalup}/marcheaza-platit', [PlataCalupController::class, 'marcheazaPlatit'])
-                ->name('plati-calupuri.marcheaza-platit');
-
-            Route::post('plati-calupuri/{plataCalup}/redeschide', [PlataCalupController::class, 'redeschide'])
-                ->name('plati-calupuri.redeschide');
-
             Route::get('plati-calupuri/{plataCalup}/descarca-fisier', [PlataCalupController::class, 'descarcaFisier'])
                 ->name('plati-calupuri.descarca-fisier');
         });


### PR DESCRIPTION
## Summary
- drop the calup status column/index from new installs and add a migration that removes it from existing databases while indexing payment dates
- simplify the calup controllers, service, and related views to stop reading or displaying a status and always allow detach/delete operations
- update supplier invoice eager loading and views to reflect the removal of calup statuses

## Testing
- `php artisan test` *(fails: vendor/autoload.php is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57a759ff083268c10d5966acea2a9