### PR TITLE
feat: add service masini management

### DIFF
--- a/app/Http/Controllers/ServiceMasiniController.php
+++ b/app/Http/Controllers/ServiceMasiniController.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreMasinaRequest;
+use App\Http\Requests\StoreMasinaServiceEntryRequest;
+use App\Models\FacturiFurnizori\GestiunePiesa;
+use App\Models\Masina;
+use App\Models\MasinaServiceEntry;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+class ServiceMasiniController extends Controller
+{
+    public function index(Request $request)
+    {
+        $filters = [
+            'masina_id' => $request->query('masina_id'),
+            'numar_inmatriculare' => trim((string) $request->query('numar_inmatriculare', '')),
+            'data_start' => $request->query('data_start'),
+            'data_end' => $request->query('data_end'),
+            'piesa' => trim((string) $request->query('piesa', '')),
+            'cod' => trim((string) $request->query('cod', '')),
+        ];
+
+        $masini = $this->getMasiniList($filters['numar_inmatriculare']);
+        $selectedMasina = $this->resolveSelectedMasina($masini, $filters['masina_id']);
+
+        $entries = $selectedMasina
+            ? $this->getServiceEntries($selectedMasina->id, $filters)
+            : $this->emptyPaginator();
+
+        return view('serviceMasini.index', [
+            'masini' => $masini,
+            'selectedMasina' => $selectedMasina,
+            'entries' => $entries,
+            'filters' => $filters,
+            'availablePieces' => $this->getAvailablePieces(),
+        ]);
+    }
+
+    public function storeMasina(StoreMasinaRequest $request): RedirectResponse
+    {
+        $masina = Masina::query()->create($request->validated());
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id])
+            ->with('status', 'Mașina a fost adăugată cu succes.');
+    }
+
+    public function storeEntry(StoreMasinaServiceEntryRequest $request, Masina $masina): RedirectResponse
+    {
+        $filters = $this->extractFilterState($request);
+
+        try {
+            DB::transaction(function () use ($request, $masina): void {
+                $data = $request->validated();
+                $user = $request->user();
+
+                $entry = new MasinaServiceEntry();
+                $entry->masina_id = $masina->id;
+                $entry->tip = $data['tip'];
+                $entry->data_montaj = $data['data_montaj'];
+                $entry->nume_mecanic = $data['nume_mecanic'];
+                $entry->observatii = $data['observatii'] ?? null;
+                $entry->nume_utilizator = $user?->name;
+                $entry->user_id = $user?->id;
+
+                if ($data['tip'] === 'piesa') {
+                    $piesa = $request->piece() ?: GestiunePiesa::query()->find($data['gestiune_piesa_id']);
+
+                    if (! $piesa) {
+                        throw new \RuntimeException('Piesa selectată nu a fost găsită.');
+                    }
+
+                    $cantitate = (float) $data['cantitate'];
+
+                    $entry->gestiune_piesa_id = $piesa->id;
+                    $entry->denumire_piesa = $piesa->denumire;
+                    $entry->cod_piesa = $piesa->cod;
+                    $entry->cantitate = $cantitate;
+
+                    $updated = GestiunePiesa::query()
+                        ->whereKey($piesa->id)
+                        ->where('nr_bucati', '>=', $cantitate)
+                        ->decrement('nr_bucati', $cantitate);
+
+                    if ($updated === 0) {
+                        throw new \RuntimeException('Stocul piesei s-a modificat între timp.');
+                    }
+                } else {
+                    $entry->denumire_interventie = $data['denumire_interventie'];
+                }
+
+                $entry->save();
+            });
+        } catch (Throwable $exception) {
+            Log::error('Unable to save service entry', [
+                'exception' => $exception,
+                'masina_id' => $masina->id,
+            ]);
+
+            return redirect()
+                ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+                ->withErrors(['general' => 'Nu am putut salva intervenția. Încearcă din nou.']);
+        }
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+            ->with('status', 'Intervenția a fost salvată.');
+    }
+
+    public function export(Request $request)
+    {
+        $filters = [
+            'masina_id' => $request->query('masina_id'),
+            'numar_inmatriculare' => trim((string) $request->query('numar_inmatriculare', '')),
+            'data_start' => $request->query('data_start'),
+            'data_end' => $request->query('data_end'),
+            'piesa' => trim((string) $request->query('piesa', '')),
+            'cod' => trim((string) $request->query('cod', '')),
+        ];
+
+        $masini = $this->getMasiniList($filters['numar_inmatriculare']);
+        $selectedMasina = $this->resolveSelectedMasina($masini, $filters['masina_id']);
+
+        if (! $selectedMasina) {
+            abort(404, 'Mașina selectată nu există.');
+        }
+
+        $entries = $this->getServiceEntriesCollection($selectedMasina->id, $filters);
+
+        $pdf = Pdf::loadView('serviceMasini.export', [
+            'masina' => $selectedMasina,
+            'entries' => $entries,
+            'filters' => $filters,
+        ]);
+
+        $filename = 'service-masini-' . Str::slug($selectedMasina->numar_inmatriculare ?: $selectedMasina->denumire) . '.pdf';
+
+        return $pdf->download($filename);
+    }
+
+    protected function getMasiniList(string $numarInmatriculare = ''): EloquentCollection
+    {
+        $query = Masina::query()->orderBy('denumire');
+
+        if ($numarInmatriculare !== '') {
+            $query->where(function ($builder) use ($numarInmatriculare): void {
+                $builder->where('numar_inmatriculare', 'like', '%' . $numarInmatriculare . '%')
+                    ->orWhere('denumire', 'like', '%' . $numarInmatriculare . '%');
+            });
+        }
+
+        return $query->get();
+    }
+
+    protected function resolveSelectedMasina(EloquentCollection $masini, $masinaId): ?Masina
+    {
+        if ($masini->isEmpty()) {
+            return null;
+        }
+
+        if ($masinaId) {
+            $selected = $masini->firstWhere('id', (int) $masinaId);
+
+            if ($selected) {
+                return $selected;
+            }
+        }
+
+        return $masini->first();
+    }
+
+    protected function getServiceEntries(int $masinaId, array $filters): LengthAwarePaginator
+    {
+        return $this->baseEntriesQuery($masinaId, $filters)
+            ->with(['user'])
+            ->orderByDesc('data_montaj')
+            ->orderByDesc('id')
+            ->paginate(25)
+            ->withQueryString();
+    }
+
+    protected function getServiceEntriesCollection(int $masinaId, array $filters): Collection
+    {
+        return $this->baseEntriesQuery($masinaId, $filters)
+            ->with(['user'])
+            ->orderBy('data_montaj')
+            ->orderBy('id')
+            ->get();
+    }
+
+    protected function baseEntriesQuery(int $masinaId, array $filters)
+    {
+        $query = MasinaServiceEntry::query()->where('masina_id', $masinaId);
+
+        if ($filters['data_start']) {
+            try {
+                $query->whereDate('data_montaj', '>=', $filters['data_start']);
+            } catch (Throwable $exception) {
+                Log::warning('Invalid start date filter for service entries', ['exception' => $exception]);
+            }
+        }
+
+        if ($filters['data_end']) {
+            try {
+                $query->whereDate('data_montaj', '<=', $filters['data_end']);
+            } catch (Throwable $exception) {
+                Log::warning('Invalid end date filter for service entries', ['exception' => $exception]);
+            }
+        }
+
+        if ($filters['piesa'] !== '') {
+            $query->where(function ($builder) use ($filters): void {
+                $builder->where('denumire_piesa', 'like', '%' . $filters['piesa'] . '%')
+                    ->orWhere('denumire_interventie', 'like', '%' . $filters['piesa'] . '%');
+            });
+        }
+
+        if ($filters['cod'] !== '') {
+            $query->where('cod_piesa', 'like', '%' . $filters['cod'] . '%');
+        }
+
+        return $query;
+    }
+
+    protected function getAvailablePieces(): Collection
+    {
+        try {
+            return GestiunePiesa::query()
+                ->where('nr_bucati', '>', 0)
+                ->orderBy('denumire')
+                ->get(['id', 'denumire', 'cod', 'nr_bucati']);
+        } catch (Throwable $exception) {
+            Log::warning('Unable to load available pieces', ['exception' => $exception]);
+
+            return collect();
+        }
+    }
+
+    protected function extractFilterState(Request $request): array
+    {
+        $keys = ['numar_inmatriculare', 'data_start', 'data_end', 'piesa', 'cod'];
+
+        $data = [];
+        foreach ($keys as $key) {
+            $value = $request->input($key);
+            if ($value !== null && $value !== '') {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+
+    protected function emptyPaginator(): LengthAwarePaginator
+    {
+        return new LengthAwarePaginator(
+            [],
+            0,
+            25,
+            1,
+            [
+                'path' => LengthAwarePaginator::resolveCurrentPath(),
+                'query' => request()->query(),
+            ]
+        );
+    }
+}

--- a/app/Http/Requests/StoreMasinaRequest.php
+++ b/app/Http/Requests/StoreMasinaRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMasinaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'denumire' => ['required', 'string', 'max:255'],
+            'numar_inmatriculare' => ['required', 'string', 'max:255', 'unique:masini,numar_inmatriculare'],
+            'serie_sasiu' => ['nullable', 'string', 'max:255'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/StoreMasinaServiceEntryRequest.php
+++ b/app/Http/Requests/StoreMasinaServiceEntryRequest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\FacturiFurnizori\GestiunePiesa;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class StoreMasinaServiceEntryRequest extends FormRequest
+{
+    protected ?GestiunePiesa $piesa = null;
+
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tip' => ['required', 'in:piesa,manual'],
+            'gestiune_piesa_id' => ['nullable', 'integer', 'exists:gestiune_piese,id'],
+            'cantitate' => ['nullable', 'numeric', 'min:0.01'],
+            'denumire_interventie' => ['nullable', 'string', 'max:255'],
+            'data_montaj' => ['required', 'date'],
+            'nume_mecanic' => ['required', 'string', 'max:255'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $tip = (string) $this->input('tip', '');
+
+            if ($tip === 'piesa') {
+                if (! $this->filled('gestiune_piesa_id')) {
+                    $validator->errors()->add('gestiune_piesa_id', 'Selectează o piesă din gestiune.');
+
+                    return;
+                }
+
+                $cantitate = (float) $this->input('cantitate', 0);
+                if ($cantitate <= 0) {
+                    $validator->errors()->add('cantitate', 'Cantitatea trebuie să fie mai mare decât zero.');
+                }
+
+                $this->piesa = GestiunePiesa::query()->find($this->input('gestiune_piesa_id'));
+
+                if (! $this->piesa) {
+                    $validator->errors()->add('gestiune_piesa_id', 'Piesa selectată nu există.');
+                } elseif ((float) $this->piesa->nr_bucati < $cantitate) {
+                    $validator->errors()->add('cantitate', 'Cantitatea depășește stocul disponibil.');
+                }
+            } elseif ($tip === 'manual') {
+                if (! $this->filled('denumire_interventie')) {
+                    $validator->errors()->add('denumire_interventie', 'Completează denumirea intervenției.');
+                }
+            }
+        });
+    }
+
+    public function piece(): ?GestiunePiesa
+    {
+        return $this->piesa;
+    }
+}

--- a/app/Models/Masina.php
+++ b/app/Models/Masina.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Masina extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'denumire',
+        'numar_inmatriculare',
+        'serie_sasiu',
+        'observatii',
+    ];
+
+    public function serviceEntries(): HasMany
+    {
+        return $this->hasMany(MasinaServiceEntry::class);
+    }
+}

