### PR TITLE
Add supplier invoice products and fix index filters

### DIFF
--- a/app/Models/FacturiFurnizori/FacturaFurnizor.php
+++ b/app/Models/FacturiFurnizori/FacturaFurnizor.php
@@ -2,8 +2,10 @@
 
 namespace App\Models\FacturiFurnizori;
 
+use App\Models\FacturiFurnizori\GestiunePiesa;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class FacturaFurnizor extends Model
 {
@@ -35,5 +37,10 @@ class FacturaFurnizor extends Model
     public function calupuri()
     {
         return $this->belongsToMany(PlataCalup::class, 'ff_facturi_plati', 'factura_id', 'calup_id')->withTimestamps();
+    }
+
+    public function piese(): HasMany
+    {
+        return $this->hasMany(GestiunePiesa::class, 'factura_id');
     }
 }

--- a/app/Models/FacturiFurnizori/GestiunePiesa.php
+++ b/app/Models/FacturiFurnizori/GestiunePiesa.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models\FacturiFurnizori;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class GestiunePiesa extends Model
+{
+    use HasFactory;
+
+    protected $table = 'gestiune_piese';
+
+    protected $fillable = [
+        'factura_id',
+        'denumire',
+        'cod',
+        'nr_bucati',
+        'pret',
+    ];
+
+    protected $casts = [
+        'nr_bucati' => 'decimal:2',
+        'pret' => 'decimal:2',
+    ];
+
+    public function factura(): BelongsTo
+    {
+        return $this->belongsTo(FacturaFurnizor::class, 'factura_id');
+    }
+}

--- a/app/Support/FacturiFurnizori/FacturiIndexFilterState.php
+++ b/app/Support/FacturiFurnizori/FacturiIndexFilterState.php
@@ -15,7 +15,9 @@ class FacturiIndexFilterState
 
     public static function extractQuery(Request $request): array
     {
-        return $request->query();
+        return collect($request->query())
+            ->except(['page', 'cursor'])
+            ->toArray();
     }
 
     public static function get(): array

--- a/database/migrations/2025_03_16_000000_create_gestiune_piese_table.php
+++ b/database/migrations/2025_03_16_000000_create_gestiune_piese_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('gestiune_piese', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('factura_id')
+                ->constrained('ff_facturi')
+                ->cascadeOnDelete();
+            $table->string('denumire');
+            $table->string('cod')->nullable();
+            $table->decimal('nr_bucati', 12, 2)->nullable();
+            $table->decimal('pret', 12, 2)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('gestiune_piese');
+    }
+};

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -3,6 +3,23 @@
     $buttonText ??= __('Salvează factura');
     $buttonClass ??= 'btn-primary';
     $cancelUrl ??= \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+    $produseColectie = collect(old('produse', $factura?->piese?->map(function ($piesa) {
+        return [
+            'denumire' => $piesa->denumire,
+            'cod' => $piesa->cod,
+            'nr_bucati' => $piesa->nr_bucati,
+            'pret' => $piesa->pret,
+        ];
+    })->toArray() ?? []));
+    if ($produseColectie->isEmpty()) {
+        $produseColectie = collect([[
+            'denumire' => '',
+            'cod' => '',
+            'nr_bucati' => '',
+            'pret' => '',
+        ]]);
+    }
+    $produse = $produseColectie->values()->toArray();
 @endphp
 
 <div class="row">
@@ -157,6 +174,144 @@
     </div>
 </div>
 
