### PR TITLE
Adjust gestiune piese filters and factura column

### DIFF
--- a/app/Http/Controllers/GestiunePieseController.php
+++ b/app/Http/Controllers/GestiunePieseController.php
@@ -2,36 +2,30 @@
 
 namespace App\Http\Controllers;
 
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Throwable;
 
 class GestiunePieseController extends Controller
 {
     public function index(Request $request)
     {
-        $search = trim((string) $request->query('search'));
-        $filters = collect($request->input('filters', []))
-            ->map(function ($value) {
-                if (is_string($value)) {
-                    return trim($value);
-                }
+        $denumireSearch = trim((string) $request->query('denumire'));
+        $codSearch = trim((string) $request->query('cod'));
+        $invoiceDateSearch = trim((string) $request->query('data_factura'));
+        $invoiceDateFilter = null;
+        $useExactInvoiceDate = false;
 
-                if (is_array($value)) {
-                    return array_filter(array_map(static fn ($item) => is_string($item) ? trim($item) : $item, $value), static fn ($item) => $item !== '' && $item !== null);
-                }
-
-                return $value;
-            })
-            ->filter(function ($value) {
-                if (is_array($value)) {
-                    return ! empty($value);
-                }
-
-                return $value !== '' && $value !== null;
-            });
+        if ($invoiceDateSearch !== '') {
+            try {
+                $invoiceDateFilter = Carbon::parse($invoiceDateSearch)->toDateString();
+                $useExactInvoiceDate = true;
+            } catch (\Throwable $exception) {
+                $invoiceDateFilter = $invoiceDateSearch;
+            }
+        }
 
         $columns = [];
         $hasTable = false;
@@ -46,7 +40,7 @@ class GestiunePieseController extends Controller
             if ($hasTable) {
                 $columns = Schema::getColumnListing('gestiune_piese');
             }
-        } catch (Throwable $exception) {
+        } catch (\Throwable $exception) {
             $hasTable = false;
             $columns = [];
             Log::warning('Unable to inspect gestiune_piese structure', ['exception' => $exception]);
@@ -77,42 +71,19 @@ class GestiunePieseController extends Controller
                     $query->addSelect('ff.data_factura as '.$invoiceDateAlias);
                 }
 
-                if ($search !== '') {
-                    $searchableColumns = collect($columns)
-                        ->reject(static fn ($column) => in_array($column, ['id'], true));
-
-                    if ($invoiceDateAlias) {
-                        $searchableColumns = $searchableColumns->push($invoiceDateAlias);
-                    }
-
-                    if ($searchableColumns->isNotEmpty()) {
-                        $query->where(function ($innerQuery) use ($searchableColumns, $search) {
-                            foreach ($searchableColumns as $column) {
-                                $innerQuery->orWhere($column === 'factura_data_factura' ? 'ff.data_factura' : "gp.$column", 'like', "%$search%");
-                            }
-                        });
-                    }
+                if ($denumireSearch !== '' && in_array('denumire', $columns, true)) {
+                    $query->where('gp.denumire', 'like', "%$denumireSearch%");
                 }
 
-                foreach ($filters as $column => $value) {
-                    if ($column === 'factura_data_factura' && $invoiceDateAlias) {
-                        if (is_array($value)) {
-                            $query->whereIn('ff.data_factura', $value);
-                        } else {
-                            $query->where('ff.data_factura', $value);
-                        }
+                if ($codSearch !== '' && in_array('cod', $columns, true)) {
+                    $query->where('gp.cod', 'like', "%$codSearch%");
+                }
 
-                        continue;
-                    }
-
-                    if (! in_array($column, $columns, true)) {
-                        continue;
-                    }
-
-                    if (is_array($value)) {
-                        $query->whereIn("gp.$column", $value);
+                if ($invoiceDateAlias && $invoiceDateFilter !== null) {
+                    if ($useExactInvoiceDate) {
+                        $query->whereDate('ff.data_factura', $invoiceDateFilter);
                     } else {
-                        $query->where("gp.$column", 'like', "%$value%");
+                        $query->where('ff.data_factura', 'like', "%$invoiceDateFilter%");
                     }
                 }
 
@@ -134,24 +105,29 @@ class GestiunePieseController extends Controller
                 }
 
                 $items = $query->simplePaginate(100)->withQueryString();
-            } catch (Throwable $exception) {
+            } catch (\Throwable $exception) {
                 $loadError = 'Nu am putut încărca datele din gestiune_piese.';
                 Log::error('Failed to load gestiune_piese data', ['exception' => $exception]);
             }
         }
 
-        $displayColumns = $columns;
+        $displayColumns = array_values(array_filter(
+            $columns,
+            static fn ($column) => ! in_array($column, ['id', 'factura_id', 'created_at', 'updated_at'], true)
+        ));
         if ($invoiceDateAlias && ! in_array($invoiceDateAlias, $displayColumns, true)) {
             $displayColumns[] = $invoiceDateAlias;
         }
 
         return view('gestiunePiese.index', [
-            'search' => $search,
-            'filters' => $filters->toArray(),
+            'denumire' => $denumireSearch,
+            'cod' => $codSearch,
+            'dataFactura' => $useExactInvoiceDate ? $invoiceDateFilter : $invoiceDateSearch,
             'columns' => $displayColumns,
             'items' => $items,
             'hasTable' => $hasTable,
             'loadError' => $loadError,
+            'invoiceColumn' => $invoiceJoinColumn,
         ]);
     }
 }

