### PR TITLE
Add super admin user impersonation interface

### DIFF
--- a/app/Http/Controllers/Tech/ImpersonationController.php
+++ b/app/Http/Controllers/Tech/ImpersonationController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Tech;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class ImpersonationController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $search = trim((string) $request->input('search', ''));
+
+        $users = User::query()
+            ->when($search !== '', function ($query) use ($search) {
+                $query->where(function ($subQuery) use ($search) {
+                    $subQuery->where('name', 'like', '%' . $search . '%')
+                        ->orWhere('email', 'like', '%' . $search . '%');
+                });
+            })
+            ->orderBy('name')
+            ->paginate(15)
+            ->appends(['search' => $search]);
+
+        return view('tech.impersonation.index', [
+            'users' => $users,
+            'search' => $search,
+            'isImpersonating' => $request->session()->has('impersonated_by'),
+            'activeUserId' => Auth::id(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'user_id' => ['required', 'integer', 'exists:users,id'],
+        ]);
+
+        $targetUser = User::query()->findOrFail($validated['user_id']);
+        $currentUser = $request->user();
+
+        if ($currentUser && $targetUser->is($currentUser)) {
+            return redirect()
+                ->route('tech.impersonation.index')
+                ->with('impersonation_status', 'Ești deja autentificat ca acest utilizator.');
+        }
+
+        $request->session()->put('impersonated_by', $currentUser?->id);
+        $request->session()->put('impersonated_by_name', $currentUser?->name);
+
+        Auth::login($targetUser);
+
+        return redirect('/');
+    }
+
+    public function destroy(Request $request): RedirectResponse
+    {
+        $originalUserId = $request->session()->pull('impersonated_by');
+        $originalUserName = $request->session()->pull('impersonated_by_name');
+
+        if ($originalUserId) {
+            $originalUser = User::find($originalUserId);
+
+            if ($originalUser) {
+                Auth::login($originalUser);
+
+                return redirect('/')
+                    ->with('impersonation_status', sprintf('Ai revenit la contul %s.', $originalUserName ?? $originalUser->name));
+            }
+        }
+
+        Auth::logout();
+
+        return redirect('/');
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -39,6 +39,8 @@
     @auth
     @php
         $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+        $impersonationActive = session()->has('impersonated_by');
+        $impersonatorName = session('impersonated_by_name');
     @endphp
     {{-- <div id="app"> --}}
     <header>
@@ -154,26 +156,6 @@
                                 </li>
                             </ul>
                         </li>
-                        @can('access-tech')
-                            <li class="nav-item me-3 dropdown">
-                                <a class="nav-link active dropdown-toggle" href="about:blank" id="navbarTech" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                    <i class="fa-solid fa-microchip me-1"></i>
-                                    Tech
-                                </a>
-                                <ul class="dropdown-menu" aria-labelledby="navbarTech">
-                                    <li>
-                                        <a class="dropdown-item" href="{{ route('tech.migrations.index') }}">
-                                            <i class="fa-solid fa-database me-1"></i>Migration Center
-                                        </a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item" href="{{ route('tech.seeders.index') }}">
-                                            <i class="fa-solid fa-seedling me-1"></i>Seeder Center
-                                        </a>
-                                    </li>
-                                </ul>
-                            </li>
-                        @endcan
                         {{-- <li class="nav-item me-3">
                             <a class="nav-link active" aria-current="page" href="/camioane">
                                 <i class="fa-solid fa-truck me-1"></i>Camioane
@@ -288,6 +270,31 @@
                                 @endif
                             </ul>
                         </li>
+                        @can('access-tech')
+                            <li class="nav-item me-3 dropdown">
+                                <a class="nav-link active dropdown-toggle" href="about:blank" id="navbarTech" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="fa-solid fa-microchip me-1"></i>
+                                    Tech
+                                </a>
+                                <ul class="dropdown-menu" aria-labelledby="navbarTech">
+                                    <li>
+                                        <a class="dropdown-item" href="{{ route('tech.impersonation.index') }}">
+                                            <i class="fa-solid fa-user-secret me-1"></i>Impersonare utilizatori
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="{{ route('tech.migrations.index') }}">
+                                            <i class="fa-solid fa-database me-1"></i>Migration Center
+                                        </a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="{{ route('tech.seeders.index') }}">
+                                            <i class="fa-solid fa-seedling me-1"></i>Seeder Center
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                        @endcan
                     </ul>
 
                     <!-- Right Side Of Navbar -->
@@ -306,6 +313,21 @@
                                 </li> --}}
                             @endif
                         @else
+                            @if ($impersonationActive)
+                                <li class="nav-item d-flex align-items-center me-3 gap-2">
+                                    <span class="badge bg-warning text-dark text-wrap">
+                                        <i class="fa-solid fa-user-secret me-1"></i>
+                                        Impersonare: {{ auth()->user()->name }}
+                                    </span>
+                                    <form method="post" action="{{ route('impersonation.stop') }}" class="d-inline">
+                                        @csrf
+                                        <button type="submit" class="btn btn-outline-light btn-sm"
+                                            title="Revenire la {{ $impersonatorName ?? 'contul inițial' }}">
+                                            <i class="fa-solid fa-person-walking-arrow-loop-left me-1"></i>Stop impersonating
+                                        </button>
+                                    </form>
+                                </li>
+                            @endif
                             <li class="nav-item dropdown">
                                 <a class="nav-link active dropdown-toggle" href="about:blank" id="navbarAuthentication" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                     {{ Auth::user()->name }}

--- a/resources/views/tech/impersonation/index.blade.php
+++ b/resources/views/tech/impersonation/index.blade.php
@@ -1,0 +1,79 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container py-4">
+        <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center mb-4 gap-3">
+            <div>
+                <h1 class="h3 mb-0">Impersonare utilizatori</h1>
+                <p class="text-muted mb-0">Autentifică-te temporar ca un alt utilizator pentru a-i vedea permisiunile.</p>
+            </div>
+            <form class="d-flex" method="get" action="{{ route('tech.impersonation.index') }}">
+                <div class="input-group">
+                    <input type="search" name="search" value="{{ $search }}" class="form-control"
+                        placeholder="Caută după nume sau email">
+                    <button class="btn btn-outline-secondary" type="submit">
+                        <i class="fa-solid fa-magnifying-glass me-1"></i>Caută
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        @if (session('impersonation_status'))
+            <div class="alert alert-info" role="alert">
+                {{ session('impersonation_status') }}
+            </div>
+        @endif
+
+        @if ($isImpersonating)
+            <div class="alert alert-warning" role="alert">
+                <i class="fa-solid fa-triangle-exclamation me-1"></i>
+                Ești autentificat temporar ca <strong>{{ auth()->user()->name }}</strong>.
+                Folosește butonul „Stop impersonating” din meniu pentru a reveni la contul tău.
+            </div>
+        @endif
+
+        <div class="card">
+            <div class="table-responsive">
+                <table class="table table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col">Nume</th>
+                            <th scope="col">Email</th>
+                            <th scope="col" class="text-end">Acțiuni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @forelse ($users as $user)
+                            <tr>
+                                <td class="align-middle">{{ $user->name }}</td>
+                                <td class="align-middle">{{ $user->email }}</td>
+                                <td class="align-middle text-end">
+                                    <form method="post" action="{{ route('tech.impersonation.start') }}" class="d-inline">
+                                        @csrf
+                                        <input type="hidden" name="user_id" value="{{ $user->id }}">
+                                        <button type="submit" class="btn btn-sm btn-primary"
+                                            @if ($user->id === $activeUserId) disabled @endif>
+                                            <i class="fa-solid fa-user-secret me-1"></i>Impersonare
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="3" class="text-center text-muted py-4">
+                                    Nu am găsit niciun utilizator pentru criteriile de căutare introduse.
+                                </td>
+                            </tr>
+                        @endforelse
+                    </tbody>
+                </table>
+            </div>
+
+            @if ($users->hasPages())
+                <div class="card-footer">
+                    {{ $users->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\KeyPerformanceIndicatorController;
 use App\Http\Controllers\OfertaCursaController;
 use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorController;
 use App\Http\Controllers\FacturiFurnizori\PlataCalupController;
+use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\SeederCenterController;
 
@@ -83,12 +84,17 @@ Route::group(['middleware' => 'auth'], function () {
         ->name('tech.')
         ->middleware('role:super-admin')
         ->group(function () {
+            Route::get('impersonation', [ImpersonationController::class, 'index'])->name('impersonation.index');
+            Route::post('impersonation', [ImpersonationController::class, 'store'])->name('impersonation.start');
             Route::get('migrations', [MigrationCenterController::class, 'index'])->name('migrations.index');
             Route::post('migrations/preview', [MigrationCenterController::class, 'preview'])->name('migrations.preview');
             Route::post('migrations/run', [MigrationCenterController::class, 'run'])->name('migrations.run');
             Route::get('seeders', [SeederCenterController::class, 'index'])->name('seeders.index');
             Route::post('seeders/run', [SeederCenterController::class, 'run'])->name('seeders.run');
         });
+
+    Route::post('impersonation/stop', [ImpersonationController::class, 'destroy'])
+        ->name('impersonation.stop');
 
     Route::get('/file-manager-personalizat/{cale?}', [FileManagerPersonalizatController::class, 'afisareDirectoareSiFisiere'])->where('cale', '.*');
     Route::post('/file-manager-personalizat-director/creaza', [FileManagerPersonalizatController::class, 'directorCreaza']);

--- a/tests/Feature/ImpersonationTest.php
+++ b/tests/Feature/ImpersonationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ImpersonationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_view_impersonation_screen(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+
+        $response = $this->actingAs($superAdmin)->get(route('tech.impersonation.index'));
+
+        $response->assertOk();
+        $response->assertSee('Impersonare utilizatori');
+    }
+
+    public function test_super_admin_can_impersonate_a_user(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+        $targetUser = User::factory()->create();
+
+        $response = $this->actingAs($superAdmin)->post(route('tech.impersonation.start'), [
+            'user_id' => $targetUser->id,
+        ]);
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticatedAs($targetUser);
+        $this->assertSame($superAdmin->id, session('impersonated_by'));
+        $this->assertSame($superAdmin->name, session('impersonated_by_name'));
+    }
+
+    public function test_impersonated_user_can_stop_impersonation(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+        $targetUser = User::factory()->create();
+
+        $this->actingAs($superAdmin)->post(route('tech.impersonation.start'), [
+            'user_id' => $targetUser->id,
+        ]);
+
+        $this->assertAuthenticatedAs($targetUser);
+
+        $response = $this->post(route('impersonation.stop'));
+
+        $response->assertRedirect('/');
+        $this->assertAuthenticatedAs($superAdmin);
+        $this->assertNull(session('impersonated_by'));
+        $this->assertNull(session('impersonated_by_name'));
+    }
+
+    private function createSuperAdmin(): User
+    {
+        $role = Role::firstOrCreate(
+            ['slug' => 'super-admin'],
+            [
+                'name' => 'Super Admin',
+                'description' => 'Full access to the technical toolbox.',
+            ]
+        );
+
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Tech impersonation controller and routes so super admins can temporarily log in as other users
- move the Tech menu after Utile, add the impersonation entry, and surface a "Stop impersonating" control in the header
- build the Tech impersonation page with filtering and cover the impersonation lifecycle with feature tests

## Testing
- php artisan test *(fails: vendor/autoload.php missing because Composer dependencies are not installed in the environment)*
- composer install *(fails: GitHub API requires a token to download packages in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eebb3c7d688326bd420909ad5be281