+<div class="row mb-4">
+    <div class="col-lg-12">
+        <div class="border border-dark rounded-3 p-3 bg-white">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h6 class="text-uppercase text-muted mb-0">Produse</h6>
+                <button type="button" class="btn btn-sm btn-success text-white" data-add-produs>
+                    <i class="fa-solid fa-plus me-1"></i>Adaugă produs
+                </button>
+            </div>
+
+            @error('produse')
+                <div class="alert alert-danger py-2">{{ $message }}</div>
+            @enderror
+
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered align-middle mb-0" id="produse-table">
+                    <thead class="text-white rounded culoare2">
+                        <tr>
+                            <th style="min-width: 220px;">Denumire</th>
+                            <th style="min-width: 140px;">Cod</th>
+                            <th style="min-width: 120px;">Cantitate</th>
+                            <th style="min-width: 120px;">Preț</th>
+                            <th style="width: 70px;" class="text-center">Acțiuni</th>
+                        </tr>
+                    </thead>
+                    <tbody id="produse-table-body">
+                        @foreach ($produse as $index => $produs)
+                            <tr data-index="{{ $index }}">
+                                <td>
+                                    <input
+                                        type="text"
+                                        name="produse[{{ $index }}][denumire]"
+                                        class="form-control form-control-sm {{ $errors->has('produse.' . $index . '.denumire') ? 'is-invalid' : '' }}"
+                                        value="{{ $produs['denumire'] }}"
+                                        placeholder="Ex: Filtru ulei"
+                                    >
+                                    @error('produse.' . $index . '.denumire')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td>
+                                    <input
+                                        type="text"
+                                        name="produse[{{ $index }}][cod]"
+                                        class="form-control form-control-sm {{ $errors->has('produse.' . $index . '.cod') ? 'is-invalid' : '' }}"
+                                        value="{{ $produs['cod'] }}"
+                                        placeholder="Ex: COD123"
+                                    >
+                                    @error('produse.' . $index . '.cod')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        name="produse[{{ $index }}][nr_bucati]"
+                                        class="form-control form-control-sm {{ $errors->has('produse.' . $index . '.nr_bucati') ? 'is-invalid' : '' }}"
+                                        value="{{ $produs['nr_bucati'] }}"
+                                        placeholder="0"
+                                    >
+                                    @error('produse.' . $index . '.nr_bucati')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        name="produse[{{ $index }}][pret]"
+                                        class="form-control form-control-sm {{ $errors->has('produse.' . $index . '.pret') ? 'is-invalid' : '' }}"
+                                        value="{{ $produs['pret'] }}"
+                                        placeholder="0.00"
+                                    >
+                                    @error('produse.' . $index . '.pret')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td class="text-center">
+                                    <button type="button" class="btn btn-outline-danger btn-sm" data-remove-produs>
+                                        <i class="fa-solid fa-trash"></i>
+                                    </button>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <template id="template-produs-row">
+                <tr data-index="__INDEX__">
+                    <td>
+                        <input
+                            type="text"
+                            name="produse[__INDEX__][denumire]"
+                            class="form-control form-control-sm"
+                            placeholder="Ex: Filtru ulei"
+                        >
+                    </td>
+                    <td>
+                        <input
+                            type="text"
+                            name="produse[__INDEX__][cod]"
+                            class="form-control form-control-sm"
+                            placeholder="Ex: COD123"
+                        >
+                    </td>
+                    <td>
+                        <input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            name="produse[__INDEX__][nr_bucati]"
+                            class="form-control form-control-sm"
+                            placeholder="0"
+                        >
+                    </td>
+                    <td>
+                        <input
+                            type="number"
+                            step="0.01"
+                            name="produse[__INDEX__][pret]"
+                            class="form-control form-control-sm"
+                            placeholder="0.00"
+                        >
+                    </td>
+                    <td class="text-center">
+                        <button type="button" class="btn btn-outline-danger btn-sm" data-remove-produs>
+                            <i class="fa-solid fa-trash"></i>
+                        </button>
+                    </td>
+                </tr>
+            </template>
+        </div>
+    </div>
+</div>
+
 <div class="row mb-0 px-3">
     <div class="col-lg-12 mb-2 d-flex justify-content-center">
         <button type="submit" class="btn btn-lg {{ $buttonClass }} text-white me-3 rounded-3">
@@ -167,3 +322,48 @@
         </a>
     </div>
 </div>
