### PR TITLE
Fix Throwable import warning

### DIFF
--- a/app/Http/Controllers/GestiunePieseController.php
+++ b/app/Http/Controllers/GestiunePieseController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Throwable;
 
 class GestiunePieseController extends Controller
 {
@@ -46,7 +45,7 @@ class GestiunePieseController extends Controller
             if ($hasTable) {
                 $columns = Schema::getColumnListing('gestiune_piese');
             }
-        } catch (Throwable $exception) {
+        } catch (\Throwable $exception) {
             $hasTable = false;
             $columns = [];
             Log::warning('Unable to inspect gestiune_piese structure', ['exception' => $exception]);
@@ -134,7 +133,7 @@ class GestiunePieseController extends Controller
                 }
 
                 $items = $query->simplePaginate(100)->withQueryString();
-            } catch (Throwable $exception) {
+            } catch (\Throwable $exception) {
                 $loadError = 'Nu am putut încărca datele din gestiune_piese.';
                 Log::error('Failed to load gestiune_piese data', ['exception' => $exception]);
             }


### PR DESCRIPTION
## Summary
- remove the ineffective import of `Throwable`
- update the catch blocks to reference the global `Throwable` interface explicitly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef4828ff448326b26c534aa06ee5de