### PR TITLE
Fix Throwable usage in gestiune blade view

### DIFF
--- a/app/Http/Controllers/GestiunePieseController.php
+++ b/app/Http/Controllers/GestiunePieseController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Throwable;
 
 class GestiunePieseController extends Controller
 {
@@ -46,7 +45,7 @@ class GestiunePieseController extends Controller
             if ($hasTable) {
                 $columns = Schema::getColumnListing('gestiune_piese');
             }
-        } catch (Throwable $exception) {
+        } catch (\Throwable $exception) {
             $hasTable = false;
             $columns = [];
             Log::warning('Unable to inspect gestiune_piese structure', ['exception' => $exception]);
@@ -134,7 +133,7 @@ class GestiunePieseController extends Controller
                 }
 
                 $items = $query->simplePaginate(100)->withQueryString();
-            } catch (Throwable $exception) {
+            } catch (\Throwable $exception) {
                 $loadError = 'Nu am putut încărca datele din gestiune_piese.';
                 Log::error('Failed to load gestiune_piese data', ['exception' => $exception]);
             }

--- a/resources/views/gestiunePiese/index.blade.php
+++ b/resources/views/gestiunePiese/index.blade.php
@@ -3,7 +3,6 @@
 @php
     use Carbon\Carbon;
     use Illuminate\Support\Str;
-    use Throwable;
 
     $currentSort = request('sort');
     $currentDirection = strtolower(request('direction', 'desc')) === 'asc' ? 'asc' : 'desc';
@@ -127,7 +126,7 @@
                                             if ($column === 'factura_data_factura' && $value) {
                                                 try {
                                                     $value = Carbon::parse($value)->format('d.m.Y');
-                                                } catch (Throwable $exception) {
+                                                } catch (\Throwable $exception) {
                                                     // Leave the raw value if parsing fails
                                                 }
                                             }


### PR DESCRIPTION
## Summary
- remove the ineffective import of `Throwable` from the gestiune blade view
- reference the global `Throwable` interface directly in the date formatting try/catch block

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ef4828ff448326b26c534aa06ee5de