### PR TITLE
Add SQL script for calup attachment table

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -7,11 +7,13 @@ use App\Http\Requests\FacturiFurnizori\AttachFacturiRequest;
 use App\Http\Requests\FacturiFurnizori\PlataCalupRequest;
 use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\FacturiFurnizori\PlataCalup;
+use App\Models\FacturiFurnizori\PlataCalupFisier;
 use App\Services\FacturiFurnizori\PlataCalupService;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class PlataCalupController extends Controller
 {
@@ -81,13 +83,15 @@ class PlataCalupController extends Controller
         $facturi = $payload['facturi'] ?? [];
         unset($payload['facturi']);
 
-        if ($request->hasFile('fisier_pdf')) {
-            $payload['fisier_pdf'] = $this->uploadFisierPdf($request->file('fisier_pdf'));
-        } else {
-            unset($payload['fisier_pdf']);
-        }
+        $fisiereNoi = $this->normalizeUploadedFiles($request->file('fisiere_pdf'));
+        unset($payload['fisiere_pdf']);
 
         $calup = PlataCalup::create($payload);
+
+        if (!empty($fisiereNoi)) {
+            $this->adaugaFisiere($calup, $fisiereNoi);
+            $calup->load('fisiere');
+        }
 
         if (!empty($facturi)) {
             $this->plataCalupService->attachFacturi($calup, $facturi);
@@ -101,7 +105,10 @@ class PlataCalupController extends Controller
 
     public function show(PlataCalup $plataCalup)
     {
-        $plataCalup->load(['facturi' => fn ($query) => $query->orderBy('data_scadenta')]);
+        $plataCalup->load([
+            'facturi' => fn ($query) => $query->orderBy('data_scadenta'),
+            'fisiere' => fn ($query) => $query->orderBy('created_at'),
+        ]);
 
         $facturiDisponibile = FacturaFurnizor::query()
             ->whereDoesntHave('calupuri')
@@ -126,16 +133,15 @@ class PlataCalupController extends Controller
         $facturi = $payload['facturi'] ?? null;
         unset($payload['facturi']);
 
-        if ($request->hasFile('fisier_pdf')) {
-            if ($plataCalup->fisier_pdf) {
-                Storage::delete($plataCalup->fisier_pdf);
-            }
-            $payload['fisier_pdf'] = $this->uploadFisierPdf($request->file('fisier_pdf'));
-        } else {
-            unset($payload['fisier_pdf']);
-        }
+        $fisiereNoi = $this->normalizeUploadedFiles($request->file('fisiere_pdf'));
+        unset($payload['fisiere_pdf']);
 
         $plataCalup->update($payload);
+
+        if (!empty($fisiereNoi)) {
+            $this->adaugaFisiere($plataCalup, $fisiereNoi);
+            $plataCalup->load('fisiere');
+        }
 
         if (is_array($facturi)) {
             $idsCurente = $plataCalup->facturi()->pluck('ff_facturi.id')->toArray();
@@ -163,14 +169,16 @@ class PlataCalupController extends Controller
 
     public function destroy(PlataCalup $plataCalup)
     {
-        $plataCalup->load('facturi');
+        $plataCalup->load(['facturi', 'fisiere']);
 
         foreach ($plataCalup->facturi as $factura) {
             $this->plataCalupService->detachFactura($plataCalup, $factura);
         }
 
-        if ($plataCalup->fisier_pdf) {
-            Storage::delete($plataCalup->fisier_pdf);
+        foreach ($plataCalup->fisiere as $fisier) {
+            if ($fisier->cale && Storage::exists($fisier->cale)) {
+                Storage::delete($fisier->cale);
+            }
         }
 
         $plataCalup->delete();
@@ -198,31 +206,103 @@ class PlataCalupController extends Controller
         return back()->with('status', 'Factura a fost eliminata din calup.');
     }
 
-    public function descarcaFisier(PlataCalup $plataCalup)
+    public function descarcaFisier(PlataCalup $plataCalup, ?PlataCalupFisier $fisier = null)
     {
-        if (!$plataCalup->fisier_pdf || !Storage::exists($plataCalup->fisier_pdf)) {
+        if ($fisier && $fisier->plata_calup_id !== $plataCalup->id) {
+            abort(404);
+        }
+
+        $fisierSelectat = $fisier;
+
+        if (!$fisierSelectat) {
+            $fisierSelectat = $plataCalup->fisiere()->orderBy('created_at')->first();
+        }
+
+        if (!$fisierSelectat || !Storage::exists($fisierSelectat->cale)) {
             return back()->with('error', 'Fisierul nu a putut fi descarcat.');
         }
 
-        return Storage::download($plataCalup->fisier_pdf, basename($plataCalup->fisier_pdf));
+        $downloadName = $fisierSelectat->nume_original ?: basename($fisierSelectat->cale);
+
+        return Storage::download($fisierSelectat->cale, $downloadName);
     }
 
-    private function uploadFisierPdf(UploadedFile $file): string
+    /**
+     * @param array<int, UploadedFile>|UploadedFile|null $files
+     * @return array<int, UploadedFile>
+     */
+    private function normalizeUploadedFiles($files): array
+    {
+        if (empty($files)) {
+            return [];
+        }
+
+        if ($files instanceof UploadedFile) {
+            $files = [$files];
+        }
+
+        return array_values(array_filter($files, fn ($file) => $file instanceof UploadedFile));
+    }
+
+    /**
+     * @param array<int, UploadedFile> $files
+     */
+    private function adaugaFisiere(PlataCalup $plataCalup, array $files): void
+    {
+        foreach ($files as $file) {
+            $this->salveazaFisier($plataCalup, $file);
+        }
+    }
+
+    private function salveazaFisier(PlataCalup $plataCalup, UploadedFile $file): PlataCalupFisier
     {
         $folder = 'facturi-furnizori/calupuri';
-        $filename = $file->getClientOriginalName() ?: ('calup_' . uniqid() . '.pdf');
-        $path = $folder . '/' . $filename;
-
-        while (Storage::exists($path)) {
-            $name = pathinfo($filename, PATHINFO_FILENAME);
-            $extension = $file->getClientOriginalExtension() ?: 'pdf';
-            $filename = $name . '_' . uniqid() . '.' . $extension;
-            $path = $folder . '/' . $filename;
-        }
+        $filename = $this->genereazaNumeFisier($file, $folder);
 
         Storage::putFileAs($folder, $file, $filename);
 
-        return $path;
+        return $plataCalup->fisiere()->create([
+            'cale' => $folder . '/' . $filename,
+            'nume_original' => $file->getClientOriginalName() ?: $filename,
+        ]);
+    }
+
+    private function genereazaNumeFisier(UploadedFile $file, string $folder): string
+    {
+        $originalName = $file->getClientOriginalName() ?: 'calup';
+        $extension = strtolower($file->getClientOriginalExtension() ?: 'pdf');
+        $baseName = pathinfo($originalName, PATHINFO_FILENAME);
+        $baseName = Str::slug(Str::ascii($baseName) ?: 'calup', '_');
+
+        if ($baseName === '') {
+            $baseName = 'calup';
+        }
+
+        $baseName = substr($baseName, 0, 120);
+        $filename = $baseName . '.' . $extension;
+        $counter = 1;
+
+        while (Storage::exists($folder . '/' . $filename)) {
+            $filename = $baseName . '_' . $counter . '.' . $extension;
+            $counter++;
+        }
+
+        return $filename;
+    }
+
+    public function stergeFisier(PlataCalup $plataCalup, PlataCalupFisier $fisier)
+    {
+        if ($fisier->plata_calup_id !== $plataCalup->id) {
+            abort(404);
+        }
+
+        if ($fisier->cale && Storage::exists($fisier->cale)) {
+            Storage::delete($fisier->cale);
+        }
+
+        $fisier->delete();
+
+        return back()->with('status', 'Fisierul a fost sters.');
     }
 }
 

--- a/app/Http/Requests/FacturiFurnizori/PlataCalupRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/PlataCalupRequest.php
@@ -25,7 +25,8 @@ class PlataCalupRequest extends FormRequest
             'denumire_calup' => ['required', 'string', 'max:150'],
             'data_plata' => ['nullable', 'date'],
             'observatii' => ['nullable', 'string'],
-            'fisier_pdf' => ['nullable', 'file', 'mimetypes:application/pdf', 'max:10240'],
+            'fisiere_pdf' => ['nullable', 'array'],
+            'fisiere_pdf.*' => ['file', 'mimetypes:application/pdf', 'max:10240'],
             'facturi' => ['nullable', 'array'],
             'facturi.*' => ['integer', 'exists:ff_facturi,id'],
         ];
@@ -37,8 +38,9 @@ class PlataCalupRequest extends FormRequest
             'denumire_calup.required' => 'Denumirea calupului este obligatorie.',
             'denumire_calup.max' => 'Denumirea calupului poate avea cel mult 150 de caractere.',
             'data_plata.date' => 'Data platii trebuie sa fie o data valida.',
-            'fisier_pdf.mimetypes' => 'Fisierul incarcat trebuie sa fie PDF.',
-            'fisier_pdf.max' => 'Fisierul PDF poate avea cel mult 10MB.',
+            'fisiere_pdf.array' => 'Lista de fisiere nu este valida.',
+            'fisiere_pdf.*.mimetypes' => 'Fiecare fisier incarcat trebuie sa fie PDF.',
+            'fisiere_pdf.*.max' => 'Fiecare fisier PDF poate avea cel mult 10MB.',
             'facturi.array' => 'Lista de facturi nu este valida.',
             'facturi.*.exists' => 'Cel putin una dintre facturile selectate nu mai exista.',
         ];
@@ -50,7 +52,7 @@ class PlataCalupRequest extends FormRequest
             'denumire_calup' => 'denumire calup',
             'data_plata' => 'data platii',
             'observatii' => 'observatii',
-            'fisier_pdf' => 'fisier PDF',
+            'fisiere_pdf' => 'fisiere PDF',
             'facturi' => 'facturi selectate',
         ];
     }

--- a/app/Models/FacturiFurnizori/PlataCalup.php
+++ b/app/Models/FacturiFurnizori/PlataCalup.php
@@ -4,6 +4,8 @@ namespace App\Models\FacturiFurnizori;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class PlataCalup extends Model
 {
@@ -14,7 +16,6 @@ class PlataCalup extends Model
     protected $fillable = [
         'denumire_calup',
         'data_plata',
-        'fisier_pdf',
         'observatii',
     ];
 
@@ -25,8 +26,13 @@ class PlataCalup extends Model
     /**
      * Invoices linked to this payment batch.
      */
-    public function facturi()
+    public function facturi(): BelongsToMany
     {
         return $this->belongsToMany(FacturaFurnizor::class, 'ff_facturi_plati', 'calup_id', 'factura_id')->withTimestamps();
+    }
+
+    public function fisiere(): HasMany
+    {
+        return $this->hasMany(PlataCalupFisier::class, 'plata_calup_id');
     }
 }

--- a/app/Models/FacturiFurnizori/PlataCalupFisier.php
+++ b/app/Models/FacturiFurnizori/PlataCalupFisier.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models\FacturiFurnizori;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PlataCalupFisier extends Model
+{
+    use HasFactory;
+
+    protected $table = 'ff_plati_calupuri_fisiere';
+
+    protected $fillable = [
+        'plata_calup_id',
+        'cale',
+        'nume_original',
+    ];
+
+    public function calup(): BelongsTo
+    {
+        return $this->belongsTo(PlataCalup::class, 'plata_calup_id');
+    }
+}

--- a/database/factories/PlataCalupFactory.php
+++ b/database/factories/PlataCalupFactory.php
@@ -18,7 +18,6 @@ class PlataCalupFactory extends Factory
         return [
             'denumire_calup' => 'Calup ' . strtoupper($this->faker->bothify('PLT-##')),
             'data_plata' => null,
-            'fisier_pdf' => null,
             'observatii' => $this->faker->optional()->sentence(),
         ];
     }