+
+@push('page-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const produseTableBody = document.getElementById('produse-table-body');
+            const addButton = document.querySelector('[data-add-produs]');
+            const template = document.getElementById('template-produs-row');
+
+            if (!produseTableBody || !addButton || !template) {
+                return;
+            }
+
+            const getNextIndex = () => {
+                const indexes = Array.from(produseTableBody.querySelectorAll('tr[data-index]'))
+                    .map((row) => Number.parseInt(row.getAttribute('data-index') ?? '0', 10));
+
+                if (indexes.length === 0) {
+                    return 0;
+                }
+
+                return Math.max(...indexes) + 1;
+            };
+
+            addButton.addEventListener('click', () => {
+                const newIndex = getNextIndex();
+                const html = template.innerHTML.replace(/__INDEX__/g, String(newIndex));
+                produseTableBody.insertAdjacentHTML('beforeend', html);
+            });
+
+            produseTableBody.addEventListener('click', (event) => {
+                const trigger = event.target.closest('[data-remove-produs]');
+
+                if (!trigger) {
+                    return;
+                }
+
+                const row = trigger.closest('tr');
+
+                if (row) {
+                    row.remove();
+                }
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/facturiFurnizori/facturi/show.blade.php
+++ b/resources/views/facturiFurnizori/facturi/show.blade.php
@@ -48,6 +48,36 @@
                 </div>
             </div>
 
+            <div class="border border-dark rounded-3 p-3 bg-white mb-3">
+                <h6 class="text-uppercase text-muted mb-3">Produse</h6>
+                @if ($factura->piese->isEmpty())
+                    <p class="text-muted mb-0">Factura nu are produse asociate.</p>
+                @else
+                    <div class="table-responsive">
+                        <table class="table table-sm table-hover table-bordered border-dark align-middle mb-0">
+                            <thead class="text-white rounded culoare2">
+                                <tr>
+                                    <th>Denumire</th>
+                                    <th>Cod</th>
+                                    <th class="text-end">Cantitate</th>
+                                    <th class="text-end">Preț</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($factura->piese as $piesa)
+                                    <tr>
+                                        <td>{{ $piesa->denumire }}</td>
+                                        <td>{{ $piesa->cod ?: '-' }}</td>
+                                        <td class="text-end">{{ $piesa->nr_bucati !== null ? number_format($piesa->nr_bucati, 2) : '-' }}</td>
+                                        <td class="text-end">{{ $piesa->pret !== null ? number_format($piesa->pret, 2) : '-' }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+
             <div class="border border-dark rounded-3 p-3 bg-white">
                 <h6 class="text-uppercase text-muted mb-3">Calupuri asociate</h6>
                 @if ($factura->calupuri->isEmpty())

--- a/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
+++ b/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
@@ -68,4 +68,102 @@ class FacturaFurnizorTest extends TestCase
             'suma' => -99.99,
         ]);
     }
+
+    public function test_it_stores_products_together_with_the_invoice(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = [
+            'denumire_furnizor' => 'Furnizor Produse SRL',
+            'numar_factura' => 'PRD-001',
+            'data_factura' => '2025-02-10',
+            'data_scadenta' => '2025-02-20',
+            'suma' => 999.99,
+            'moneda' => 'RON',
+            'cont_iban' => 'RO49AAAA1B31007593840000',
+            'departament_vehicul' => 'BT-01',
+            'observatii' => 'Observatie test',
+            'produse' => [
+                [
+                    'denumire' => 'Filtru ulei',
+                    'cod' => 'FU-01',
+                    'nr_bucati' => '2',
+                    'pret' => '35.50',
+                ],
+                [
+                    'denumire' => 'Ulei motor',
+                    'cod' => null,
+                    'nr_bucati' => '1',
+                    'pret' => '250',
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->post(route('facturi-furnizori.facturi.store'), $payload);
+
+        $response->assertRedirect(route('facturi-furnizori.facturi.index'));
+
+        $factura = FacturaFurnizor::query()
+            ->where('numar_factura', 'PRD-001')
+            ->with('piese')
+            ->firstOrFail();
+
+        $this->assertCount(2, $factura->piese);
+        $this->assertEquals('Filtru ulei', $factura->piese[0]->denumire);
+        $this->assertSame('35.50', $factura->piese[0]->pret);
+        $this->assertEquals('Ulei motor', $factura->piese[1]->denumire);
+        $this->assertSame('250.00', $factura->piese[1]->pret);
+    }
+
+    public function test_it_replaces_products_when_updating_an_invoice(): void
+    {
+        $user = User::factory()->create();
+        $factura = FacturaFurnizor::factory()->create([
+            'suma' => 150,
+            'moneda' => 'EUR',
+        ]);
+
+        $factura->piese()->create([
+            'denumire' => 'Produs vechi',
+            'cod' => 'OLD-1',
+            'nr_bucati' => 5,
+            'pret' => 75,
+        ]);
+
+        $payload = [
+            'denumire_furnizor' => $factura->denumire_furnizor,
+            'numar_factura' => $factura->numar_factura,
+            'data_factura' => $factura->data_factura->format('Y-m-d'),
+            'data_scadenta' => $factura->data_scadenta->format('Y-m-d'),
+            'suma' => $factura->suma,
+            'moneda' => $factura->moneda,
+            'cont_iban' => $factura->cont_iban ?? '',
+            'departament_vehicul' => $factura->departament_vehicul ?? '',
+            'observatii' => $factura->observatii ?? '',
+            'produse' => [
+                [
+                    'denumire' => 'Plăcuțe frână',
+                    'cod' => 'PF-02',
+                    'nr_bucati' => 4,
+                    'pret' => 120,
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)
+            ->put(route('facturi-furnizori.facturi.update', $factura), $payload);
+
+        $response->assertRedirect(route('facturi-furnizori.facturi.index'));
+
+        $factura->refresh()->load('piese');
+
+        $this->assertCount(1, $factura->piese);
+        $this->assertEquals('Plăcuțe frână', $factura->piese[0]->denumire);
+        $this->assertSame('120.00', $factura->piese[0]->pret);
+        $this->assertDatabaseMissing('gestiune_piese', [
+            'factura_id' => $factura->id,
+            'denumire' => 'Produs vechi',
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- strip pagination-only parameters when remembering supplier invoice filters so the list reloads correctly after returning
- add persistence, validation, and UI for managing multiple products per supplier invoice backed by the new `gestiune_piese` table
- display associated products on the invoice detail page and cover the workflow with feature tests

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef380a1c50832680e9d6b1a57dc984