### PR TITLE
Align calup payment batches list styling with invoices page

### DIFF
--- a/resources/views/facturiFurnizori/calupuri/index.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/index.blade.php
@@ -7,50 +7,80 @@
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
-        <div class="col-lg-3">
+        <div class="col-lg-2 mb-2">
             <span class="badge culoare1 fs-5">
                 <i class="fa-solid fa-layer-group me-1"></i>Calupuri plăți
             </span>
         </div>
-        <div class="col-lg-9 text-lg-end mt-3 mt-lg-0">
-            <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3 me-2" href="{{ $facturiIndexUrl }}">
-                <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la facturi
-            </a>
-            {{-- <a class="btn btn-sm btn-primary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.create') }}">
-                <i class="fa-solid fa-plus me-1"></i>Creează calup
-            </a> --}}
-        </div>
-        <div class="col-12 mt-3">
-            <form method="GET" action="{{ url()->current() }}" class="row g-2 g-md-3 align-items-end">
-                <div class="col-12 col-md-6 col-xl-4">
-                    <label for="filter-data-de" class="mb-0 ps-2">Data plată de la</label>
-                    <input type="date" name="data_plata_de_la" id="filter-data-de" class="form-control bg-white rounded-3" value="{{ $filters['data_plata_de_la'] }}">
+        <div class="col-lg-8 mb-0" id="formularCalupuri">
+            <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ url()->current() }}">
+                <div class="row gy-1 gx-4 mb-2 custom-search-form d-flex justify-content-center">
+                    <div class="col-lg-4 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <label for="filter-data-de" class="form-label small text-muted mb-0 flex-shrink-0 text-nowrap">Data plată de la</label>
+                            <input
+                                type="date"
+                                class="form-control rounded-3"
+                                id="filter-data-de"
+                                name="data_plata_de_la"
+                                value="{{ $filters['data_plata_de_la'] }}"
+                            >
+                        </div>
+                    </div>
+                    <div class="col-lg-4 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <label for="filter-data-pana" class="form-label small text-muted mb-0 flex-shrink-0 text-nowrap">Data plată până la</label>
+                            <input
+                                type="date"
+                                class="form-control rounded-3"
+                                id="filter-data-pana"
+                                name="data_plata_pana"
+                                value="{{ $filters['data_plata_pana'] }}"
+                            >
+                        </div>
+                    </div>
+                    <div class="col-lg-4 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-magnifying-glass text-muted"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-cauta"
+                                name="cauta"
+                                placeholder="Denumire sau observații"
+                                value="{{ $filters['cauta'] }}"
+                                aria-label="Caută calupuri"
+                            >
+                        </div>
+                    </div>
                 </div>
-                <div class="col-12 col-md-6 col-xl-4">
-                    <label for="filter-data-pana" class="mb-0 ps-2">Data plată până la</label>
-                    <input type="date" name="data_plata_pana" id="filter-data-pana" class="form-control bg-white rounded-3" value="{{ $filters['data_plata_pana'] }}">
-                </div>
-                <div class="col-12 col-md-6 col-xl-4">
-                    <label for="filter-cauta" class="mb-0 ps-2">Caută</label>
-                    <input type="text" name="cauta" id="filter-cauta" class="form-control bg-white rounded-3" placeholder="Denumire sau observații" value="{{ $filters['cauta'] }}">
-                </div>
-                <div class="col-12 col-md-6 col-xl-3 d-flex gap-2">
-                    <button type="submit" class="btn btn-sm btn-primary text-white border border-dark rounded-3 flex-fill">
-                        <i class="fa-solid fa-filter me-1"></i>Filtrează
+                <div class="row custom-search-form justify-content-center">
+                    <button class="btn btn-sm btn-primary text-white col-md-4 me-3 border border-dark rounded-3" type="submit">
+                        <i class="fas fa-search text-white me-1"></i>Caută
                     </button>
-                    <a href="{{ route('facturi-furnizori.plati-calupuri.index') }}" class="btn btn-sm btn-secondary text-white border border-dark rounded-3 flex-fill">
-                        <i class="fa-solid fa-rotate-left me-1"></i>Resetează
+                    <a class="btn btn-sm btn-secondary text-white col-md-4 border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.index') }}" role="button">
+                        <i class="far fa-trash-alt text-white me-1"></i>Resetează
                     </a>
                 </div>
             </form>
+        </div>
+        <div class="col-lg-2 text-lg-end mt-3 mt-lg-0">
+            <div class="d-flex flex-column align-items-stretch align-items-lg-end gap-2">
+                <a class="btn btn-sm btn-secondary text-white border border-dark rounded-3" href="{{ $facturiIndexUrl }}">
+                    <i class="fa-solid fa-rotate-left me-1"></i>Înapoi la facturi
+                </a>
+                {{-- <a class="btn btn-sm btn-primary text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.create') }}">
+                    <i class="fa-solid fa-plus me-1"></i>Creează calup
+                </a> --}}
+            </div>
         </div>
     </div>
 
     <div class="card-body px-0 py-3">
         @include('errors')
 
-        <div class="table-responsive rounded mb-3 px-3">
-            <table class="table table-sm table-striped table-hover table-bordered border-dark align-middle">
+        <div class="table-responsive rounded">
+            <table class="table table-sm table-striped table-hover rounded align-middle">
                 <thead class="text-white rounded culoare2">
                     <tr>
                         <th>Denumire</th>


### PR DESCRIPTION
## Summary
- restyled the supplier payment batches index header to mirror the invoice filters layout and actions
- updated filter inputs and buttons to reuse the shared custom search form styling
- adjusted the table container styling to match the invoices listing appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61dabdb388326ad6ec299dd00183f