### PR TITLE
Tighten supplier invoice filters and calup selection styling

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -101,16 +101,22 @@ class PlataCalupController extends Controller
 
     public function show(PlataCalup $plataCalup)
     {
-        $plataCalup->load(['facturi' => fn ($query) => $query->orderBy('data_scadenta')]);
+        $plataCalup->load(['facturi' => fn ($query) => $query->orderByRaw('data_scadenta IS NULL')->orderBy('data_scadenta')]);
+
+        $facturiCalup = $plataCalup->facturi
+            ->sortBy(fn (FacturaFurnizor $factura) => $factura->data_scadenta?->timestamp ?? PHP_INT_MAX)
+            ->values();
 
         $facturiDisponibile = FacturaFurnizor::query()
             ->whereDoesntHave('calupuri')
+            ->orderByRaw('data_scadenta IS NULL')
             ->orderBy('data_scadenta')
             ->orderBy('denumire_furnizor')
             ->get();
 
         return view('facturiFurnizori.calupuri.show', [
             'calup' => $plataCalup,
+            'facturiCalup' => $facturiCalup,
             'facturiDisponibile' => $facturiDisponibile,
         ]);
     }

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -22,8 +22,7 @@
             <div class="mb-3">
                 <div class="border border-dark rounded-3 p-3 bg-white">
                     <h6 class="text-uppercase text-muted">Sumar calup</h6>
-                    <p class="mb-1"><strong>Facturi atașate:</strong> {{ $calup->facturi->count() }}</p>
-                    <p class="mb-1"><strong>Total sume:</strong> {{ number_format($calup->facturi->sum('suma'), 2) }}</p>
+                    <p class="mb-1"><strong>Facturi atașate:</strong> {{ $facturiCalup->count() }}</p>
                     <p class="mb-1"><strong>Data plată:</strong> {{ $calup->data_plata?->format('d.m.Y') ?: 'Nespecificată' }}</p>
                     @if ($calup->fisier_pdf)
                         <p class="mb-0"><a href="{{ route('facturi-furnizori.plati-calupuri.descarca-fisier', $calup) }}">Descarcă PDF asociat</a> <span class="text-muted small">({{ basename($calup->fisier_pdf) }})</span></p>
@@ -44,7 +43,7 @@
 
             <div class="border border-dark rounded-3 p-3 mb-3 bg-white">
                 <h6 class="text-uppercase text-muted mb-3">Facturi atașate</h6>
-                @if ($calup->facturi->isEmpty())
+                @if ($facturiCalup->isEmpty())
                     <p class="text-muted mb-0">Nu sunt facturi atașate acestui calup.</p>
                 @else
                     <div class="table-responsive">
@@ -59,7 +58,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach ($calup->facturi as $factura)
+                                @foreach ($facturiCalup as $factura)
                                     <tr>
                                         <td>{{ $factura->denumire_furnizor }}</td>
                                         <td>{{ $factura->numar_factura }}</td>
@@ -83,7 +82,7 @@
                 @endif
             </div>
 
-            @foreach ($calup->facturi as $factura)
+            @foreach ($facturiCalup as $factura)
                 <div
                     class="modal fade"
                     id="detaseazaFacturaModal{{ $factura->id }}"
@@ -154,7 +153,7 @@
                             </table>
                         </div>
                         <div class="d-flex justify-content-end gap-2 mt-3">
-                            <span class="badge bg-info text-dark" id="attach-counter">Selectate: 0</span>
+                            <span class="badge bg-primary text-white" id="attach-counter">Selectate: 0</span>
                             <button type="submit" class="btn btn-sm btn-success text-white border border-dark rounded-3">
                                 <i class="fa-solid fa-plus me-1"></i>Adaugă în calup
                             </button>

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -23,44 +23,44 @@
         </div>
         <div class="col-lg-8 mb-0" id="formularFacturi">
             <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ url()->current() }}">
-                <div class="row mb-1 custom-search-form d-flex justify-content-center">
-                    <div class="col-lg-4">
-                        <input
-                            type="text"
-                            class="form-control rounded-3"
-                            id="filter-furnizor"
-                            name="furnizor"
-                            placeholder="Furnizor"
-                            value="{{ $filters['furnizor'] }}"
-                            list="filter-furnizor-suggestions"
-                            autocomplete="off"
-                            data-typeahead-tip="furnizor"
-                            data-typeahead-minlength="1"
-                        >
+                <div class="row g-2 mb-2 custom-search-form d-flex justify-content-center">
+                    <div class="col-lg-4 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-wand-magic-sparkles text-muted" title="Autocomplete disponibil"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-furnizor"
+                                name="furnizor"
+                                placeholder="Furnizor"
+                                value="{{ $filters['furnizor'] }}"
+                                list="filter-furnizor-suggestions"
+                                autocomplete="off"
+                                data-typeahead-tip="furnizor"
+                                data-typeahead-minlength="1"
+                            >
+                        </div>
                         <datalist id="filter-furnizor-suggestions"></datalist>
-                        <small class="form-text text-muted ps-1">
-                            <i class="fa-solid fa-wand-magic-sparkles me-1"></i>Autocomplete disponibil
-                        </small>
                     </div>