--- a/resources/views/gestiunePiese/index.blade.php
+++ b/resources/views/gestiunePiese/index.blade.php
@@ -3,10 +3,13 @@
 @php
     use Carbon\Carbon;
     use Illuminate\Support\Str;
-    use Throwable;
 
     $currentSort = request('sort');
     $currentDirection = strtolower(request('direction', 'desc')) === 'asc' ? 'asc' : 'desc';
+    $denumire = $denumire ?? '';
+    $cod = $cod ?? '';
+    $dataFactura = $dataFactura ?? '';
+    $invoiceColumn = $invoiceColumn ?? null;
 @endphp
 
 @section('content')
@@ -17,46 +20,35 @@
                     <i class="fa-solid fa-warehouse me-1"></i>Gestiune piese
                 </span>
             </div>
-            <div class="col-lg-9">
-                <form class="needs-validation" novalidate method="GET" action="{{ route('gestiune-piese.index') }}">
-                    <div class="row mb-2 custom-search-form justify-content-center">
-                        <div class="col-lg-8">
-                            <input type="text" class="form-control rounded-3" id="search" name="search"
-                                placeholder="Căutare rapidă" value="{{ $search }}">
+            <div class="col-lg-9 mb-2" id="formularGestiunePiese">
+                <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ route('gestiune-piese.index') }}">
+                    <div class="row gy-1 gx-4 mb-2 custom-search-form d-flex justify-content-center">
+                        <div class="col-lg-4 col-md-6">
+                            <div class="d-flex align-items-center gap-2">
+                                <i class="fa-solid fa-font text-muted" title="Caută după denumire"></i>
+                                <input type="text" class="form-control rounded-3 flex-grow-1" id="denumire" name="denumire"
+                                    placeholder="Denumire" value="{{ $denumire }}" autocomplete="off">
+                            </div>
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <div class="d-flex align-items-center gap-2">
+                                <i class="fa-solid fa-barcode text-muted" title="Caută după cod"></i>
+                                <input type="text" class="form-control rounded-3 flex-grow-1" id="cod" name="cod"
+                                    placeholder="Cod" value="{{ $cod }}" autocomplete="off">
+                            </div>
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <div class="d-flex align-items-center gap-2">
+                                <label for="data_factura" class="form-label small text-muted mb-0 flex-shrink-0 text-nowrap">
+                                    Data factură
+                                </label>
+                                <input type="date" class="form-control rounded-3" id="data_factura" name="data_factura"
+                                    value="{{ $dataFactura }}">
+                            </div>
                         </div>
                     </div>
 
