### PR TITLE
Organize calup uploads per batch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,19 @@ php artisan db:seed --class=FacturiFurnizoriDemoSeeder
 ```
 
 > **Note:** When invoking the seeder from a Unix shell do not include single backslashes in the class name (for example, `Database\Seeders\...`). The shell treats `\` as an escape character and will pass an invalid class reference to Artisan. The shorter `--class=FacturiFurnizoriDemoSeeder` form avoids that pitfall while still resolving to the fully qualified seeder class.
+
+## Calup file storage
+
+Supplier payment batch (calup) uploads are now stored in directories that mirror the calup identifier (`storage/app/facturi-furnizori/calupuri/{calup_id}`).
+
+To migrate legacy uploads into the new structure, run:
+
+```bash
+php artisan facturi-furnizori:organize-calup-files
+```
+
+You can perform a dry run first to inspect the planned moves without making changes:
+
+```bash
+php artisan facturi-furnizori:organize-calup-files --dry-run
+```

--- a/app/Console/Commands/OrganizeCalupFiles.php
+++ b/app/Console/Commands/OrganizeCalupFiles.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\FacturiFurnizori\PlataCalupFisier;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class OrganizeCalupFiles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'facturi-furnizori:organize-calup-files {--dry-run : Doar raporteaza schimbarile fara a muta fisierele}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reorganizeaza fisierele calupurilor pe directoare individuale pentru fiecare calup';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        $fisiere = PlataCalupFisier::query()->orderBy('id')->get();
+
+        if ($fisiere->isEmpty()) {
+            $this->info('Nu exista fisiere pentru procesare.');
+
+            return self::SUCCESS;
+        }
+
+        $mutate = 0;
+        $dejaPozitionate = 0;
+        $lipsa = 0;
+
+        $this->output->progressStart($fisiere->count());
+
+        foreach ($fisiere as $fisier) {
+            $this->output->progressAdvance();
+
+            $caleCurenta = $fisier->cale;
+
+            if (!$caleCurenta) {
+                $dejaPozitionate++;
+                continue;
+            }
+
+            $targetFolder = $this->targetFolder($fisier->plata_calup_id);
+
+            if (Str::startsWith($caleCurenta, $targetFolder . '/')) {
+                $dejaPozitionate++;
+                continue;
+            }
+
+            if (!Storage::exists($caleCurenta)) {
+                $lipsa++;
+                $this->warn("Fisier lipsa: {$caleCurenta}");
+                continue;
+            }
+
+            $basename = basename($caleCurenta);
+
+            if ($basename === '' || $basename === '.' || $basename === '..') {
+                $basename = 'fisier-' . $fisier->id;
+            }
+
+            $caleNoua = $this->determinaCaleNoua($targetFolder, $basename, $fisier->id);
+
+            if ($dryRun) {
+                $mutate++;
+                $this->line("[Simulare] {$caleCurenta} -> {$caleNoua}");
+                continue;
+            }
+
+            Storage::makeDirectory($targetFolder);
+
+            if (!Storage::move($caleCurenta, $caleNoua)) {
+                $this->error("Mutarea a esuat pentru {$caleCurenta}");
+                continue;
+            }
+
+            $fisier->update(['cale' => $caleNoua]);
+            $mutate++;
+        }
+
+        $this->output->progressFinish();
+
+        $this->info("Fisiere mutate: {$mutate}");
+        $this->info("Fisiere deja in ordine: {$dejaPozitionate}");
+
+        if ($lipsa > 0) {
+            $this->warn("Fisiere lipsa: {$lipsa}");
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function targetFolder(int $calupId): string
+    {
+        return 'facturi-furnizori/calupuri/' . $calupId;
+    }
+
+    private function determinaCaleNoua(string $folder, string $basename, int $fisierId): string
+    {
+        $nume = pathinfo($basename, PATHINFO_FILENAME);
+        $extensie = pathinfo($basename, PATHINFO_EXTENSION);
+
+        if ($nume === '') {
+            $nume = 'fisier_' . $fisierId;
+        }
+
+        $nume = Str::slug(Str::ascii($nume) ?: ('fisier_' . $fisierId), '_');
+
+        if ($nume === '') {
+            $nume = 'fisier_' . $fisierId;
+        }
+
+        $nume = substr($nume, 0, 120);
+
+        $sufix = $extensie ? '.' . strtolower($extensie) : '';
+        $cale = $folder . '/' . $nume . $sufix;
+        $counter = 1;
+
+        while (Storage::exists($cale)) {
+            $cale = $folder . '/' . $nume . '_' . $counter . $sufix;
+            $counter++;
+        }
+
+        return $cale;
+    }
+}

--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers\FacturiFurnizori;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\FacturiFurnizori\FacturaFurnizorRequest;
 use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Support\FacturiFurnizori\FacturiIndexFilterState;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Http\RedirectResponse;
 
 class FacturaFurnizorController extends Controller
 {
@@ -104,6 +106,8 @@ class FacturaFurnizorController extends Controller
 
         $neplatiteCount = FacturaFurnizor::query()->whereDoesntHave('calupuri')->count();
 
+        FacturiIndexFilterState::remember($request);
+
         return view('facturiFurnizori.facturi.index', [
             'facturi' => $facturi,
             'filters' => $filters,
@@ -132,8 +136,7 @@ class FacturaFurnizorController extends Controller
 
         $factura = FacturaFurnizor::create($payload);
 
-        return redirect()
-            ->route('facturi-furnizori.facturi.index')
+        return $this->redirectToIndexWithFilters()
             ->with('status', 'Factura a fost adaugata cu succes.');
     }
 
@@ -171,8 +174,7 @@ class FacturaFurnizorController extends Controller
 
         $factura->update($payload);
 
-        return redirect()
-            ->route('facturi-furnizori.facturi.index')
+        return $this->redirectToIndexWithFilters()
             ->with('status', 'Factura a fost actualizata cu succes.');
     }
 
@@ -187,9 +189,15 @@ class FacturaFurnizorController extends Controller
 
         $factura->delete();
 
-        return redirect()
-            ->route('facturi-furnizori.facturi.index')
+        return $this->redirectToIndexWithFilters()
             ->with('status', 'Factura a fost stearsa.');
+    }
+
+    protected function redirectToIndexWithFilters(): RedirectResponse
+    {
+        $filters = FacturiIndexFilterState::get();
+
+        return redirect()->route('facturi-furnizori.facturi.index', $filters);
     }
 
     /**

--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -9,6 +9,7 @@ use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\FacturiFurnizori\PlataCalup;
 use App\Models\FacturiFurnizori\PlataCalupFisier;
 use App\Services\FacturiFurnizori\PlataCalupService;
+use App\Support\FacturiFurnizori\FacturiIndexFilterState;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
@@ -99,7 +100,7 @@ class PlataCalupController extends Controller
         }
 
         return redirect()
-            ->route('facturi-furnizori.facturi.index')
+            ->route('facturi-furnizori.facturi.index', FacturiIndexFilterState::get())
             ->with('status', 'Calupul a fost creat cu succes.');
     }
 
@@ -209,6 +210,36 @@ class PlataCalupController extends Controller
         return back()->with('status', 'Factura a fost eliminata din calup.');
     }
 
+    public function vizualizeazaFisier(PlataCalup $plataCalup, PlataCalupFisier $fisier)
+    {
+        if ($fisier->plata_calup_id !== $plataCalup->id) {
+            abort(404);
+        }
+
+        if (!$fisier->isPreviewable()) {
+            return back()->with('error', 'Fisierul nu poate fi deschis în browser.');
+        }
+
+        if (!Storage::exists($fisier->cale)) {
+            return back()->with('error', 'Fisierul nu a putut fi gasit.');
+        }
+
+        $displayName = $fisier->nume_original ?: basename($fisier->cale);
+        $safeDisplayName = addcslashes($displayName, "\\\"");
+
+        $headers = [
+            'Content-Disposition' => 'inline; filename="' . $safeDisplayName . '"',
+        ];
+
+        $mimeType = Storage::mimeType($fisier->cale);
+
+        if ($mimeType) {
+            $headers['Content-Type'] = $mimeType;
+        }
+
+        return Storage::response($fisier->cale, $displayName, $headers);
+    }
+
     public function descarcaFisier(PlataCalup $plataCalup, ?PlataCalupFisier $fisier = null)
     {
         if ($fisier && $fisier->plata_calup_id !== $plataCalup->id) {
@@ -259,9 +290,10 @@ class PlataCalupController extends Controller
 
     private function salveazaFisier(PlataCalup $plataCalup, UploadedFile $file): PlataCalupFisier
     {
-        $folder = 'facturi-furnizori/calupuri';
+        $folder = $this->folderPentruCalup($plataCalup);
         $filename = $this->genereazaNumeFisier($file, $folder);
 
+        Storage::makeDirectory($folder);
         Storage::putFileAs($folder, $file, $filename);
 
         return $plataCalup->fisiere()->create([
@@ -291,6 +323,11 @@ class PlataCalupController extends Controller
         }
 
         return $filename;
+    }
+
+    private function folderPentruCalup(PlataCalup $plataCalup): string
+    {
+        return 'facturi-furnizori/calupuri/' . $plataCalup->id;
     }
 
     public function stergeFisier(PlataCalup $plataCalup, PlataCalupFisier $fisier)

--- a/app/Models/FacturiFurnizori/PlataCalupFisier.php
+++ b/app/Models/FacturiFurnizori/PlataCalupFisier.php
@@ -22,4 +22,36 @@ class PlataCalupFisier extends Model
     {
         return $this->belongsTo(PlataCalup::class, 'plata_calup_id');
     }
+
+    public function extension(): ?string
+    {
+        $source = $this->nume_original ?: $this->cale;
+
+        if (!$source) {
+            return null;
+        }
+
+        $extension = pathinfo($source, PATHINFO_EXTENSION);
+
+        if (!$extension) {
+            return null;
+        }
+
+        return strtolower($extension);
+    }
+
+    public function isPreviewable(): bool
+    {
+        $extension = $this->extension();
+
+        if (!$extension) {
+            return false;
+        }
+
+        return in_array($extension, [
+            'pdf',
+            'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg',
+            'txt', 'csv',
+        ], true);
+    }
 }

--- a/app/Support/FacturiFurnizori/FacturiIndexFilterState.php
+++ b/app/Support/FacturiFurnizori/FacturiIndexFilterState.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Support\FacturiFurnizori;
+
+use Illuminate\Http\Request;
+
+class FacturiIndexFilterState
+{
+    public const SESSION_KEY = 'facturi_furnizori_facturi_filters';
+
+    public static function remember(Request $request): void
+    {
+        $request->session()->put(self::SESSION_KEY, self::extractQuery($request));
+    }
+
+    public static function extractQuery(Request $request): array
+    {
+        return $request->query();
+    }
+
+    public static function get(): array
+    {
+        return session(self::SESSION_KEY, []);
+    }
+
+    public static function route(): string
+    {
+        return route('facturi-furnizori.facturi.index', self::get());
+    }
+}

--- a/resources/views/facturiFurnizori/calupuri/_form.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/_form.blade.php
@@ -55,6 +55,6 @@
         @endforeach
     @endforeach
     @if ($calup && $calup->relationLoaded('fisiere') && $calup->fisiere->isNotEmpty())
-        <p class="mt-2 mb-0 text-muted small">Fișierele deja încărcate sunt listate mai jos.</p>
+        <p class="mt-2 mb-0 text-muted small">Fișierele deja încărcate sunt listate mai sus.</p>
     @endif
 </div>

--- a/resources/views/facturiFurnizori/calupuri/index.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/index.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+@endphp
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -9,7 +13,7 @@
             </span>
         </div>
         <div class="col-lg-9 text-lg-end mt-3 mt-lg-0">
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3 me-2" href="{{ route('facturi-furnizori.facturi.index') }}">
+            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3 me-2" href="{{ $facturiIndexUrl }}">
                 <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la facturi
             </a>
             <a class="btn btn-sm btn-primary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.create') }}">

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+@endphp
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -9,7 +13,7 @@
             </span>
         </div>
         <div class="col-lg-6 text-end">
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.index') }}">
+            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
                 <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la facturi
             </a>
         </div>
@@ -49,6 +53,16 @@
                                             <td class="align-middle">{{ $fisier->nume_original ?: basename($fisier->cale) }}</td>
                                             <td class="align-middle">{{ $fisier->created_at?->format('d.m.Y H:i') }}</td>
                                             <td class="text-end">
+                                                @if ($fisier->isPreviewable())
+                                                    <a
+                                                        href="{{ route('facturi-furnizori.plati-calupuri.vizualizeaza-fisier', [$calup, $fisier]) }}"
+                                                        class="btn btn-sm btn-outline-secondary border border-secondary me-2"
+                                                        target="_blank"
+                                                        rel="noopener"
+                                                    >
+                                                        <i class="fa-solid fa-up-right-from-square me-1"></i>Deschide
+                                                    </a>
+                                                @endif
                                                 <a
                                                     href="{{ route('facturi-furnizori.plati-calupuri.descarca-fisier', [$calup, $fisier]) }}"
                                                     class="btn btn-sm btn-outline-primary border border-primary me-2"

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -2,7 +2,7 @@
     $factura ??= null;
     $buttonText ??= __('Salvează factura');
     $buttonClass ??= 'btn-primary';
-    $cancelUrl ??= route('facturi-furnizori.facturi.index');
+    $cancelUrl ??= \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
 @endphp
 
 <div class="row">

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -121,6 +121,9 @@
         </div>
         <div class="col-lg-2 text-lg-end mt-3 mt-lg-0">
             <div class="d-flex flex-column align-items-stretch align-items-lg-end gap-2">
+                <a class="btn btn-sm btn-info text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.index') }}" role="button">
+                    <i class="fa-solid fa-layer-group text-white me-1"></i>Vezi toate calupurile
+                </a>
                 <a class="btn btn-sm btn-success text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.create') }}" role="button">
                     <i class="fas fa-plus-square text-white me-1"></i>Adaugă factură
                 </a>

--- a/resources/views/facturiFurnizori/facturi/save.blade.php
+++ b/resources/views/facturiFurnizori/facturi/save.blade.php
@@ -4,6 +4,7 @@
     /** @var \App\Models\FacturiFurnizori\FacturaFurnizor|null $factura */
     $factura ??= null;
     $isEdit = $factura?->exists;
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
 @endphp
 
 @section('content')
@@ -16,7 +17,7 @@
                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>
                         {{ $isEdit ? 'Modifică factură furnizor' : 'Adaugă factură furnizor' }}
                     </span>
-                    <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.index') }}">
+                    <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
                         <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la listă
                     </a>
                 </div>
@@ -52,7 +53,7 @@
                             'factura' => $factura,
                             'buttonText' => $isEdit ? 'Actualizează factura' : 'Salvează factura',
                             'buttonClass' => $isEdit ? 'btn-primary' : 'btn-success',
-                            'cancelUrl' => route('facturi-furnizori.facturi.index'),
+                            'cancelUrl' => $facturiIndexUrl,
                         ])
                     </form>
                 </div>

--- a/resources/views/facturiFurnizori/facturi/show.blade.php
+++ b/resources/views/facturiFurnizori/facturi/show.blade.php
@@ -1,5 +1,9 @@
 @extends('layouts.app')
 
+@php
+    $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+@endphp
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -12,7 +16,7 @@
             <a class="btn btn-sm btn-primary text-white border border-dark rounded-3 me-2" href="{{ route('facturi-furnizori.facturi.edit', $factura) }}">
                 <i class="fa-solid fa-pen-to-square me-1"></i>Modifică
             </a>
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.index') }}">
+            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
                 <i class="fa-solid fa-rotate-left me-1"></i>Înapoi
             </a>
         </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,6 +37,9 @@
 </head>
 <body class="d-flex flex-column h-100">
     @auth
+    @php
+        $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+    @endphp
     {{-- <div id="app"> --}}
     <header>
         <nav class="navbar navbar-lg navbar-expand-lg navbar-dark shadow culoare1"
@@ -64,7 +67,7 @@
                                     </a>
                                 </li>
                                 <li>
-                                    <a class="dropdown-item" href="{{ route('facturi-furnizori.facturi.index') }}">
+                                    <a class="dropdown-item" href="{{ $facturiIndexUrl }}">
                                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
                                     </a>
                                 </li>
@@ -245,7 +248,7 @@
                                 </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
-                                    <a class="dropdown-item" href="{{ route('facturi-furnizori.facturi.index') }}">
+                                    <a class="dropdown-item" href="{{ $facturiIndexUrl }}">
                                         <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
                                     </a>
                                 </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -202,6 +202,9 @@ Route::group(['middleware' => 'auth'], function () {
             Route::delete('plati-calupuri/{plataCalup}/fisiere/{fisier}', [PlataCalupController::class, 'stergeFisier'])
                 ->name('plati-calupuri.fisiere.destroy');
 
+            Route::get('plati-calupuri/{plataCalup}/vizualizeaza-fisier/{fisier}', [PlataCalupController::class, 'vizualizeazaFisier'])
+                ->name('plati-calupuri.vizualizeaza-fisier');
+
             Route::get('plati-calupuri/{plataCalup}/descarca-fisier/{fisier?}', [PlataCalupController::class, 'descarcaFisier'])
                 ->name('plati-calupuri.descarca-fisier');
         });


### PR DESCRIPTION
## Summary
- store new calup uploads in per-calup directories so future files are grouped with their batch
- add an artisan command that can migrate existing calup files into the new directory structure with an optional dry run
- link to the calup index from the invoice list and document the migration command for operators

## Testing
- php -l app/Console/Commands/OrganizeCalupFiles.php
- php -l app/Http/Controllers/FacturiFurnizori/PlataCalupController.php

------
https://chatgpt.com/codex/tasks/task_e_68e611295e088326891e86b5548ffbda