-                    <div class="col-lg-4">
-                        <input
-                            type="text"
-                            class="form-control rounded-3"
-                            id="filter-departament"
-                            name="departament"
-                            placeholder="Departament"
-                            value="{{ $filters['departament'] }}"
-                            list="filter-departament-suggestions"
-                            autocomplete="off"
-                            data-typeahead-tip="departament"
-                            data-typeahead-minlength="1"
-                        >
+                    <div class="col-lg-4 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-wand-magic-sparkles text-muted" title="Autocomplete disponibil"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-departament"
+                                name="departament"
+                                placeholder="Departament"
+                                value="{{ $filters['departament'] }}"
+                                list="filter-departament-suggestions"
+                                autocomplete="off"
+                                data-typeahead-tip="departament"
+                                data-typeahead-minlength="1"
+                            >
+                        </div>
                         <datalist id="filter-departament-suggestions"></datalist>
-                        <small class="form-text text-muted ps-1">
-                            <i class="fa-solid fa-wand-magic-sparkles me-1"></i>Autocomplete disponibil
-                        </small>
                     </div>
-                    <div class="col-lg-4">
+                    <div class="col-lg-4 col-md-6">
                         <select name="moneda" id="filter-moneda" class="form-select bg-white rounded-3">
                             <option value="">Monedă</option>
                             @foreach ($monede as $moneda)
@@ -69,29 +69,43 @@
                         </select>
                     </div>
                 </div>
-                <div class="row mb-1 custom-search-form d-flex justify-content-center">
-                    <div class="col-lg-3">
-                        <input type="date" class="form-control rounded-3" id="filter-scadenta-de-la" name="scadenta_de_la" placeholder="Scadență de la" value="{{ $filters['scadenta_de_la'] }}">
+                <div class="row g-2 mb-2 custom-search-form d-flex justify-content-center">
+                    <div class="col-lg-3 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <label for="filter-scadenta-de-la" class="form-label small text-muted mb-0 flex-shrink-0 text-nowrap">Scadență de la</label>
+                            <input type="date" class="form-control rounded-3" id="filter-scadenta-de-la" name="scadenta_de_la" value="{{ $filters['scadenta_de_la'] }}">
+                        </div>
                     </div>
-                    <div class="col-lg-3">
-                        <input type="date" class="form-control rounded-3" id="filter-scadenta-pana" name="scadenta_pana" placeholder="Scadență până la" value="{{ $filters['scadenta_pana'] }}">
+                    <div class="col-lg-3 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <label for="filter-scadenta-pana" class="form-label small text-muted mb-0 flex-shrink-0 text-nowrap">Scadență până la</label>
+                            <input type="date" class="form-control rounded-3" id="filter-scadenta-pana" name="scadenta_pana" value="{{ $filters['scadenta_pana'] }}">
+                        </div>
                     </div>
-                    <div class="col-lg-3">
-                        <input type="number" min="0" class="form-control rounded-3" id="filter-scadente-in-zile" name="scadente_in_zile" placeholder="Scadente în (zile)" value="{{ $filters['scadente_in_zile'] }}">
+                    <div class="col-lg-3 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <label for="filter-calup-data" class="form-label small text-muted mb-0 flex-shrink-0 text-nowrap">Data plată calup</label>
+                            <input type="date" class="form-control rounded-3" id="filter-calup-data" name="calup_data_plata" value="{{ $filters['calup_data_plata'] }}">
+                        </div>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <input
+                            type="text"
+                            class="form-control rounded-3"
+                            id="filter-calup"
+                            name="calup"
+                            placeholder="Calup"
+                            value="{{ $filters['calup'] }}"
+                            aria-label="Calup"
+                        >
                     </div>
                 </div>
-                <div class="row mb-1 custom-search-form d-flex justify-content-center">
-                    <div class="col-lg-3">
-                        <input type="text" class="form-control rounded-3" id="filter-calup" name="calup" placeholder="Calup" value="{{ $filters['calup'] }}">
-                    </div>
-                    <div class="col-lg-3">
-                        <input type="date" class="form-control rounded-3" id="filter-calup-data" name="calup_data_plata" value="{{ $filters['calup_data_plata'] }}">
-                    </div>
-                    <div class="col-lg-3">
+                <div class="row g-2 mb-2 custom-search-form d-flex justify-content-center">
+                    <div class="col-lg-3 col-md-6">
                         <select name="status" id="filter-status" class="form-select bg-white rounded-3">
-                            <option value="" @selected(!$filters['status'])>Toate</option>
+                            <option value="" @selected($filters['status'] === '')>Toate</option>
                             <option value="neplatite" @selected($filters['status'] === 'neplatite')>Neplătite ({{ $neplatiteCount }})</option>
-                            <option value="platite" @selected($filters['status'] === 'platite')>Plătite</option>
+                            <option value="platite" @selected($filters['status'] === 'platite')>Arhivate (în calupuri)</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- default supplier invoice listings to the "Neplătite" status and drop the unused scadente-in-zile filter
- streamline the invoice filter layout with inline labels, icon-only autocomplete hints, and updated status option text
- improve calup attachment feedback by using a higher-contrast counter badge

## Testing
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68e6000463c0832694ae975d5828cda0