### PR TITLE
Preserve supplier invoice filter state across navigation

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\FacturiFurnizori;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\FacturiFurnizori\FacturaFurnizorRequest;
 use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Support\FacturiFurnizori\FacturiIndexFilterState;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Http\RedirectResponse;
 
 class FacturaFurnizorController extends Controller
 {
@@ -104,6 +106,8 @@ class FacturaFurnizorController extends Controller
 
         $neplatiteCount = FacturaFurnizor::query()->whereDoesntHave('calupuri')->count();
 
+        FacturiIndexFilterState::remember($request);
+
         return view('facturiFurnizori.facturi.index', [
             'facturi' => $facturi,
             'filters' => $filters,
@@ -132,8 +136,7 @@ class FacturaFurnizorController extends Controller
 
         $factura = FacturaFurnizor::create($payload);
 
-        return redirect()
-            ->route('facturi-furnizori.facturi.index')
+        return $this->redirectToIndexWithFilters()
             ->with('status', 'Factura a fost adaugata cu succes.');
     }
 
@@ -171,8 +174,7 @@ class FacturaFurnizorController extends Controller
 
         $factura->update($payload);
 
-        return redirect()
-            ->route('facturi-furnizori.facturi.index')
+        return $this->redirectToIndexWithFilters()
             ->with('status', 'Factura a fost actualizata cu succes.');
     }
 
@@ -187,9 +189,15 @@ class FacturaFurnizorController extends Controller
 
         $factura->delete();
 
-        return redirect()
-            ->route('facturi-furnizori.facturi.index')
+        return $this->redirectToIndexWithFilters()
             ->with('status', 'Factura a fost stearsa.');
+    }
+
+    protected function redirectToIndexWithFilters(): RedirectResponse
+    {
+        $filters = FacturiIndexFilterState::get();
+
+        return redirect()->route('facturi-furnizori.facturi.index', $filters);
     }
 
     /**

--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -9,6 +9,7 @@ use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\FacturiFurnizori\PlataCalup;
 use App\Models\FacturiFurnizori\PlataCalupFisier;
 use App\Services\FacturiFurnizori\PlataCalupService;
+use App\Support\FacturiFurnizori\FacturiIndexFilterState;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
@@ -99,7 +100,7 @@ class PlataCalupController extends Controller
         }
 
         return redirect()
-            ->route('facturi-furnizori.facturi.index')
+            ->route('facturi-furnizori.facturi.index', FacturiIndexFilterState::get())
             ->with('status', 'Calupul a fost creat cu succes.');
     }
 

--- a/app/Support/FacturiFurnizori/FacturiIndexFilterState.php
+++ b/app/Support/FacturiFurnizori/FacturiIndexFilterState.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support\FacturiFurnizori;
+
+use Illuminate\Http\Request;
+
+class FacturiIndexFilterState
+{
+    public const SESSION_KEY = 'facturi_furnizori_facturi_filters';
+
+    public static function remember(Request $request): void
+    {
+        $request->session()->put(self::SESSION_KEY, self::extractQuery($request));
+    }
+
+    public static function extractQuery(Request $request): array
+    {
+        return $request->query();
+    }
+
+    public static function get(): array
+    {
+        return session(self::SESSION_KEY, []);
+    }
+
+    public static function route(): string
+    {
+        return route('facturi-furnizori.facturi.index', self::get());
+    }
+}

--- a/resources/views/facturiFurnizori/calupuri/_form.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/_form.blade.php
@@ -55,6 +55,6 @@
         @endforeach
     @endforeach
     @if ($calup && $calup->relationLoaded('fisiere') && $calup->fisiere->isNotEmpty())
-        <p class="mt-2 mb-0 text-muted small">Fișierele deja încărcate sunt listate mai jos.</p>
+        <p class="mt-2 mb-0 text-muted small">Fișierele deja încărcate sunt listate mai sus.</p>
     @endif
 </div>

--- a/resources/views/facturiFurnizori/calupuri/index.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/index.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+@endphp
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -9,7 +13,7 @@
             </span>
         </div>
         <div class="col-lg-9 text-lg-end mt-3 mt-lg-0">
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3 me-2" href="{{ route('facturi-furnizori.facturi.index') }}">
+            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3 me-2" href="{{ $facturiIndexUrl }}">
                 <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la facturi
             </a>
             <a class="btn btn-sm btn-primary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.create') }}">

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+@endphp
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -9,7 +13,7 @@
             </span>
         </div>
         <div class="col-lg-6 text-end">
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.index') }}">
+            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
                 <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la facturi
             </a>
         </div>

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -2,7 +2,7 @@
     $factura ??= null;
     $buttonText ??= __('Salvează factura');
     $buttonClass ??= 'btn-primary';
-    $cancelUrl ??= route('facturi-furnizori.facturi.index');
+    $cancelUrl ??= \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
 @endphp
 
 <div class="row">

--- a/resources/views/facturiFurnizori/facturi/save.blade.php
+++ b/resources/views/facturiFurnizori/facturi/save.blade.php
@@ -4,6 +4,7 @@
     /** @var \App\Models\FacturiFurnizori\FacturaFurnizor|null $factura */
     $factura ??= null;
     $isEdit = $factura?->exists;
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
 @endphp
 
 @section('content')
@@ -16,7 +17,7 @@
                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>
                         {{ $isEdit ? 'Modifică factură furnizor' : 'Adaugă factură furnizor' }}
                     </span>
-                    <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.index') }}">
+                    <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
                         <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la listă
                     </a>
                 </div>
@@ -52,7 +53,7 @@
                             'factura' => $factura,
                             'buttonText' => $isEdit ? 'Actualizează factura' : 'Salvează factura',
                             'buttonClass' => $isEdit ? 'btn-primary' : 'btn-success',
-                            'cancelUrl' => route('facturi-furnizori.facturi.index'),
+                            'cancelUrl' => $facturiIndexUrl,
                         ])
                     </form>
                 </div>

--- a/resources/views/facturiFurnizori/facturi/show.blade.php
+++ b/resources/views/facturiFurnizori/facturi/show.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+@endphp
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -12,7 +16,7 @@
             <a class="btn btn-sm btn-primary text-white border border-dark rounded-3 me-2" href="{{ route('facturi-furnizori.facturi.edit', $factura) }}">
                 <i class="fa-solid fa-pen-to-square me-1"></i>Modifică
             </a>
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.index') }}">
+            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
                 <i class="fa-solid fa-rotate-left me-1"></i>Înapoi
             </a>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,6 +37,9 @@
 </head>
 <body class="d-flex flex-column h-100">
     @auth
+    @php
+        $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+    @endphp
     {{-- <div id="app"> --}}
     <header>
         <nav class="navbar navbar-lg navbar-expand-lg navbar-dark shadow culoare1"
@@ -64,7 +67,7 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a class="dropdown-item" href="{{ route('facturi-furnizori.facturi.index') }}">
+                                    <a class="dropdown-item" href="{{ $facturiIndexUrl }}">
                                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
                                     </a>
                                 </li>
@@ -245,7 +248,7 @@
                                 </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
-                                    <a class="dropdown-item" href="{{ route('facturi-furnizori.facturi.index') }}">
+                                    <a class="dropdown-item" href="{{ $facturiIndexUrl }}">
                                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
                                     </a>
                                 </li>


### PR DESCRIPTION
## Summary
- remember the supplier invoice list filters in the session and reuse them for redirects
- update controllers and views to link back to the filtered invoice list via a shared helper
- tweak the calup file upload message to note that existing files are listed above

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e611295e088326891e86b5548ffbda