### PR TITLE
Allow negative supplier invoice amounts

### DIFF
--- a/app/Http/Requests/FacturiFurnizori/FacturaFurnizorRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/FacturaFurnizorRequest.php
@@ -26,7 +26,7 @@ class FacturaFurnizorRequest extends FormRequest
             'numar_factura' => ['required', 'string', 'max:100'],
             'data_factura' => ['required', 'date'],
             'data_scadenta' => ['required', 'date', 'after_or_equal:data_factura'],
-            'suma' => ['required', 'numeric', 'min:0'],
+            'suma' => ['required', 'numeric'],
             'moneda' => ['required', 'string', 'size:3'],
             'cont_iban' => ['nullable', 'string', 'max:255'],
             'departament_vehicul' => ['nullable', 'string', 'max:150'],

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -97,7 +97,6 @@
             id="suma"
             class="form-control bg-white rounded-3 {{ $errors->has('suma') ? 'is-invalid' : '' }}"
             step="0.01"
-            min="0"
             value="{{ old('suma', $factura->suma ?? '') }}"
             required
         >

--- a/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
+++ b/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\FacturiFurnizori;
+
+use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FacturaFurnizorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_allows_storing_negative_amounts(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = [
+            'denumire_furnizor' => 'Furnizor Negativ SRL',
+            'numar_factura' => 'NEG-001',
+            'data_factura' => '2025-01-15',
+            'data_scadenta' => '2025-01-20',
+            'suma' => -150.25,
+            'moneda' => 'RON',
+            'cont_iban' => '',
+            'departament_vehicul' => '',
+            'observatii' => '',
+        ];
+
+        $response = $this->actingAs($user)
+            ->post(route('facturi-furnizori.facturi.store'), $payload);
+
+        $response->assertRedirect(route('facturi-furnizori.facturi.index'));
+
+        $this->assertDatabaseHas('ff_facturi', [
+            'numar_factura' => 'NEG-001',
+            'suma' => -150.25,
+        ]);
+    }
+
+    public function test_it_allows_updating_to_negative_amounts(): void
+    {
+        $user = User::factory()->create();
+        $factura = FacturaFurnizor::factory()->create([
+            'suma' => 450.00,
+            'moneda' => 'RON',
+        ]);
+
+        $payload = [
+            'denumire_furnizor' => $factura->denumire_furnizor,
+            'numar_factura' => $factura->numar_factura,
+            'data_factura' => $factura->data_factura->format('Y-m-d'),
+            'data_scadenta' => $factura->data_scadenta->format('Y-m-d'),
+            'suma' => -99.99,
+            'moneda' => $factura->moneda,
+            'cont_iban' => $factura->cont_iban ?? '',
+            'departament_vehicul' => $factura->departament_vehicul ?? '',
+            'observatii' => $factura->observatii ?? '',
+        ];
+
+        $response = $this->actingAs($user)
+            ->put(route('facturi-furnizori.facturi.update', $factura), $payload);
+
+        $response->assertRedirect(route('facturi-furnizori.facturi.index'));
+
+        $this->assertDatabaseHas('ff_facturi', [
+            'id' => $factura->id,
+            'suma' => -99.99,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow negative supplier invoice sums by removing the non-negative constraint in the form request and UI
- add feature coverage to confirm negative values can be stored and updated for supplier invoices

## Testing
- `php artisan test` *(fails: missing vendor autoload because Composer install requires GitHub access in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e8e236a1008326a42671c721d61a5e