-                    @if (!empty($columns))
-                        <div class="text-end">
-                            <button class="btn btn-link text-decoration-none" type="button" data-bs-toggle="collapse"
-                                data-bs-target="#advancedFilters" aria-expanded="{{ request()->has('filters') ? 'true' : 'false' }}"
-                                aria-controls="advancedFilters">
-                                <i class="fa-solid fa-sliders me-1"></i>Filtre avansate
-                            </button>
-                        </div>
-                        <div class="collapse {{ request()->has('filters') ? 'show' : '' }}" id="advancedFilters">
-                            <div class="row g-3 mt-1">
-                                @foreach ($columns as $column)
-                                    @php
-                                        $label = $column === 'factura_data_factura'
-                                            ? 'Data factură'
-                                            : Str::of($column)->replace('_', ' ')->title();
-                                        $rawFilterValue = $filters[$column] ?? '';
-                                        $filterValue = is_array($rawFilterValue) ? implode(', ', $rawFilterValue) : $rawFilterValue;
-                                    @endphp
-                                    <div class="col-md-4">
-                                        <label class="form-label small text-uppercase text-muted" for="filter_{{ $column }}">
-                                            {{ $label }}
-                                        </label>
-                                        <input type="text" class="form-control form-control-sm rounded-3"
-                                            id="filter_{{ $column }}" name="filters[{{ $column }}]" value="{{ $filterValue }}">
-                                    </div>
-                                @endforeach
-                            </div>
-                        </div>
-                    @endif
-
-                    <div class="row custom-search-form justify-content-center mt-3">
+                    <div class="row custom-search-form justify-content-center mt-2">
                         <button class="btn btn-sm btn-primary text-white col-md-4 me-3 border border-dark rounded-3"
                             type="submit">
                             <i class="fas fa-search text-white me-1"></i>Caută
@@ -104,7 +96,8 @@
                                         ]);
                                     @endphp
                                     <th class="culoare2 text-white">
-                                        <a class="text-white text-decoration-none" href="{{ route('gestiune-piese.index', $query) }}">
+                                        <a class="text-white text-decoration-none"
+                                            href="{{ route('gestiune-piese.index', $query) }}">
                                             {{ $label }}
                                             @if ($isSorted)
                                                 <i class="fa-solid fa-arrow-{{ $currentDirection === 'asc' ? 'up' : 'down' }} ms-1"></i>
@@ -112,6 +105,9 @@
                                         </a>
                                     </th>
                                 @endforeach
+                                @if ($invoiceColumn)
+                                    <th class="culoare2 text-white" style="min-width: 130px;">Factură</th>
+                                @endif
                             </tr>
                         </thead>
                         <tbody>
@@ -120,6 +116,9 @@
                                     <td>
                                         {{ ($items->currentPage() - 1) * $items->perPage() + $loop->index + 1 }}
                                     </td>
+                                    @php
+                                        $invoiceId = $invoiceColumn ? ($row->{$invoiceColumn} ?? null) : null;
+                                    @endphp
                                     @foreach ($columns as $column)
                                         @php
                                             $value = $row->{$column} ?? null;
@@ -127,7 +126,7 @@
                                             if ($column === 'factura_data_factura' && $value) {
                                                 try {
                                                     $value = Carbon::parse($value)->format('d.m.Y');
-                                                } catch (Throwable $exception) {
+                                                } catch (\Throwable $exception) {
                                                     // Leave the raw value if parsing fails
                                                 }
                                             }
@@ -136,10 +135,23 @@
                                             {{ $value !== null && $value !== '' ? $value : '—' }}
                                         </td>
                                     @endforeach
+                                    @if ($invoiceColumn)
+                                        <td>
+                                            @if ($invoiceId !== null && $invoiceId !== '')
+                                                <a class="btn btn-sm btn-outline-primary border-0 rounded-3"
+                                                    href="{{ route('facturi-furnizori.facturi.show', $invoiceId) }}">
+                                                    <i class="fa-solid fa-file-invoice me-1"></i>Deschide
+                                                </a>
+                                            @else
+                                                —
+                                            @endif
+                                        </td>
+                                    @endif
                                 </tr>
                             @empty
                                 <tr>
-                                    <td colspan="{{ count($columns) + 1 }}" class="text-center text-muted py-4">
+                                    <td colspan="{{ count($columns) + 1 + ($invoiceColumn ? 1 : 0) }}"
+                                        class="text-center text-muted py-4">
                                         Nu există înregistrări care să corespundă filtrelor alese.
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary
- replace the advanced filters with dedicated fields for denumire, cod, and data factură searches styled like the facturi page, including a date picker for the invoice date
- update the controller logic to apply the new filters, normalize invoice date input, and hide the id/factura_id/timestamp columns from the gestiune piese table output
- add a factura action column so each gestiune piese row links directly to its supplier invoice and render it after the data columns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ef4828ff448326b26c534aa06ee5de