--- a/database/migrations/2025_10_05_182212_create_ff_plati_calupuri_table.php
+++ b/database/migrations/2025_10_05_182212_create_ff_plati_calupuri_table.php
@@ -15,7 +15,6 @@ return new class extends Migration
             $table->id();
             $table->string('denumire_calup', 150);
             $table->date('data_plata')->nullable();
-            $table->string('fisier_pdf')->nullable();
             $table->text('observatii')->nullable();
             $table->timestamps();
             $table->index('data_plata');

--- a/database/migrations/2025_10_05_182213_create_ff_plati_calupuri_fisiere_table.php
+++ b/database/migrations/2025_10_05_182213_create_ff_plati_calupuri_fisiere_table.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ff_plati_calupuri_fisiere', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('plata_calup_id')->constrained('ff_plati_calupuri')->cascadeOnDelete();
+            $table->string('cale');
+            $table->string('nume_original')->nullable();
+            $table->timestamps();
+        });
+
+        if (Schema::hasColumn('ff_plati_calupuri', 'fisier_pdf')) {
+            $records = DB::table('ff_plati_calupuri')
+                ->whereNotNull('fisier_pdf')
+                ->select(['id', 'fisier_pdf'])
+                ->get();
+
+            foreach ($records as $record) {
+                DB::table('ff_plati_calupuri_fisiere')->insert([
+                    'plata_calup_id' => $record->id,
+                    'cale' => $record->fisier_pdf,
+                    'nume_original' => basename($record->fisier_pdf),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            Schema::table('ff_plati_calupuri', function (Blueprint $table) {
+                $table->dropColumn('fisier_pdf');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (!Schema::hasColumn('ff_plati_calupuri', 'fisier_pdf')) {
+            Schema::table('ff_plati_calupuri', function (Blueprint $table) {
+                $table->string('fisier_pdf')->nullable();
+            });
+        }
+
+        $attachments = DB::table('ff_plati_calupuri_fisiere')
+            ->orderBy('id')
+            ->select(['plata_calup_id', 'cale'])
+            ->get();
+
+        foreach ($attachments as $attachment) {
+            $exists = DB::table('ff_plati_calupuri')
+                ->where('id', $attachment->plata_calup_id)
+                ->whereNull('fisier_pdf')
+                ->exists();
+
+            if ($exists) {
+                DB::table('ff_plati_calupuri')
+                    ->where('id', $attachment->plata_calup_id)
+                    ->update(['fisier_pdf' => $attachment->cale]);
+            }
+        }
+
+        Schema::dropIfExists('ff_plati_calupuri_fisiere');
+    }
+};

--- a/database/sql/ff_plati_calupuri_fisiere.sql
+++ b/database/sql/ff_plati_calupuri_fisiere.sql
@@ -1,0 +1,23 @@
+-- SQL script to mirror the 2025_10_05_182213_create_ff_plati_calupuri_fisiere_table migration
+
+CREATE TABLE `ff_plati_calupuri_fisiere` (
+  `id` bigint unsigned NOT NULL AUTO_INCREMENT,
+  `plata_calup_id` bigint unsigned NOT NULL,
+  `cale` varchar(255) NOT NULL,
+  `nume_original` varchar(255) DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ff_plati_calupuri_fisiere_plata_calup_id_index` (`plata_calup_id`),
+  CONSTRAINT `ff_plati_calupuri_fisiere_plata_calup_id_foreign` FOREIGN KEY (`plata_calup_id`) REFERENCES `ff_plati_calupuri` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Optional data migration from the legacy single-file column.
+INSERT INTO `ff_plati_calupuri_fisiere` (`plata_calup_id`, `cale`, `nume_original`, `created_at`, `updated_at`)
+SELECT `id`, `fisier_pdf`, SUBSTRING_INDEX(`fisier_pdf`, '/', -1), NOW(), NOW()
+FROM `ff_plati_calupuri`
+WHERE `fisier_pdf` IS NOT NULL AND `fisier_pdf` <> '';
+
+-- Optional clean-up of the legacy column once data has been migrated.
+ALTER TABLE `ff_plati_calupuri`
+  DROP COLUMN `fisier_pdf`;

--- a/resources/views/facturiFurnizori/calupuri/_form.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/_form.blade.php
@@ -1,5 +1,6 @@
 @php
     $calup ??= null;
+    $fisiereErrors = $errors->has('fisiere_pdf') || collect($errors->get('fisiere_pdf.*'))->flatten()->isNotEmpty();
 @endphp
 
 <div class="row">
@@ -35,17 +36,25 @@
     >{{ old('observatii', $calup->observatii ?? '') }}</textarea>
 </div>
 <div class="mb-3">
-    <label for="fisier_pdf" class="mb-0 ps-2">Fișier PDF</label>
+    <label for="fisiere_pdf" class="mb-0 ps-2">Fișiere PDF</label>
     <input
         type="file"
-        name="fisier_pdf"
-        id="fisier_pdf"
-        class="form-control bg-white rounded-3 {{ $errors->has('fisier_pdf') ? 'is-invalid' : '' }}"
+        name="fisiere_pdf[]"
+        id="fisiere_pdf"
+        class="form-control bg-white rounded-3 {{ $fisiereErrors ? 'is-invalid' : '' }}"
         accept="application/pdf"
+        multiple
     >
-    @if (!empty($calup?->fisier_pdf))
-        <p class="mt-2 mb-0">
-            <a href="{{ route('facturi-furnizori.plati-calupuri.descarca-fisier', $calup) }}">Descarcă fișier existent</a>
-        </p>
+    <small class="form-text text-muted">Poți selecta unul sau mai multe fișiere PDF.</small>
+    @if ($errors->has('fisiere_pdf'))
+        <div class="invalid-feedback d-block">{{ $errors->first('fisiere_pdf') }}</div>
+    @endif
+    @foreach ($errors->get('fisiere_pdf.*') as $messages)
+        @foreach ((array) $messages as $message)
+            <div class="invalid-feedback d-block">{{ $message }}</div>
+        @endforeach
+    @endforeach
+    @if ($calup && $calup->relationLoaded('fisiere') && $calup->fisiere->isNotEmpty())
+        <p class="mt-2 mb-0 text-muted small">Fișierele deja încărcate sunt listate mai jos.</p>
     @endif
 </div>

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -25,8 +25,55 @@
                     <p class="mb-1"><strong>Facturi atașate:</strong> {{ $calup->facturi->count() }}</p>
                     <p class="mb-1"><strong>Total sume:</strong> {{ number_format($calup->facturi->sum('suma'), 2) }}</p>
                     <p class="mb-1"><strong>Data plată:</strong> {{ $calup->data_plata?->format('d.m.Y') ?: 'Nespecificată' }}</p>
-                    @if ($calup->fisier_pdf)
-                        <p class="mb-0"><a href="{{ route('facturi-furnizori.plati-calupuri.descarca-fisier', $calup) }}">Descarcă PDF asociat</a> <span class="text-muted small">({{ basename($calup->fisier_pdf) }})</span></p>
+                    <p class="mb-0"><strong>Fișiere PDF:</strong> {{ $calup->fisiere->count() }}</p>
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <div class="border border-dark rounded-3 p-3 bg-white">
+                    <h6 class="text-uppercase text-muted">Fișiere PDF atașate</h6>
+                    @if ($calup->fisiere->isEmpty())
+                        <p class="text-muted mb-0">Nu există fișiere atașate acestui calup.</p>
+                    @else
+                        <div class="table-responsive">
+                            <table class="table table-sm table-hover table-bordered border-dark align-middle mb-0">
+                                <thead class="text-white rounded culoare2">
+                                    <tr>
+                                        <th>Nume fișier</th>
+                                        <th>Încărcat la</th>
+                                        <th class="text-end">Acțiuni</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach ($calup->fisiere as $fisier)
+                                        <tr>
+                                            <td class="align-middle">{{ $fisier->nume_original ?: basename($fisier->cale) }}</td>
+                                            <td class="align-middle">{{ $fisier->created_at?->format('d.m.Y H:i') }}</td>
+                                            <td class="text-end">
+                                                <a
+                                                    href="{{ route('facturi-furnizori.plati-calupuri.descarca-fisier', [$calup, $fisier]) }}"
+                                                    class="btn btn-sm btn-outline-primary border border-primary me-2"
+                                                >
+                                                    <i class="fa-solid fa-download me-1"></i>Descarcă
+                                                </a>
+                                                <form
+                                                    action="{{ route('facturi-furnizori.plati-calupuri.fisiere.destroy', [$calup, $fisier]) }}"
+                                                    method="POST"
+                                                    class="d-inline"
+                                                    onsubmit="return confirm('Ștergi acest fișier PDF?');"
+                                                >
+                                                    @csrf
+                                                    @method('DELETE')
+                                                    <button type="submit" class="btn btn-sm btn-outline-danger border border-danger">
+                                                        <i class="fa-solid fa-trash me-1"></i>Șterge
+                                                    </button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
                     @endif
                 </div>
             </div>

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 @php
     $selectedFacturiOld = collect(old('facturi', []))->map(fn ($id) => (int) $id)->all();
-    $calupErrorFields = ['denumire_calup', 'data_plata', 'observatii', 'fisier_pdf', 'facturi', 'facturi.*'];
+    $calupErrorFields = ['denumire_calup', 'data_plata', 'observatii', 'fisiere_pdf', 'fisiere_pdf.*', 'facturi', 'facturi.*'];
     $shouldShowCalupModal = !empty($selectedFacturiOld);
 
     foreach ($calupErrorFields as $field) {
@@ -225,9 +225,28 @@
                         <label for="observatii" class="mb-0 ps-2">Observații</label>
                         <textarea name="observatii" id="observatii" class="form-control bg-white rounded-3 {{ $errors->has('observatii') ? 'is-invalid' : '' }}" rows="3">{{ old('observatii') }}</textarea>
                     </div>
+                    @php
+                        $fisiereModalErrors = $errors->has('fisiere_pdf') || collect($errors->get('fisiere_pdf.*'))->flatten()->isNotEmpty();
+                    @endphp
                     <div class="mb-3">
-                        <label for="fisier_pdf" class="mb-0 ps-2">Fișier PDF</label>
-                        <input type="file" name="fisier_pdf" id="fisier_pdf" class="form-control bg-white rounded-3 {{ $errors->has('fisier_pdf') ? 'is-invalid' : '' }}" accept="application/pdf">
+                        <label for="fisiere_pdf_modal" class="mb-0 ps-2">Fișiere PDF</label>
+                        <input
+                            type="file"
+                            name="fisiere_pdf[]"
+                            id="fisiere_pdf_modal"
+                            class="form-control bg-white rounded-3 {{ $fisiereModalErrors ? 'is-invalid' : '' }}"
+                            accept="application/pdf"
+                            multiple
+                        >
+                        <small class="form-text text-muted">Poți selecta unul sau mai multe fișiere PDF.</small>
+                        @if ($errors->has('fisiere_pdf'))
+                            <div class="invalid-feedback d-block">{{ $errors->first('fisiere_pdf') }}</div>
+                        @endif
+                        @foreach ($errors->get('fisiere_pdf.*') as $messages)
+                            @foreach ((array) $messages as $message)
+                                <div class="invalid-feedback d-block">{{ $message }}</div>
+                            @endforeach
+                        @endforeach
                     </div>
                     <div id="calup-form-selected" class="d-none"></div>
                     @if ($errors->has('facturi'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -199,7 +199,10 @@ Route::group(['middleware' => 'auth'], function () {
             Route::delete('plati-calupuri/{plataCalup}/facturi/{factura}', [PlataCalupController::class, 'detaseazaFactura'])
                 ->name('plati-calupuri.detaseaza-factura');
 
-            Route::get('plati-calupuri/{plataCalup}/descarca-fisier', [PlataCalupController::class, 'descarcaFisier'])
+            Route::delete('plati-calupuri/{plataCalup}/fisiere/{fisier}', [PlataCalupController::class, 'stergeFisier'])
+                ->name('plati-calupuri.fisiere.destroy');
+
+            Route::get('plati-calupuri/{plataCalup}/descarca-fisier/{fisier?}', [PlataCalupController::class, 'descarcaFisier'])
                 ->name('plati-calupuri.descarca-fisier');
         });
 


### PR DESCRIPTION
## Summary
- add a raw SQL script that mirrors the migration for the ff_plati_calupuri_fisiere table
- include optional insert-select and cleanup statements to migrate legacy fisier_pdf values

## Testing
- not run (SQL script only)


------
https://chatgpt.com/codex/tasks/task_e_68e600d149ec83269e7c52c92f48dece