--- a/app/Models/MasinaServiceEntry.php
+++ b/app/Models/MasinaServiceEntry.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\FacturiFurnizori\GestiunePiesa;
+use App\Models\User;
+
+class MasinaServiceEntry extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'masina_id',
+        'gestiune_piesa_id',
+        'user_id',
+        'tip',
+        'denumire_interventie',
+        'cod_piesa',
+        'denumire_piesa',
+        'cantitate',
+        'data_montaj',
+        'nume_mecanic',
+        'nume_utilizator',
+        'observatii',
+    ];
+
+    protected $casts = [
+        'data_montaj' => 'date',
+        'cantitate' => 'decimal:2',
+    ];
+
+    public function masina(): BelongsTo
+    {
+        return $this->belongsTo(Masina::class);
+    }
+
+    public function piesa(): BelongsTo
+    {
+        return $this->belongsTo(GestiunePiesa::class, 'gestiune_piesa_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/FacturiFurnizori/GestiunePiesaFactory.php
+++ b/database/factories/FacturiFurnizori/GestiunePiesaFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories\FacturiFurnizori;
+
+use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Models\FacturiFurnizori\GestiunePiesa;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<GestiunePiesa>
+ */
+class GestiunePiesaFactory extends Factory
+{
+    protected $model = GestiunePiesa::class;
+
+    public function definition(): array
+    {
+        return [
+            'factura_id' => FacturaFurnizor::factory(),
+            'denumire' => $this->faker->words(3, true),
+            'cod' => strtoupper($this->faker->bothify('PIE###')),
+            'nr_bucati' => $this->faker->randomFloat(2, 1, 20),
+            'pret' => $this->faker->randomFloat(2, 10, 500),
+        ];
+    }
+}

--- a/database/factories/MasinaFactory.php
+++ b/database/factories/MasinaFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Masina;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Masina>
+ */
+class MasinaFactory extends Factory
+{
+    protected $model = Masina::class;
+
+    public function definition(): array
+    {
+        return [
+            'denumire' => $this->faker->company . ' ' . $this->faker->word(),
+            'numar_inmatriculare' => strtoupper($this->faker->bothify('??##???')),
+            'serie_sasiu' => strtoupper($this->faker->bothify('###########')),
+            'observatii' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/MasinaServiceEntryFactory.php
+++ b/database/factories/MasinaServiceEntryFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Masina;
+use App\Models\MasinaServiceEntry;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\MasinaServiceEntry>
+ */
+class MasinaServiceEntryFactory extends Factory
+{
+    protected $model = MasinaServiceEntry::class;
+
+    public function definition(): array
+    {
+        $tip = $this->faker->randomElement(['piesa', 'manual']);
+
+        return [
+            'masina_id' => Masina::factory(),
+            'tip' => $tip,
+            'data_montaj' => $this->faker->date(),
+            'nume_mecanic' => $this->faker->name(),
+            'nume_utilizator' => $this->faker->name(),
+            'observatii' => $this->faker->sentence(),
+            'denumire_piesa' => $tip === 'piesa' ? $this->faker->words(3, true) : null,
+            'cod_piesa' => $tip === 'piesa' ? strtoupper($this->faker->bothify('PIE###')) : null,
+            'cantitate' => $tip === 'piesa' ? $this->faker->randomFloat(2, 1, 5) : null,
+            'denumire_interventie' => $tip === 'manual' ? $this->faker->sentence(3) : null,
+        ];
+    }
+}

--- a/database/migrations/2025_03_17_000000_create_masini_table.php
+++ b/database/migrations/2025_03_17_000000_create_masini_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('masini', function (Blueprint $table) {
+            $table->id();
+            $table->string('denumire');
+            $table->string('numar_inmatriculare')->unique();
+            $table->string('serie_sasiu')->nullable();
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('masini');
+    }
+};

--- a/database/migrations/2025_03_17_010000_create_masina_service_entries_table.php
+++ b/database/migrations/2025_03_17_010000_create_masina_service_entries_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('masina_service_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('masina_id')->constrained('masini')->cascadeOnDelete();
+            $table->foreignId('gestiune_piesa_id')->nullable()->constrained('gestiune_piese')->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('tip');
+            $table->string('denumire_interventie')->nullable();
+            $table->string('cod_piesa')->nullable();
+            $table->string('denumire_piesa')->nullable();
+            $table->decimal('cantitate', 10, 2)->nullable();
+            $table->date('data_montaj')->nullable();
+            $table->string('nume_mecanic')->nullable();
+            $table->string('nume_utilizator')->nullable();
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+
+            $table->index(['tip', 'data_montaj']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('masina_service_entries');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -259,6 +259,11 @@
                                         <i class="fa-solid fa-boxes-stacked me-1"></i>Gestiune piese
                                     </a>
                                 </li>
+                                <li>
+                                    <a class="dropdown-item" href="{{ route('service-masini.index') }}">
+                                        <i class="fa-solid fa-screwdriver-wrench me-1"></i>Service mașini
+                                    </a>
+                                </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     <a class="dropdown-item" href="{{ route('mesaje-trimise-sms.index') }}">

--- a/resources/views/serviceMasini/export.blade.php
+++ b/resources/views/serviceMasini/export.blade.php
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ro">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Service mașini - {{ $masina->denumire }}</title>
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            font-size: 12px;
+            color: #1a1a1a;
+        }
+
+        h1 {
+            font-size: 20px;
+            margin-bottom: 10px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 15px;
+        }
+
+        th,
+        td {
+            border: 1px solid #ccc;
+            padding: 6px 8px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f0f0f0;
+        }
+
+        .meta {
+            margin-bottom: 15px;
+        }
+
+        .meta div {
+            margin-bottom: 4px;
+        }
+
+        .small {
+            font-size: 11px;
+            color: #666;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Service mașini</h1>
+
+    <div class="meta">
+        <div><strong>Mașină:</strong> {{ $masina->denumire }} ({{ $masina->numar_inmatriculare }})</div>
+        @if ($masina->serie_sasiu)
+            <div><strong>Serie șasiu:</strong> {{ $masina->serie_sasiu }}</div>
+        @endif
+        @if ($filters['data_start'] ?? null)
+            <div><strong>De la:</strong> {{ \Carbon\Carbon::parse($filters['data_start'])->format('d.m.Y') }}</div>
+        @endif
+        @if ($filters['data_end'] ?? null)
+            <div><strong>Până la:</strong> {{ \Carbon\Carbon::parse($filters['data_end'])->format('d.m.Y') }}</div>
+        @endif
+        @if (($filters['piesa'] ?? '') !== '')
+            <div><strong>Denumire piesă:</strong> {{ $filters['piesa'] }}</div>
+        @endif
+        @if (($filters['cod'] ?? '') !== '')
+            <div><strong>Cod piesă:</strong> {{ $filters['cod'] }}</div>
+        @endif
+        <div class="small">Generat la {{ now()->format('d.m.Y H:i') }}</div>
+    </div>
+
+    <table>
+        <thead>
+            <tr>
+                <th style="width: 80px;">Data</th>
+                <th style="width: 80px;">Tip</th>
+                <th>Denumire</th>
+                <th style="width: 100px;">Cod</th>
+                <th style="width: 80px;">Cantitate</th>
+                <th style="width: 130px;">Mecanic</th>
+                <th style="width: 130px;">Utilizator</th>
+                <th>Observații</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($entries as $entry)
+                <tr>
+                    <td>{{ optional($entry->data_montaj)->format('d.m.Y') ?? '—' }}</td>
+                    <td>{{ $entry->tip === 'piesa' ? 'Piesă' : 'Manual' }}</td>
+                    <td>
+                        @if ($entry->tip === 'piesa')
+                            {{ $entry->denumire_piesa ?? '—' }}
+                        @else
+                            {{ $entry->denumire_interventie ?? '—' }}
+                        @endif
+                    </td>
+                    <td>{{ $entry->tip === 'piesa' ? ($entry->cod_piesa ?? '—') : '—' }}</td>
+                    <td>
+                        @if ($entry->tip === 'piesa')
+                            {{ $entry->cantitate !== null ? number_format((float) $entry->cantitate, 2) : '—' }}
+                        @else
+                            —
+                        @endif
+                    </td>
+                    <td>{{ $entry->nume_mecanic ?? '—' }}</td>
+                    <td>{{ $entry->nume_utilizator ?? optional($entry->user)->name ?? '—' }}</td>
+                    <td>{{ $entry->observatii ?? '—' }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="8" style="text-align: center;">Nu există intervenții pentru filtrul selectat.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/resources/views/serviceMasini/index.blade.php
+++ b/resources/views/serviceMasini/index.blade.php
@@ -1,0 +1,380 @@
+@extends('layouts.app')
+
+@php
+    $filters = $filters ?? [];
+    $selectedMasinaId = optional($selectedMasina)->id;
+    $queryParams = collect($filters)
+        ->reject(fn ($value) => $value === null || $value === '')
+        ->toArray();
+@endphp
+
+@section('content')
+    <div class="mx-3 px-3 card mx-auto" style="border-radius: 40px 40px 40px 40px;">
+        <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+            <div class="col-lg-3">
+                <span class="badge culoare1 fs-5">
+                    <i class="fa-solid fa-screwdriver-wrench me-1"></i>Service mașini
+                </span>
+            </div>
+            <div class="col-lg-9 mb-2">
+                <form class="needs-validation" novalidate method="GET" action="{{ route('service-masini.index') }}">
+                    <div class="row gy-2 gx-3 align-items-end">
+                        <div class="col-lg-4 col-md-6">
+                            <label for="numar_inmatriculare" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-car me-1"></i>Nr. înmatriculare / Denumire mașină
+                            </label>
+                            <input type="text" class="form-control rounded-3" id="numar_inmatriculare"
+                                name="numar_inmatriculare" placeholder="Ex: B00ABC"
+                                value="{{ $filters['numar_inmatriculare'] ?? '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="piesa" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-puzzle-piece me-1"></i>Denumire piesă / intervenție
+                            </label>
+                            <input type="text" class="form-control rounded-3" id="piesa" name="piesa"
+                                placeholder="Ex: Filtru ulei"
+                                value="{{ $filters['piesa'] ?? '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="cod" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-barcode me-1"></i>Cod piesă
+                            </label>
+                            <input type="text" class="form-control rounded-3" id="cod" name="cod"
+                                placeholder="Cod piesă" value="{{ $filters['cod'] ?? '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="data_start" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-calendar-day me-1"></i>De la data
+                            </label>
+                            <input type="date" class="form-control rounded-3" id="data_start" name="data_start"
+                                value="{{ $filters['data_start'] ?? '' }}">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="data_end" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-calendar-check me-1"></i>Până la data
+                            </label>
+                            <input type="date" class="form-control rounded-3" id="data_end" name="data_end"
+                                value="{{ $filters['data_end'] ?? '' }}">
+                        </div>
+                        <div class="col-lg-4 col-md-6 d-flex gap-2">
+                            <button class="btn btn-sm btn-primary text-white flex-grow-1 border border-dark rounded-3"
+                                type="submit">
+                                <i class="fas fa-search text-white me-1"></i>Caută
+                            </button>
+                            <a class="btn btn-sm btn-secondary text-white flex-grow-1 border border-dark rounded-3"
+                                href="{{ route('service-masini.index') }}">
+                                <i class="far fa-trash-alt text-white me-1"></i>Resetează
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="card-body">
+            @include('errors')
+
+            @if (session('status'))
+                <div class="alert alert-success alert-dismissible fade show" role="alert">
+                    {{ session('status') }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Închide"></button>
+                </div>
+            @endif
+
+            @if ($errors->has('general'))
+                <div class="alert alert-danger" role="alert">
+                    {{ $errors->first('general') }}
+                </div>
+            @endif
+
+            <div class="row g-4">
+                <div class="col-lg-4">
+                    <div class="card h-100 shadow-sm border-0">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold"><i class="fa-solid fa-car-side me-1"></i>Mașini</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="list-group mb-4" style="max-height: 320px; overflow-y: auto;">
+                                @forelse ($masini as $masina)
+                                    @php
+                                        $masinaQuery = $queryParams;
+                                        $masinaQuery['masina_id'] = $masina->id;
+                                    @endphp
+                                    <a href="{{ route('service-masini.index', $masinaQuery) }}"
+                                        class="list-group-item list-group-item-action rounded-3 mb-2 {{ $selectedMasinaId === $masina->id ? 'active text-white' : '' }}">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div>
+                                                <div class="fw-semibold">{{ $masina->denumire }}</div>
+                                                <small class="text-muted {{ $selectedMasinaId === $masina->id ? 'text-white-50' : '' }}">
+                                                    {{ $masina->numar_inmatriculare }}
+                                                </small>
+                                            </div>
+                                            <i class="fa-solid fa-chevron-right small"></i>
+                                        </div>
+                                    </a>
+                                @empty
+                                    <div class="text-center text-muted py-4">
+                                        Nu există mașini adăugate momentan.
+                                    </div>
+                                @endforelse
+                            </div>
+
+                            <h6 class="fw-semibold mb-3"><i class="fa-solid fa-plus-circle me-1"></i>Adaugă mașină</h6>
+                            <form method="POST" action="{{ route('service-masini.store-masina') }}" class="row g-2">
+                                @csrf
+                                <div class="col-12">
+                                    <label for="denumire" class="form-label small text-muted mb-1">Denumire mașină</label>
+                                    <input type="text" name="denumire" id="denumire" class="form-control rounded-3"
+                                        value="{{ old('denumire') }}" required>
+                                    @error('denumire')
+                                        <div class="text-danger small mt-1">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-12">
+                                    <label for="numar_inmatriculare_form" class="form-label small text-muted mb-1">Nr.
+                                        înmatriculare</label>
+                                    <input type="text" name="numar_inmatriculare" id="numar_inmatriculare_form"
+                                        class="form-control rounded-3" value="{{ old('numar_inmatriculare') }}" required>
+                                    @error('numar_inmatriculare')
+                                        <div class="text-danger small mt-1">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-12">
+                                    <label for="serie_sasiu" class="form-label small text-muted mb-1">Serie șasiu</label>
+                                    <input type="text" name="serie_sasiu" id="serie_sasiu" class="form-control rounded-3"
+                                        value="{{ old('serie_sasiu') }}">
+                                    @error('serie_sasiu')
+                                        <div class="text-danger small mt-1">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-12">
+                                    <label for="observatii" class="form-label small text-muted mb-1">Observații</label>
+                                    <textarea name="observatii" id="observatii" rows="2" class="form-control rounded-3">{{ old('observatii') }}</textarea>
+                                    @error('observatii')
+                                        <div class="text-danger small mt-1">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-12 d-grid">
+                                    <button type="submit" class="btn btn-sm btn-success rounded-3">
+                                        <i class="fa-solid fa-save me-1"></i>Salvează mașina
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-8">
+                    @if ($selectedMasina)
+                        <div class="card shadow-sm border-0 mb-4">
+                            <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+                                <div>
+                                    <h5 class="mb-0">{{ $selectedMasina->denumire }}</h5>
+                                    <small class="text-muted">Nr. înmatriculare: {{ $selectedMasina->numar_inmatriculare }}</small>
+                                </div>
+                                <a class="btn btn-outline-primary btn-sm rounded-3"
+                                    href="{{ route('service-masini.export', $queryParams + ['masina_id' => $selectedMasina->id]) }}">
+                                    <i class="fa-solid fa-file-pdf me-1"></i>Descarcă PDF
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                <form method="POST"
+                                    action="{{ route('service-masini.entries.store', $selectedMasina) }}"
+                                    class="row g-3" id="service-entry-form">
+                                    @csrf
+                                    @foreach ($filters as $key => $value)
+                                        @if ($value !== null && $value !== '')
+                                            <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                        @endif
+                                    @endforeach
+
+                                    <div class="col-12">
+                                        <label class="form-label small text-muted mb-1">Tip intervenție</label>
+                                        <div class="d-flex gap-3">
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="tip" id="tip_piesa"
+                                                    value="piesa" {{ old('tip', 'piesa') === 'piesa' ? 'checked' : '' }}>
+                                                <label class="form-check-label" for="tip_piesa">
+                                                    Alocare piesă din gestiune
+                                                </label>
+                                            </div>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="tip" id="tip_manual"
+                                                    value="manual" {{ old('tip') === 'manual' ? 'checked' : '' }}>
+                                                <label class="form-check-label" for="tip_manual">
+                                                    Intervenție manuală
+                                                </label>
+                                            </div>
+                                        </div>
+                                        @error('tip')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6" data-entry="piesa">
+                                        <label for="gestiune_piesa_id" class="form-label small text-muted mb-1">Piesă</label>
+                                        <select name="gestiune_piesa_id" id="gestiune_piesa_id"
+                                            class="form-select rounded-3">
+                                            <option value="">Selectează piesa</option>
+                                            @foreach ($availablePieces as $piesa)
+                                                <option value="{{ $piesa->id }}"
+                                                    @selected((int) old('gestiune_piesa_id') === $piesa->id)>
+                                                    {{ $piesa->denumire }} ({{ $piesa->cod }}) - {{ number_format((float) $piesa->nr_bucati, 2) }} buc
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                        @error('gestiune_piesa_id')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-3" data-entry="piesa">
+                                        <label for="cantitate" class="form-label small text-muted mb-1">Cantitate</label>
+                                        <input type="number" step="0.01" min="0" class="form-control rounded-3"
+                                            id="cantitate" name="cantitate" value="{{ old('cantitate', '1') }}">
+                                        @error('cantitate')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6" data-entry="manual">
+                                        <label for="denumire_interventie" class="form-label small text-muted mb-1">Denumire
+                                            intervenție</label>
+                                        <input type="text" class="form-control rounded-3" id="denumire_interventie"
+                                            name="denumire_interventie" value="{{ old('denumire_interventie') }}">
+                                        @error('denumire_interventie')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6">
+                                        <label for="data_montaj" class="form-label small text-muted mb-1">Data intervenției</label>
+                                        <input type="date" class="form-control rounded-3" id="data_montaj" name="data_montaj"
+                                            value="{{ old('data_montaj', now()->toDateString()) }}" required>
+                                        @error('data_montaj')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6">
+                                        <label for="nume_mecanic" class="form-label small text-muted mb-1">Nume mecanic</label>
+                                        <input type="text" class="form-control rounded-3" id="nume_mecanic" name="nume_mecanic"
+                                            value="{{ old('nume_mecanic') }}" required>
+                                        @error('nume_mecanic')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12">
+                                        <label for="observatii_interventie" class="form-label small text-muted mb-1">Observații</label>
+                                        <textarea name="observatii" id="observatii_interventie" rows="3" class="form-control rounded-3">{{ old('observatii') }}</textarea>
+                                        @error('observatii')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12 d-flex justify-content-end">
+                                        <button type="submit" class="btn btn-primary rounded-3">
+                                            <i class="fa-solid fa-paper-plane me-1"></i>Salvează intervenția
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+
+                        <div class="card shadow-sm border-0">
+                            <div class="card-header">
+                                <h6 class="mb-0"><i class="fa-solid fa-clipboard-list me-1"></i>Istoric intervenții</h6>
+                            </div>
+                            <div class="table-responsive">
+                                <table class="table table-striped table-hover mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th style="min-width: 110px;">Data</th>
+                                            <th style="min-width: 120px;">Tip</th>
+                                            <th style="min-width: 180px;">Denumire</th>
+                                            <th style="min-width: 120px;">Cod</th>
+                                            <th style="min-width: 90px;">Cantitate</th>
+                                            <th style="min-width: 150px;">Mecanic</th>
+                                            <th style="min-width: 150px;">Utilizator</th>
+                                            <th>Observații</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @forelse ($entries as $entry)
+                                            <tr>
+                                                <td>{{ optional($entry->data_montaj)->format('d.m.Y') ?? '—' }}</td>
+                                                <td>
+                                                    @if ($entry->tip === 'piesa')
+                                                        <span class="badge bg-primary">Piesă</span>
+                                                    @else
+                                                        <span class="badge bg-secondary">Manual</span>
+                                                    @endif
+                                                </td>
+                                                <td>
+                                                    @if ($entry->tip === 'piesa')
+                                                        {{ $entry->denumire_piesa ?? '—' }}
+                                                    @else
+                                                        {{ $entry->denumire_interventie ?? '—' }}
+                                                    @endif
+                                                </td>
+                                                <td>{{ $entry->tip === 'piesa' ? ($entry->cod_piesa ?? '—') : '—' }}</td>
+                                                <td>
+                                                    @if ($entry->tip === 'piesa')
+                                                        {{ $entry->cantitate !== null ? number_format((float) $entry->cantitate, 2) : '—' }}
+                                                    @else
+                                                        —
+                                                    @endif
+                                                </td>
+                                                <td>{{ $entry->nume_mecanic ?? '—' }}</td>
+                                                <td>{{ $entry->nume_utilizator ?? optional($entry->user)->name ?? '—' }}</td>
+                                                <td class="text-wrap" style="max-width: 220px;">{{ $entry->observatii ?? '—' }}</td>
+                                            </tr>
+                                        @empty
+                                            <tr>
+                                                <td colspan="8" class="text-center text-muted py-4">
+                                                    Nu există intervenții pentru această mașină.
+                                                </td>
+                                            </tr>
+                                        @endforelse
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="card-footer">
+                                {{ $entries->links() }}
+                            </div>
+                        </div>
+                    @else
+                        <div class="alert alert-info" role="alert">
+                            Adaugă o mașină pentru a începe să înregistrezi intervenții.
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('page-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            function toggleEntryFields() {
+                const selectedType = document.querySelector('input[name="tip"]:checked')?.value || 'piesa';
+
+                document.querySelectorAll('#service-entry-form [data-entry="piesa"]').forEach(function (element) {
+                    element.classList.toggle('d-none', selectedType !== 'piesa');
+                });
+
+                document.querySelectorAll('#service-entry-form [data-entry="manual"]').forEach(function (element) {
+                    element.classList.toggle('d-none', selectedType !== 'manual');
+                });
+            }
+
+            document.querySelectorAll('input[name="tip"]').forEach(function (radio) {
+                radio.addEventListener('change', toggleEntryFields);
+            });
+
+            toggleEntryFields();
+        });
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\OfertaCursaController;
 use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorController;
 use App\Http\Controllers\FacturiFurnizori\PlataCalupController;
 use App\Http\Controllers\GestiunePieseController;
+use App\Http\Controllers\ServiceMasiniController;
 use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\SeederCenterController;
@@ -168,6 +169,15 @@ Route::group(['middleware' => 'auth'], function () {
 
     Route::get('/gestiune-piese', [GestiunePieseController::class, 'index'])
         ->name('gestiune-piese.index');
+
+    Route::get('/service-masini', [ServiceMasiniController::class, 'index'])
+        ->name('service-masini.index');
+    Route::post('/service-masini', [ServiceMasiniController::class, 'storeMasina'])
+        ->name('service-masini.store-masina');
+    Route::post('/service-masini/{masina}/entries', [ServiceMasiniController::class, 'storeEntry'])
+        ->name('service-masini.entries.store');
+    Route::get('/service-masini/export/pdf', [ServiceMasiniController::class, 'export'])
+        ->name('service-masini.export');
 
 
     Route::get('/rapoarte/incasari-utilizatori', [RaportController::class, 'incasariUtilizatori']);

--- a/tests/Feature/ServiceMasiniTest.php
+++ b/tests/Feature/ServiceMasiniTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FacturiFurnizori\GestiunePiesa;
+use App\Models\Masina;
+use App\Models\MasinaServiceEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServiceMasiniTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_displays_masini(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create(['denumire' => 'Camion Test', 'numar_inmatriculare' => 'B01ABC']);
+
+        $response = $this->actingAs($user)->get(route('service-masini.index', ['masina_id' => $masina->id]));
+
+        $response->assertOk();
+        $response->assertSee('Service mașini');
+        $response->assertSee('Camion Test');
+    }
+
+    public function test_it_creates_a_new_masina(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('service-masini.store-masina'), [
+            'denumire' => 'Duba Test',
+            'numar_inmatriculare' => 'CT09XYZ',
+            'serie_sasiu' => 'SERIE1234567',
+            'observatii' => 'Test observatii',
+        ]);
+
+        $masina = Masina::query()->first();
+
+        $response->assertRedirect(route('service-masini.index', ['masina_id' => $masina->id]));
+        $this->assertDatabaseHas('masini', [
+            'denumire' => 'Duba Test',
+            'numar_inmatriculare' => 'CT09XYZ',
+        ]);
+    }
+
+    public function test_it_allocates_piece_and_decrements_stock(): void
+    {
+        $user = User::factory()->create(['name' => 'Test User']);
+        $masina = Masina::factory()->create();
+        $piesa = GestiunePiesa::factory()->create(['nr_bucati' => 5]);
+
+        $response = $this->actingAs($user)->post(route('service-masini.entries.store', $masina), [
+            'tip' => 'piesa',
+            'gestiune_piesa_id' => $piesa->id,
+            'cantitate' => 2,
+            'data_montaj' => now()->toDateString(),
+            'nume_mecanic' => 'Ion Mecanic',
+            'observatii' => 'Test piesă',
+        ]);
+
+        $response->assertRedirect();
+
+        $entry = MasinaServiceEntry::query()->first();
+        $this->assertNotNull($entry);
+        $this->assertSame('piesa', $entry->tip);
+        $this->assertSame($masina->id, $entry->masina_id);
+        $this->assertSame($piesa->id, $entry->gestiune_piesa_id);
+        $this->assertSame('Ion Mecanic', $entry->nume_mecanic);
+        $this->assertSame('Test User', $entry->nume_utilizator);
+        $this->assertEquals(2.0, (float) $entry->cantitate);
+
+        $piesa->refresh();
+        $this->assertEquals(3.0, (float) $piesa->nr_bucati);
+    }
+
+    public function test_it_stores_manual_intervention(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('service-masini.entries.store', $masina), [
+            'tip' => 'manual',
+            'denumire_interventie' => 'Schimb ulei',
+            'data_montaj' => now()->toDateString(),
+            'nume_mecanic' => 'Mecanic Test',
+            'observatii' => 'Ulei 5W40',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('masina_service_entries', [
+            'masina_id' => $masina->id,
+            'tip' => 'manual',
+            'denumire_interventie' => 'Schimb ulei',
+        ]);
+    }
+
+    public function test_it_exports_pdf(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        MasinaServiceEntry::factory()->create([
+            'masina_id' => $masina->id,
+            'tip' => 'manual',
+            'denumire_interventie' => 'Verificare lumini',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('service-masini.export', ['masina_id' => $masina->id]));
+
+        $response->assertOk();
+        $this->assertStringContainsString('application/pdf', $response->headers->get('content-type'));
+    }
+}


### PR DESCRIPTION
## Summary
- add ServiceMasiniController with routes, requests, and PDF export for managing vehicle service interventions
- introduce Masina and MasinaServiceEntry models with migrations, factories, and tests tied to gestiune_piese inventory
- build Service mașini UI and navigation updates mirroring existing factura pages for allocating pieces and logging manual work

## Testing
- `php artisan test --filter=ServiceMasiniTest` *(fails: composer install requires GitHub authentication to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ef532dd76883268836b2f0fdc2ce05