### PR TITLE
Enable editing and deletion for Service Mașini records

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorFisierController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorFisierController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\FacturiFurnizori;
+
+use App\Http\Controllers\Controller;
+use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Models\FacturiFurnizori\FacturaFurnizorFisier;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Storage;
+
+class FacturaFurnizorFisierController extends Controller
+{
+    public function vizualizeaza(FacturaFurnizor $factura, FacturaFurnizorFisier $fisier)
+    {
+        $this->ensureBelongsToFactura($factura, $fisier);
+
+        if (! $fisier->isPreviewable()) {
+            return back()->with('error', 'Fișierul nu poate fi deschis în browser.');
+        }
+
+        if (! Storage::exists($fisier->cale)) {
+            return back()->with('error', 'Fișierul nu a putut fi găsit.');
+        }
+
+        $displayName = $fisier->nume_original ?: basename($fisier->cale);
+        $safeDisplayName = addcslashes($displayName, "\\\"");
+
+        $headers = [
+            'Content-Disposition' => 'inline; filename="' . $safeDisplayName . '"',
+        ];
+
+        $mimeType = Storage::mimeType($fisier->cale);
+
+        if ($mimeType) {
+            $headers['Content-Type'] = $mimeType;
+        }
+
+        return Storage::response($fisier->cale, $displayName, $headers);
+    }
+
+    public function descarca(FacturaFurnizor $factura, FacturaFurnizorFisier $fisier)
+    {
+        $this->ensureBelongsToFactura($factura, $fisier);
+
+        if (! Storage::exists($fisier->cale)) {
+            return back()->with('error', 'Fișierul nu a putut fi găsit.');
+        }
+
+        $downloadName = $fisier->nume_original ?: basename($fisier->cale);
+
+        return Storage::download($fisier->cale, $downloadName);
+    }
+
+    public function destroy(FacturaFurnizor $factura, FacturaFurnizorFisier $fisier): RedirectResponse
+    {
+        $this->ensureBelongsToFactura($factura, $fisier);
+
+        if ($fisier->cale && Storage::exists($fisier->cale)) {
+            Storage::delete($fisier->cale);
+        }
+
+        $fisier->delete();
+
+        return back()->with('status', 'Fișierul a fost șters.');
+    }
+
+    private function ensureBelongsToFactura(FacturaFurnizor $factura, FacturaFurnizorFisier $fisier): void
+    {
+        if ($fisier->factura_id !== $factura->id) {
+            abort(404);
+        }
+    }
+}

--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -148,7 +148,7 @@ class PlataCalupController extends Controller
         }
 
         if (is_array($facturi)) {
-            $idsCurente = $plataCalup->facturi()->pluck('ff_facturi.id')->toArray();
+            $idsCurente = $plataCalup->facturi()->pluck('service_ff_facturi.id')->toArray();
             $deLegat = array_diff($facturi, $idsCurente);
             $deDezlegat = array_diff($idsCurente, $facturi);
 

--- a/app/Http/Controllers/Service/GestiunePieseController.php
+++ b/app/Http/Controllers/Service/GestiunePieseController.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Service;
 
+use App\Http\Controllers\Controller;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -35,20 +36,20 @@ class GestiunePieseController extends Controller
         $invoiceDateAlias = null;
 
         try {
-            $hasTable = Schema::hasTable('gestiune_piese');
+            $hasTable = Schema::hasTable('service_gestiune_piese');
 
             if ($hasTable) {
-                $columns = Schema::getColumnListing('gestiune_piese');
+                $columns = Schema::getColumnListing('service_gestiune_piese');
             }
         } catch (\Throwable $exception) {
             $hasTable = false;
             $columns = [];
-            Log::warning('Unable to inspect gestiune_piese structure', ['exception' => $exception]);
+            Log::warning('Unable to inspect service_gestiune_piese structure', ['exception' => $exception]);
         }
 
         if ($hasTable) {
             try {
-                $query = DB::table('gestiune_piese as gp');
+                $query = DB::table('service_gestiune_piese as gp');
 
                 if (! empty($columns)) {
                     foreach ($columns as $column) {
@@ -63,11 +64,13 @@ class GestiunePieseController extends Controller
                     'facturi_furnizori_id',
                     'ff_factura_id',
                     'ff_facturi_id',
+                    'service_ff_factura_id',
+                    'service_ff_facturi_id',
                 ])->first(static fn ($column) => in_array($column, $columns, true));
 
                 if ($invoiceJoinColumn) {
                     $invoiceDateAlias = 'factura_data_factura';
-                    $query->leftJoin('ff_facturi as ff', "ff.id", '=', "gp.$invoiceJoinColumn");
+                    $query->leftJoin('service_ff_facturi as ff', "ff.id", '=', "gp.$invoiceJoinColumn");
                     $query->addSelect('ff.data_factura as '.$invoiceDateAlias);
                 }
 
@@ -106,8 +109,8 @@ class GestiunePieseController extends Controller
 
                 $items = $query->simplePaginate(100)->withQueryString();
             } catch (\Throwable $exception) {
-                $loadError = 'Nu am putut încărca datele din gestiune_piese.';
-                Log::error('Failed to load gestiune_piese data', ['exception' => $exception]);
+                $loadError = 'Nu am putut încărca datele din service_gestiune_piese.';
+                Log::error('Failed to load service_gestiune_piese data', ['exception' => $exception]);
             }
         }
 
@@ -119,7 +122,7 @@ class GestiunePieseController extends Controller
             $displayColumns[] = $invoiceDateAlias;
         }
 
-        return view('gestiunePiese.index', [
+        return view('service.gestiune-piese.index', [
             'denumire' => $denumireSearch,
             'cod' => $codSearch,
             'dataFactura' => $useExactInvoiceDate ? $invoiceDateFilter : $invoiceDateSearch,

--- a/app/Http/Controllers/Service/ServiceMasiniController.php
+++ b/app/Http/Controllers/Service/ServiceMasiniController.php
@@ -1,0 +1,462 @@
+<?php
+
+namespace App\Http\Controllers\Service;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Service\StoreMasinaRequest;
+use App\Http\Requests\Service\StoreMasinaServiceEntryRequest;
+use App\Http\Requests\Service\UpdateMasinaRequest;
+use App\Http\Requests\Service\UpdateMasinaServiceEntryRequest;
+use App\Models\Service\GestiunePiesa;
+use App\Models\Service\Masina;
+use App\Models\Service\MasinaServiceEntry;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Throwable;
+
+class ServiceMasiniController extends Controller
+{
+    public function index(Request $request)
+    {
+        $filters = [
+            'masina_id' => $request->query('masina_id'),
+            'numar_inmatriculare' => trim((string) $request->query('numar_inmatriculare', '')),
+            'data_start' => $request->query('data_start'),
+            'data_end' => $request->query('data_end'),
+            'piesa' => trim((string) $request->query('piesa', '')),
+            'cod' => trim((string) $request->query('cod', '')),
+        ];
+
+        $masini = $this->getMasiniList($filters['numar_inmatriculare']);
+        $selectedMasina = $this->resolveSelectedMasina($masini, $filters['masina_id']);
+        $editingEntry = $this->resolveEditingEntry($selectedMasina, (int) $request->query('entry_id'));
+
+        $entries = $selectedMasina
+            ? $this->getServiceEntries($selectedMasina->id, $filters)
+            : $this->emptyPaginator();
+
+        return view('service.masini.index', [
+            'masini' => $masini,
+            'selectedMasina' => $selectedMasina,
+            'entries' => $entries,
+            'filters' => $filters,
+            'availablePieces' => $this->getAvailablePieces($editingEntry),
+            'editingEntry' => $editingEntry,
+        ]);
+    }
+
+    public function storeMasina(StoreMasinaRequest $request): RedirectResponse
+    {
+        $masina = Masina::query()->create($request->validated());
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id])
+            ->with('status', 'Mașina a fost adăugată cu succes.');
+    }
+
+    public function storeEntry(StoreMasinaServiceEntryRequest $request, Masina $masina): RedirectResponse
+    {
+        $filters = $this->extractFilterState($request);
+
+        try {
+            DB::transaction(function () use ($request, $masina): void {
+                $data = $request->validated();
+                $user = $request->user();
+
+                $entry = new MasinaServiceEntry();
+                $entry->masina_id = $masina->id;
+                $entry->tip = $data['tip'];
+                $entry->data_montaj = $data['data_montaj'];
+                $entry->nume_mecanic = $data['nume_mecanic'];
+                $entry->observatii = $data['observatii'] ?? null;
+                $entry->nume_utilizator = $user?->name;
+                $entry->user_id = $user?->id;
+
+                if ($data['tip'] === 'piesa') {
+                    $piesa = $request->piece() ?: GestiunePiesa::query()->find($data['gestiune_piesa_id']);
+
+                    if (! $piesa) {
+                        throw new \RuntimeException('Piesa selectată nu a fost găsită.');
+                    }
+
+                    $cantitate = (float) $data['cantitate'];
+
+                    $entry->gestiune_piesa_id = $piesa->id;
+                    $entry->denumire_piesa = $piesa->denumire;
+                    $entry->cod_piesa = $piesa->cod;
+                    $entry->cantitate = $cantitate;
+
+                    $updated = GestiunePiesa::query()
+                        ->whereKey($piesa->id)
+                        ->where('nr_bucati', '>=', $cantitate)
+                        ->decrement('nr_bucati', $cantitate);
+
+                    if ($updated === 0) {
+                        throw new \RuntimeException('Stocul piesei s-a modificat între timp.');
+                    }
+                } else {
+                    $entry->denumire_interventie = $data['denumire_interventie'];
+                }
+
+                $entry->save();
+            });
+        } catch (Throwable $exception) {
+            Log::error('Unable to save service entry', [
+                'exception' => $exception,
+                'masina_id' => $masina->id,
+            ]);
+
+            return redirect()
+                ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+                ->withErrors(['general' => 'Nu am putut salva intervenția. Încearcă din nou.']);
+        }
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+            ->with('status', 'Intervenția a fost salvată.');
+    }
+
+    public function updateMasina(UpdateMasinaRequest $request, Masina $masina): RedirectResponse
+    {
+        $masina->update($request->validated());
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id])
+            ->with('status', 'Mașina a fost actualizată.');
+    }
+
+    public function destroyMasina(Request $request, Masina $masina): RedirectResponse
+    {
+        $filters = $this->extractFilterState($request);
+
+        try {
+            DB::transaction(function () use ($masina): void {
+                $masina->serviceEntries()
+                    ->where('tip', 'piesa')
+                    ->chunkById(100, function ($entries): void {
+                        foreach ($entries as $entry) {
+                            if ($entry->gestiune_piesa_id && $entry->cantitate) {
+                                GestiunePiesa::query()
+                                    ->whereKey($entry->gestiune_piesa_id)
+                                    ->increment('nr_bucati', (float) $entry->cantitate);
+                            }
+                        }
+                    });
+
+                $masina->delete();
+            });
+        } catch (Throwable $exception) {
+            Log::error('Unable to delete masina', [
+                'exception' => $exception,
+                'masina_id' => $masina->id,
+            ]);
+
+            return redirect()
+                ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+                ->withErrors(['general' => 'Nu am putut șterge mașina. Încearcă din nou.']);
+        }
+
+        return redirect()
+            ->route('service-masini.index', $filters)
+            ->with('status', 'Mașina a fost ștearsă.');
+    }
+
+    public function updateEntry(UpdateMasinaServiceEntryRequest $request, Masina $masina, MasinaServiceEntry $entry): RedirectResponse
+    {
+        $filters = $this->extractFilterState($request);
+
+        if ($entry->masina_id !== $masina->id) {
+            abort(404);
+        }
+
+        try {
+            DB::transaction(function () use ($request, $entry): void {
+                if ($entry->tip === 'piesa' && $entry->gestiune_piesa_id && $entry->cantitate) {
+                    GestiunePiesa::query()
+                        ->whereKey($entry->gestiune_piesa_id)
+                        ->increment('nr_bucati', (float) $entry->cantitate);
+                }
+
+                $data = $request->validated();
+
+                $entry->tip = $data['tip'];
+                $entry->data_montaj = $data['data_montaj'];
+                $entry->nume_mecanic = $data['nume_mecanic'];
+                $entry->observatii = $data['observatii'] ?? null;
+
+                if ($data['tip'] === 'piesa') {
+                    $piesa = $request->piece() ?: GestiunePiesa::query()->find($data['gestiune_piesa_id']);
+
+                    if (! $piesa) {
+                        throw new \RuntimeException('Piesa selectată nu a fost găsită.');
+                    }
+
+                    $cantitate = (float) $data['cantitate'];
+
+                    $entry->gestiune_piesa_id = $piesa->id;
+                    $entry->denumire_piesa = $piesa->denumire;
+                    $entry->cod_piesa = $piesa->cod;
+                    $entry->denumire_interventie = null;
+                    $entry->cantitate = $cantitate;
+
+                    $updated = GestiunePiesa::query()
+                        ->whereKey($piesa->id)
+                        ->where('nr_bucati', '>=', $cantitate)
+                        ->decrement('nr_bucati', $cantitate);
+
+                    if ($updated === 0) {
+                        throw new \RuntimeException('Stocul piesei s-a modificat între timp.');
+                    }
+                } else {
+                    $entry->gestiune_piesa_id = null;
+                    $entry->denumire_piesa = null;
+                    $entry->cod_piesa = null;
+                    $entry->cantitate = null;
+                    $entry->denumire_interventie = $data['denumire_interventie'];
+                }
+
+                $entry->save();
+            });
+        } catch (Throwable $exception) {
+            Log::error('Unable to update service entry', [
+                'exception' => $exception,
+                'entry_id' => $entry->id,
+                'masina_id' => $masina->id,
+            ]);
+
+            return redirect()
+                ->route('service-masini.index', ['masina_id' => $masina->id] + $filters + ['entry_id' => $entry->id])
+                ->withErrors(['general' => 'Nu am putut actualiza intervenția. Încearcă din nou.'])
+                ->withInput();
+        }
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+            ->with('status', 'Intervenția a fost actualizată.');
+    }
+
+    public function destroyEntry(Request $request, Masina $masina, MasinaServiceEntry $entry): RedirectResponse
+    {
+        $filters = $this->extractFilterState($request);
+
+        if ($entry->masina_id !== $masina->id) {
+            abort(404);
+        }
+
+        try {
+            DB::transaction(function () use ($entry): void {
+                if ($entry->tip === 'piesa' && $entry->gestiune_piesa_id && $entry->cantitate) {
+                    GestiunePiesa::query()
+                        ->whereKey($entry->gestiune_piesa_id)
+                        ->increment('nr_bucati', (float) $entry->cantitate);
+                }
+
+                $entry->delete();
+            });
+        } catch (Throwable $exception) {
+            Log::error('Unable to delete service entry', [
+                'exception' => $exception,
+                'entry_id' => $entry->id,
+                'masina_id' => $masina->id,
+            ]);
+
+            return redirect()
+                ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+                ->withErrors(['general' => 'Nu am putut șterge intervenția. Încearcă din nou.']);
+        }
+
+        return redirect()
+            ->route('service-masini.index', ['masina_id' => $masina->id] + $filters)
+            ->with('status', 'Intervenția a fost ștearsă.');
+    }
+
+    public function export(Request $request)
+    {
+        $filters = [
+            'masina_id' => $request->query('masina_id'),
+            'numar_inmatriculare' => trim((string) $request->query('numar_inmatriculare', '')),
+            'data_start' => $request->query('data_start'),
+            'data_end' => $request->query('data_end'),
+            'piesa' => trim((string) $request->query('piesa', '')),
+            'cod' => trim((string) $request->query('cod', '')),
+        ];
+
+        $masini = $this->getMasiniList($filters['numar_inmatriculare']);
+        $selectedMasina = $this->resolveSelectedMasina($masini, $filters['masina_id']);
+
+        if (! $selectedMasina) {
+            abort(404, 'Mașina selectată nu există.');
+        }
+
+        $entries = $this->getServiceEntriesCollection($selectedMasina->id, $filters);
+
+        $pdf = Pdf::loadView('service.masini.export', [
+            'masina' => $selectedMasina,
+            'entries' => $entries,
+            'filters' => $filters,
+        ]);
+
+        $filename = 'service-masini-' . Str::slug($selectedMasina->numar_inmatriculare ?: $selectedMasina->denumire) . '.pdf';
+
+        return $pdf->download($filename);
+    }
+
+    protected function getMasiniList(string $numarInmatriculare = ''): EloquentCollection
+    {
+        $query = Masina::query()->orderBy('denumire');
+
+        if ($numarInmatriculare !== '') {
+            $query->where(function ($builder) use ($numarInmatriculare): void {
+                $builder->where('numar_inmatriculare', 'like', '%' . $numarInmatriculare . '%')
+                    ->orWhere('denumire', 'like', '%' . $numarInmatriculare . '%');
+            });
+        }
+
+        return $query->get();
+    }
+
+    protected function resolveSelectedMasina(EloquentCollection $masini, $masinaId): ?Masina
+    {
+        if ($masini->isEmpty()) {
+            return null;
+        }
+
+        if ($masinaId) {
+            $selected = $masini->firstWhere('id', (int) $masinaId);
+
+            if ($selected) {
+                return $selected;
+            }
+        }
+
+        return $masini->first();
+    }
+
+    protected function getServiceEntries(int $masinaId, array $filters): LengthAwarePaginator
+    {
+        return $this->baseEntriesQuery($masinaId, $filters)
+            ->with(['user'])
+            ->orderByDesc('data_montaj')
+            ->orderByDesc('id')
+            ->paginate(25)
+            ->withQueryString();
+    }
+
+    protected function getServiceEntriesCollection(int $masinaId, array $filters): Collection
+    {
+        return $this->baseEntriesQuery($masinaId, $filters)
+            ->with(['user'])
+            ->orderBy('data_montaj')
+            ->orderBy('id')
+            ->get();
+    }
+
+    protected function baseEntriesQuery(int $masinaId, array $filters)
+    {
+        $query = MasinaServiceEntry::query()->where('masina_id', $masinaId);
+
+        if ($filters['data_start']) {
+            try {
+                $query->whereDate('data_montaj', '>=', $filters['data_start']);
+            } catch (Throwable $exception) {
+                Log::warning('Invalid start date filter for service entries', ['exception' => $exception]);
+            }
+        }
+
+        if ($filters['data_end']) {
+            try {
+                $query->whereDate('data_montaj', '<=', $filters['data_end']);
+            } catch (Throwable $exception) {
+                Log::warning('Invalid end date filter for service entries', ['exception' => $exception]);
+            }
+        }
+
+        if ($filters['piesa'] !== '') {
+            $query->where(function ($builder) use ($filters): void {
+                $builder->where('denumire_piesa', 'like', '%' . $filters['piesa'] . '%')
+                    ->orWhere('denumire_interventie', 'like', '%' . $filters['piesa'] . '%');
+            });
+        }
+
+        if ($filters['cod'] !== '') {
+            $query->where('cod_piesa', 'like', '%' . $filters['cod'] . '%');
+        }
+
+        return $query;
+    }
+
+    protected function getAvailablePieces(?MasinaServiceEntry $editingEntry = null): Collection
+    {
+        try {
+            $pieces = GestiunePiesa::query()
+                ->where('nr_bucati', '>', 0)
+                ->orderBy('denumire')
+                ->get(['id', 'denumire', 'cod', 'nr_bucati']);
+
+            if ($editingEntry && $editingEntry->tip === 'piesa' && $editingEntry->gestiune_piesa_id) {
+                if (! $pieces->firstWhere('id', $editingEntry->gestiune_piesa_id)) {
+                    $editingPiece = GestiunePiesa::query()
+                        ->find($editingEntry->gestiune_piesa_id, ['id', 'denumire', 'cod', 'nr_bucati']);
+
+                    if ($editingPiece) {
+                        $pieces = $pieces
+                            ->push($editingPiece)
+                            ->sortBy('denumire')
+                            ->values();
+                    }
+                }
+            }
+
+            return $pieces;
+        } catch (Throwable $exception) {
+            Log::warning('Unable to load available pieces', ['exception' => $exception]);
+
+            return collect();
+        }
+    }
+
+    protected function resolveEditingEntry(?Masina $masina, int $entryId): ?MasinaServiceEntry
+    {
+        if (! $masina || $entryId <= 0) {
+            return null;
+        }
+
+        return $masina->serviceEntries()->whereKey($entryId)->first();
+    }
+
+    protected function extractFilterState(Request $request): array
+    {
+        $keys = ['numar_inmatriculare', 'data_start', 'data_end', 'piesa', 'cod'];
+
+        $data = [];
+        foreach ($keys as $key) {
+            $value = $request->input($key);
+            if ($value !== null && $value !== '') {
+                $data[$key] = $value;
+            }
+        }
+
+        return $data;
+    }
+
+    protected function emptyPaginator(): LengthAwarePaginator
+    {
+        return new LengthAwarePaginator(
+            [],
+            0,
+            25,
+            1,
+            [
+                'path' => LengthAwarePaginator::resolveCurrentPath(),
+                'query' => request()->query(),
+            ]
+        );
+    }
+}

--- a/app/Http/Requests/FacturiFurnizori/AttachFacturiRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/AttachFacturiRequest.php
@@ -23,7 +23,7 @@ class AttachFacturiRequest extends FormRequest
     {
         return [
             'facturi' => ['required', 'array', 'min:1'],
-            'facturi.*' => ['integer', 'exists:ff_facturi,id'],
+            'facturi.*' => ['integer', 'exists:service_ff_facturi,id'],
         ];
     }
 

--- a/app/Http/Requests/FacturiFurnizori/FacturaFurnizorRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/FacturaFurnizorRequest.php
@@ -37,6 +37,8 @@ class FacturaFurnizorRequest extends FormRequest
             'produse.*.cod' => ['nullable', 'string', 'max:100'],
             'produse.*.nr_bucati' => ['nullable', 'numeric'],
             'produse.*.pret' => ['nullable', 'numeric'],
+            'fisiere_pdf' => ['nullable', 'array'],
+            'fisiere_pdf.*' => ['file', 'mimes:pdf', 'max:10240'],
         ];
     }
 

--- a/app/Http/Requests/FacturiFurnizori/PlataCalupRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/PlataCalupRequest.php
@@ -28,7 +28,7 @@ class PlataCalupRequest extends FormRequest
             'fisiere_pdf' => ['nullable', 'array'],
             'fisiere_pdf.*' => ['file', 'mimetypes:application/pdf', 'max:10240'],
             'facturi' => ['nullable', 'array'],
-            'facturi.*' => ['integer', 'exists:ff_facturi,id'],
+            'facturi.*' => ['integer', 'exists:service_ff_facturi,id'],
         ];
     }
 

--- a/app/Http/Requests/Service/MasinaServiceEntryRequest.php
+++ b/app/Http/Requests/Service/MasinaServiceEntryRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+use App\Models\Service\GestiunePiesa;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+abstract class MasinaServiceEntryRequest extends FormRequest
+{
+    protected ?GestiunePiesa $piesa = null;
+
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tip' => ['required', 'in:piesa,manual'],
+            'gestiune_piesa_id' => ['nullable', 'integer', 'exists:service_gestiune_piese,id'],
+            'cantitate' => ['nullable', 'numeric', 'min:0.01'],
+            'denumire_interventie' => ['nullable', 'string', 'max:255'],
+            'data_montaj' => ['required', 'date'],
+            'nume_mecanic' => ['required', 'string', 'max:255'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $tip = (string) $this->input('tip', '');
+
+            if ($tip === 'piesa') {
+                if (! $this->filled('gestiune_piesa_id')) {
+                    $validator->errors()->add('gestiune_piesa_id', 'Selectează o piesă din gestiune.');
+
+                    return;
+                }
+
+                $cantitate = (float) $this->input('cantitate', 0);
+                if ($cantitate <= 0) {
+                    $validator->errors()->add('cantitate', 'Cantitatea trebuie să fie mai mare decât zero.');
+                }
+
+                $this->piesa = GestiunePiesa::query()->find($this->input('gestiune_piesa_id'));
+
+                if (! $this->piesa) {
+                    $validator->errors()->add('gestiune_piesa_id', 'Piesa selectată nu există.');
+
+                    return;
+                }
+
+                $available = $this->availableStock($this->piesa);
+                if ($cantitate > $available) {
+                    $validator->errors()->add('cantitate', 'Cantitatea depășește stocul disponibil.');
+                }
+            } elseif ($tip === 'manual') {
+                if (! $this->filled('denumire_interventie')) {
+                    $validator->errors()->add('denumire_interventie', 'Completează denumirea intervenției.');
+                }
+            }
+        });
+    }
+
+    protected function availableStock(GestiunePiesa $piesa): float
+    {
+        return (float) $piesa->nr_bucati + $this->additionalPieceStock($piesa);
+    }
+
+    protected function additionalPieceStock(GestiunePiesa $piesa): float
+    {
+        return 0.0;
+    }
+
+    public function piece(): ?GestiunePiesa
+    {
+        return $this->piesa;
+    }
+}

--- a/app/Http/Requests/Service/StoreMasinaRequest.php
+++ b/app/Http/Requests/Service/StoreMasinaRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMasinaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'denumire' => ['required', 'string', 'max:255'],
+            'numar_inmatriculare' => ['required', 'string', 'max:255', 'unique:service_masini,numar_inmatriculare'],
+            'serie_sasiu' => ['nullable', 'string', 'max:255'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Service/StoreMasinaServiceEntryRequest.php
+++ b/app/Http/Requests/Service/StoreMasinaServiceEntryRequest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+class StoreMasinaServiceEntryRequest extends MasinaServiceEntryRequest
+{
+}

--- a/app/Http/Requests/Service/UpdateMasinaRequest.php
+++ b/app/Http/Requests/Service/UpdateMasinaRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateMasinaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        $masinaId = (int) optional($this->route('masina'))->id;
+
+        return [
+            'denumire' => ['required', 'string', 'max:255'],
+            'numar_inmatriculare' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('service_masini', 'numar_inmatriculare')->ignore($masinaId),
+            ],
+            'serie_sasiu' => ['nullable', 'string', 'max:255'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/Service/UpdateMasinaServiceEntryRequest.php
+++ b/app/Http/Requests/Service/UpdateMasinaServiceEntryRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+use App\Models\Service\GestiunePiesa;
+use App\Models\Service\MasinaServiceEntry;
+
+class UpdateMasinaServiceEntryRequest extends MasinaServiceEntryRequest
+{
+    protected function additionalPieceStock(GestiunePiesa $piesa): float
+    {
+        /** @var MasinaServiceEntry|null $entry */
+        $entry = $this->route('entry');
+
+        if ($entry && $entry->gestiune_piesa_id === $piesa->id && $entry->cantitate !== null) {
+            return (float) $entry->cantitate;
+        }
+
+        return 0.0;
+    }
+}

--- a/app/Models/FacturiFurnizori/FacturaFurnizor.php
+++ b/app/Models/FacturiFurnizori/FacturaFurnizor.php
@@ -2,7 +2,8 @@
 
 namespace App\Models\FacturiFurnizori;
 
-use App\Models\FacturiFurnizori\GestiunePiesa;
+use App\Models\FacturiFurnizori\FacturaFurnizorFisier;
+use App\Models\Service\GestiunePiesa;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -11,7 +12,7 @@ class FacturaFurnizor extends Model
 {
     use HasFactory;
 
-    protected $table = 'ff_facturi';
+    protected $table = 'service_ff_facturi';
 
     protected $fillable = [
         'denumire_furnizor',
@@ -36,11 +37,16 @@ class FacturaFurnizor extends Model
      */
     public function calupuri()
     {
-        return $this->belongsToMany(PlataCalup::class, 'ff_facturi_plati', 'factura_id', 'calup_id')->withTimestamps();
+        return $this->belongsToMany(PlataCalup::class, 'service_ff_facturi_plati', 'factura_id', 'calup_id')->withTimestamps();
     }
 
     public function piese(): HasMany
     {
         return $this->hasMany(GestiunePiesa::class, 'factura_id');
+    }
+
+    public function fisiere(): HasMany
+    {
+        return $this->hasMany(FacturaFurnizorFisier::class, 'factura_id');
     }
 }

--- a/app/Models/FacturiFurnizori/FacturaFurnizorFisier.php
+++ b/app/Models/FacturiFurnizori/FacturaFurnizorFisier.php
@@ -6,34 +6,34 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class PlataCalupFisier extends Model
+class FacturaFurnizorFisier extends Model
 {
     use HasFactory;
 
-    protected $table = 'service_ff_plati_calupuri_fisiere';
+    protected $table = 'service_ff_facturi_fisiere';
 
     protected $fillable = [
-        'plata_calup_id',
+        'factura_id',
         'cale',
         'nume_original',
     ];
 
-    public function calup(): BelongsTo
+    public function factura(): BelongsTo
     {
-        return $this->belongsTo(PlataCalup::class, 'plata_calup_id');
+        return $this->belongsTo(FacturaFurnizor::class, 'factura_id');
     }
 
     public function extension(): ?string
     {
         $source = $this->nume_original ?: $this->cale;
 
-        if (!$source) {
+        if (! $source) {
             return null;
         }
 
         $extension = pathinfo($source, PATHINFO_EXTENSION);
 
-        if (!$extension) {
+        if (! $extension) {
             return null;
         }
 
@@ -44,14 +44,10 @@ class PlataCalupFisier extends Model
     {
         $extension = $this->extension();
 
-        if (!$extension) {
+        if (! $extension) {
             return false;
         }
 
-        return in_array($extension, [
-            'pdf',
-            'jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg',
-            'txt', 'csv',
-        ], true);
+        return in_array($extension, ['pdf'], true);
     }
 }

--- a/app/Models/FacturiFurnizori/PlataCalup.php
+++ b/app/Models/FacturiFurnizori/PlataCalup.php
@@ -11,7 +11,7 @@ class PlataCalup extends Model
 {
     use HasFactory;
 
-    protected $table = 'ff_plati_calupuri';
+    protected $table = 'service_ff_plati_calupuri';
 
     protected $fillable = [
         'denumire_calup',
@@ -28,7 +28,7 @@ class PlataCalup extends Model
      */
     public function facturi(): BelongsToMany
     {
-        return $this->belongsToMany(FacturaFurnizor::class, 'ff_facturi_plati', 'calup_id', 'factura_id')->withTimestamps();
+        return $this->belongsToMany(FacturaFurnizor::class, 'service_ff_facturi_plati', 'calup_id', 'factura_id')->withTimestamps();
     }
 
     public function fisiere(): HasMany

--- a/app/Models/Service/GestiunePiesa.php
+++ b/app/Models/Service/GestiunePiesa.php
@@ -1,16 +1,17 @@
 <?php
 
-namespace App\Models\FacturiFurnizori;
+namespace App\Models\Service;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\FacturiFurnizori\FacturaFurnizor;
 
 class GestiunePiesa extends Model
 {
     use HasFactory;
 
-    protected $table = 'gestiune_piese';
+    protected $table = 'service_gestiune_piese';
 
     protected $fillable = [
         'factura_id',
@@ -24,6 +25,11 @@ class GestiunePiesa extends Model
         'nr_bucati' => 'decimal:2',
         'pret' => 'decimal:2',
     ];
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\Service\GestiunePiesaFactory::new();
+    }
 
     public function factura(): BelongsTo
     {

--- a/app/Models/Service/Masina.php
+++ b/app/Models/Service/Masina.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models\Service;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Masina extends Model
+{
+    use HasFactory;
+
+    protected $table = 'service_masini';
+
+    protected $fillable = [
+        'denumire',
+        'numar_inmatriculare',
+        'serie_sasiu',
+        'observatii',
+    ];
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\Service\MasinaFactory::new();
+    }
+
+    public function serviceEntries(): HasMany
+    {
+        return $this->hasMany(MasinaServiceEntry::class);
+    }
+}

--- a/app/Models/Service/MasinaServiceEntry.php
+++ b/app/Models/Service/MasinaServiceEntry.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models\Service;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\Service\GestiunePiesa;
+use App\Models\User;
+
+class MasinaServiceEntry extends Model
+{
+    use HasFactory;
+
+    protected $table = 'service_masina_service_entries';
+
+    protected $fillable = [
+        'masina_id',
+        'gestiune_piesa_id',
+        'user_id',
+        'tip',
+        'denumire_interventie',
+        'cod_piesa',
+        'denumire_piesa',
+        'cantitate',
+        'data_montaj',
+        'nume_mecanic',
+        'nume_utilizator',
+        'observatii',
+    ];
+
+    protected $casts = [
+        'data_montaj' => 'date',
+        'cantitate' => 'decimal:2',
+    ];
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\Service\MasinaServiceEntryFactory::new();
+    }
+
+    public function masina(): BelongsTo
+    {
+        return $this->belongsTo(Masina::class);
+    }
+
+    public function piesa(): BelongsTo
+    {
+        return $this->belongsTo(GestiunePiesa::class, 'gestiune_piesa_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/factories/Service/GestiunePiesaFactory.php
+++ b/database/factories/Service/GestiunePiesaFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories\Service;
+
+use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Models\Service\GestiunePiesa;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Service\GestiunePiesa>
+ */
+class GestiunePiesaFactory extends Factory
+{
+    protected $model = GestiunePiesa::class;
+
+    public function definition(): array
+    {
+        return [
+            'factura_id' => FacturaFurnizor::factory(),
+            'denumire' => $this->faker->words(3, true),
+            'cod' => strtoupper($this->faker->bothify('PIE###')),
+            'nr_bucati' => $this->faker->randomFloat(2, 1, 20),
+            'pret' => $this->faker->randomFloat(2, 10, 500),
+        ];
+    }
+}

--- a/database/factories/Service/MasinaFactory.php
+++ b/database/factories/Service/MasinaFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories\Service;
+
+use App\Models\Service\Masina;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Service\Masina>
+ */
+class MasinaFactory extends Factory
+{
+    protected $model = Masina::class;
+
+    public function definition(): array
+    {
+        return [
+            'denumire' => $this->faker->company . ' ' . $this->faker->word(),
+            'numar_inmatriculare' => strtoupper($this->faker->bothify('??##???')),
+            'serie_sasiu' => strtoupper($this->faker->bothify('###########')),
+            'observatii' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/Service/MasinaServiceEntryFactory.php
+++ b/database/factories/Service/MasinaServiceEntryFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories\Service;
+
+use App\Models\Service\Masina;
+use App\Models\Service\MasinaServiceEntry;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Service\MasinaServiceEntry>
+ */
+class MasinaServiceEntryFactory extends Factory
+{
+    protected $model = MasinaServiceEntry::class;
+
+    public function definition(): array
+    {
+        $tip = $this->faker->randomElement(['piesa', 'manual']);
+
+        return [
+            'masina_id' => Masina::factory(),
+            'tip' => $tip,
+            'data_montaj' => $this->faker->date(),
+            'nume_mecanic' => $this->faker->name(),
+            'nume_utilizator' => $this->faker->name(),
+            'observatii' => $this->faker->sentence(),
+            'denumire_piesa' => $tip === 'piesa' ? $this->faker->words(3, true) : null,
+            'cod_piesa' => $tip === 'piesa' ? strtoupper($this->faker->bothify('PIE###')) : null,
+            'cantitate' => $tip === 'piesa' ? $this->faker->randomFloat(2, 1, 5) : null,
+            'denumire_interventie' => $tip === 'manual' ? $this->faker->sentence(3) : null,
+        ];
+    }
+}

--- a/database/migrations/2025_03_15_235900_rename_ff_tables_to_service_prefix.php
+++ b/database/migrations/2025_03_15_235900_rename_ff_tables_to_service_prefix.php
@@ -1,0 +1,157 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Rename payment batches first so dependent tables can reference the new names.
+        $this->dropLegacyForeignKeys();
+
+        $this->renameTableIfExists('ff_plati_calupuri', 'service_ff_plati_calupuri');
+        $this->renameTableIfExists('ff_plati_calupuri_fisiere', 'service_ff_plati_calupuri_fisiere');
+        $this->renameTableIfExists('ff_facturi', 'service_ff_facturi');
+        $this->renameTableIfExists('ff_facturi_plati', 'service_ff_facturi_plati');
+
+        $this->addServiceForeignKeys();
+    }
+
+    public function down(): void
+    {
+        $this->dropServiceForeignKeys();
+
+        $this->renameTableIfExists('service_ff_facturi_plati', 'ff_facturi_plati');
+        $this->renameTableIfExists('service_ff_facturi', 'ff_facturi');
+        $this->renameTableIfExists('service_ff_plati_calupuri_fisiere', 'ff_plati_calupuri_fisiere');
+        $this->renameTableIfExists('service_ff_plati_calupuri', 'ff_plati_calupuri');
+
+        $this->addLegacyForeignKeys();
+    }
+
+    private function dropLegacyForeignKeys(): void
+    {
+        if (Schema::hasTable('ff_facturi_plati')) {
+            $this->dropForeignIfExists('ff_facturi_plati', 'ff_facturi_plati_factura_id_foreign');
+            $this->dropForeignIfExists('ff_facturi_plati', 'ff_facturi_plati_calup_id_foreign');
+        }
+
+        if (Schema::hasTable('ff_plati_calupuri_fisiere')) {
+            $this->dropForeignIfExists('ff_plati_calupuri_fisiere', 'ff_plati_calupuri_fisiere_plata_calup_id_foreign');
+        }
+    }
+
+    private function dropServiceForeignKeys(): void
+    {
+        if (Schema::hasTable('service_ff_facturi_plati')) {
+            $this->dropForeignIfExists('service_ff_facturi_plati', 'service_ff_facturi_plati_factura_id_foreign');
+            $this->dropForeignIfExists('service_ff_facturi_plati', 'service_ff_facturi_plati_calup_id_foreign');
+        }
+
+        if (Schema::hasTable('service_ff_plati_calupuri_fisiere')) {
+            $this->dropForeignIfExists('service_ff_plati_calupuri_fisiere', 'service_ff_plati_calupuri_fisiere_plata_calup_id_foreign');
+        }
+    }
+
+    private function addServiceForeignKeys(): void
+    {
+        if (Schema::hasTable('service_ff_facturi_plati')) {
+            Schema::table('service_ff_facturi_plati', function (Blueprint $table) {
+                if (! $this->foreignKeyExists('service_ff_facturi_plati', 'service_ff_facturi_plati_factura_id_foreign')) {
+                    $table->foreign('factura_id', 'service_ff_facturi_plati_factura_id_foreign')
+                        ->references('id')
+                        ->on('service_ff_facturi')
+                        ->cascadeOnDelete();
+                }
+
+                if (! $this->foreignKeyExists('service_ff_facturi_plati', 'service_ff_facturi_plati_calup_id_foreign')) {
+                    $table->foreign('calup_id', 'service_ff_facturi_plati_calup_id_foreign')
+                        ->references('id')
+                        ->on('service_ff_plati_calupuri')
+                        ->cascadeOnDelete();
+                }
+            });
+        }
+
+        if (Schema::hasTable('service_ff_plati_calupuri_fisiere')) {
+            Schema::table('service_ff_plati_calupuri_fisiere', function (Blueprint $table) {
+                if (! $this->foreignKeyExists('service_ff_plati_calupuri_fisiere', 'service_ff_plati_calupuri_fisiere_plata_calup_id_foreign')) {
+                    $table->foreign('plata_calup_id', 'service_ff_plati_calupuri_fisiere_plata_calup_id_foreign')
+                        ->references('id')
+                        ->on('service_ff_plati_calupuri')
+                        ->cascadeOnDelete();
+                }
+            });
+        }
+    }
+
+    private function addLegacyForeignKeys(): void
+    {
+        if (Schema::hasTable('ff_facturi_plati')) {
+            Schema::table('ff_facturi_plati', function (Blueprint $table) {
+                if (! $this->foreignKeyExists('ff_facturi_plati', 'ff_facturi_plati_factura_id_foreign')) {
+                    $table->foreign('factura_id', 'ff_facturi_plati_factura_id_foreign')
+                        ->references('id')
+                        ->on('ff_facturi')
+                        ->cascadeOnDelete();
+                }
+
+                if (! $this->foreignKeyExists('ff_facturi_plati', 'ff_facturi_plati_calup_id_foreign')) {
+                    $table->foreign('calup_id', 'ff_facturi_plati_calup_id_foreign')
+                        ->references('id')
+                        ->on('ff_plati_calupuri')
+                        ->cascadeOnDelete();
+                }
+            });
+        }
+
+        if (Schema::hasTable('ff_plati_calupuri_fisiere')) {
+            Schema::table('ff_plati_calupuri_fisiere', function (Blueprint $table) {
+                if (! $this->foreignKeyExists('ff_plati_calupuri_fisiere', 'ff_plati_calupuri_fisiere_plata_calup_id_foreign')) {
+                    $table->foreign('plata_calup_id', 'ff_plati_calupuri_fisiere_plata_calup_id_foreign')
+                        ->references('id')
+                        ->on('ff_plati_calupuri')
+                        ->cascadeOnDelete();
+                }
+            });
+        }
+    }
+
+    private function renameTableIfExists(string $from, string $to): void
+    {
+        if (Schema::hasTable($from) && ! Schema::hasTable($to)) {
+            Schema::rename($from, $to);
+        }
+    }
+
+    private function dropForeignIfExists(string $table, string $constraint): void
+    {
+        if (! Schema::hasTable($table)) {
+            return;
+        }
+
+        if (! $this->foreignKeyExists($table, $constraint)) {
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $table) use ($constraint) {
+            $table->dropForeign($constraint);
+        });
+    }
+
+    private function foreignKeyExists(string $table, string $constraint): bool
+    {
+        $connection = Schema::getConnection();
+        $databaseName = $connection->getDatabaseName();
+
+        return DB::connection($connection->getName())
+            ->table('information_schema.referential_constraints')
+            ->where('constraint_schema', $databaseName)
+            ->where('constraint_name', $constraint)
+            ->where('table_name', $table)
+            ->exists();
+    }
+};

--- a/database/migrations/2025_03_17_000000_create_masini_table.php
+++ b/database/migrations/2025_03_17_000000_create_masini_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('service_masini', function (Blueprint $table) {
+            $table->id();
+            $table->string('denumire');
+            $table->string('numar_inmatriculare')->unique();
+            $table->string('serie_sasiu')->nullable();
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_masini');
+    }
+};

--- a/database/migrations/2025_03_17_010000_create_masina_service_entries_table.php
+++ b/database/migrations/2025_03_17_010000_create_masina_service_entries_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('service_masina_service_entries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('masina_id')->constrained('service_masini')->cascadeOnDelete();
+            $table->foreignId('gestiune_piesa_id')->nullable()->constrained('service_gestiune_piese')->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('tip');
+            $table->string('denumire_interventie')->nullable();
+            $table->string('cod_piesa')->nullable();
+            $table->string('denumire_piesa')->nullable();
+            $table->decimal('cantitate', 10, 2)->nullable();
+            $table->date('data_montaj')->nullable();
+            $table->string('nume_mecanic')->nullable();
+            $table->string('nume_utilizator')->nullable();
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+
+            $table->index(['tip', 'data_montaj']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_masina_service_entries');
+    }
+};

--- a/database/migrations/2025_03_17_020000_create_factura_fisiere_table.php
+++ b/database/migrations/2025_03_17_020000_create_factura_fisiere_table.php
@@ -6,29 +6,21 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    /**
-     * Run the migrations.
-     */
     public function up(): void
     {
-        Schema::create('service_gestiune_piese', function (Blueprint $table) {
+        Schema::create('service_ff_facturi_fisiere', function (Blueprint $table) {
             $table->id();
             $table->foreignId('factura_id')
                 ->constrained('service_ff_facturi')
                 ->cascadeOnDelete();
-            $table->string('denumire');
-            $table->string('cod')->nullable();
-            $table->decimal('nr_bucati', 12, 2)->nullable();
-            $table->decimal('pret', 12, 2)->nullable();
+            $table->string('cale');
+            $table->string('nume_original')->nullable();
             $table->timestamps();
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
-        Schema::dropIfExists('service_gestiune_piese');
+        Schema::dropIfExists('service_ff_facturi_fisiere');
     }
 };

--- a/database/sql/service_ff_plati_calupuri_fisiere.sql
+++ b/database/sql/service_ff_plati_calupuri_fisiere.sql
@@ -1,6 +1,6 @@
--- SQL script to mirror the 2025_10_05_182213_create_ff_plati_calupuri_fisiere_table migration
+-- SQL script to mirror the 2025_10_05_182213_create_service_ff_plati_calupuri_fisiere_table migration
 
-CREATE TABLE `ff_plati_calupuri_fisiere` (
+CREATE TABLE `service_ff_plati_calupuri_fisiere` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
   `plata_calup_id` bigint unsigned NOT NULL,
   `cale` varchar(255) NOT NULL,
@@ -8,16 +8,16 @@ CREATE TABLE `ff_plati_calupuri_fisiere` (
   `created_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `ff_plati_calupuri_fisiere_plata_calup_id_index` (`plata_calup_id`),
-  CONSTRAINT `ff_plati_calupuri_fisiere_plata_calup_id_foreign` FOREIGN KEY (`plata_calup_id`) REFERENCES `ff_plati_calupuri` (`id`) ON DELETE CASCADE
+  KEY `service_ff_plati_calupuri_fisiere_plata_calup_id_index` (`plata_calup_id`),
+  CONSTRAINT `service_ff_plati_calupuri_fisiere_plata_calup_id_foreign` FOREIGN KEY (`plata_calup_id`) REFERENCES `service_ff_plati_calupuri` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- Optional data migration from the legacy single-file column.
-INSERT INTO `ff_plati_calupuri_fisiere` (`plata_calup_id`, `cale`, `nume_original`, `created_at`, `updated_at`)
+INSERT INTO `service_ff_plati_calupuri_fisiere` (`plata_calup_id`, `cale`, `nume_original`, `created_at`, `updated_at`)
 SELECT `id`, `fisier_pdf`, SUBSTRING_INDEX(`fisier_pdf`, '/', -1), NOW(), NOW()
-FROM `ff_plati_calupuri`
+FROM `service_ff_plati_calupuri`
 WHERE `fisier_pdf` IS NOT NULL AND `fisier_pdf` <> '';
 
 -- Optional clean-up of the legacy column once data has been migrated.
-ALTER TABLE `ff_plati_calupuri`
+ALTER TABLE `service_ff_plati_calupuri`
   DROP COLUMN `fisier_pdf`;

--- a/resources/views/facturiFurnizori/calupuri/_form.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/_form.blade.php
@@ -35,7 +35,7 @@
         rows="3"
     >{{ old('observatii', $calup->observatii ?? '') }}</textarea>
 </div>
-<div class="mb-3">
+<div class="mb-3 d-none" aria-hidden="true">
     <label for="fisiere_pdf" class="mb-0 ps-2">Fișiere PDF</label>
     <input
         type="file"

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -20,6 +20,8 @@
         ]]);
     }
     $produse = $produseColectie->values()->toArray();
+    $fisiereExistente = collect($factura?->fisiere ?? []);
+    $fisiereErrors = $errors->has('fisiere_pdf') || collect($errors->get('fisiere_pdf.*'))->flatten()->isNotEmpty();
 @endphp
 
 <div class="row">
@@ -171,6 +173,71 @@
         @error('observatii')
             <div class="invalid-feedback">{{ $message }}</div>
         @enderror
+    </div>
+</div>
+
+<div class="row mb-4">
+    <div class="col-lg-12">
+        <label for="fisiere_pdf" class="mb-0 ps-3">Fișiere PDF factură</label>
+        <input
+            type="file"
+            name="fisiere_pdf[]"
+            id="fisiere_pdf"
+            class="form-control bg-white rounded-3 {{ $fisiereErrors ? 'is-invalid' : '' }}"
+            accept="application/pdf"
+            multiple
+        >
+        <small class="form-text text-muted ps-3">Poți selecta unul sau mai multe fișiere PDF.</small>
+        @if ($errors->has('fisiere_pdf'))
+            <div class="invalid-feedback d-block">{{ $errors->first('fisiere_pdf') }}</div>
+        @endif
+        @foreach ($errors->get('fisiere_pdf.*') as $messages)
+            @foreach ((array) $messages as $message)
+                <div class="invalid-feedback d-block">{{ $message }}</div>
+            @endforeach
+        @endforeach
+
+        @if (($factura?->exists ?? false) && $fisiereExistente->isNotEmpty())
+            <div class="mt-3">
+                <span class="text-uppercase text-muted small d-block mb-2">Fișiere existente</span>
+                <ul class="list-group list-group-flush">
+                    @foreach ($fisiereExistente as $fisier)
+                        <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+                            <div class="me-2">
+                                <i class="fa-solid fa-file-pdf text-danger me-2"></i>
+                                {{ $fisier->nume_original ?: basename($fisier->cale) }}
+                            </div>
+                            <div class="d-flex align-items-center gap-2">
+                                <a
+                                    class="btn btn-sm btn-outline-primary"
+                                    href="{{ route('facturi-furnizori.facturi.fisiere.vizualizeaza', [$factura, $fisier]) }}"
+                                    target="_blank"
+                                >
+                                    <i class="fa-solid fa-eye me-1"></i>Vezi
+                                </a>
+                                <a
+                                    class="btn btn-sm btn-outline-secondary"
+                                    href="{{ route('facturi-furnizori.facturi.fisiere.descarca', [$factura, $fisier]) }}"
+                                >
+                                    <i class="fa-solid fa-download me-1"></i>Descarcă
+                                </a>
+                                <form
+                                    action="{{ route('facturi-furnizori.facturi.fisiere.destroy', [$factura, $fisier]) }}"
+                                    method="POST"
+                                    class="d-inline"
+                                >
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                                        <i class="fa-solid fa-trash me-1"></i>Șterge
+                                    </button>
+                                </form>
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
     </div>
 </div>
 

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -213,7 +213,7 @@
                     @php
                         $fisiereModalErrors = $errors->has('fisiere_pdf') || collect($errors->get('fisiere_pdf.*'))->flatten()->isNotEmpty();
                     @endphp
-                    <div class="mb-3">
+                    <div class="mb-3 d-none" aria-hidden="true">
                         <label for="fisiere_pdf_modal" class="mb-0 ps-2">Fișiere PDF</label>
                         <input
                             type="file"

--- a/resources/views/facturiFurnizori/facturi/partials/factura-row.blade.php
+++ b/resources/views/facturiFurnizori/facturi/partials/factura-row.blade.php
@@ -31,6 +31,16 @@
     <td class="text-muted">{{ \Illuminate\Support\Str::limit($factura->observatii, 60) }}</td>
     <td class="text-end">
         <div class="text-end">
+            @if ($factura->fisiere_count ?? 0)
+                <a
+                    href="{{ route('facturi-furnizori.facturi.show', $factura) }}#factura-fisiere"
+                    class="text-decoration-none me-1"
+                >
+                    <span class="badge bg-secondary text-white">
+                        {{ $factura->fisiere_count }} pdf
+                    </span>
+                </a>
+            @endif
             <a href="{{ route('facturi-furnizori.facturi.show', $factura) }}" class="flex me-1">
                 <span class="badge bg-success">Vezi</span></a>
             <a href="{{ route('facturi-furnizori.facturi.edit', $factura) }}" class="flex me-1">

--- a/resources/views/facturiFurnizori/facturi/save.blade.php
+++ b/resources/views/facturiFurnizori/facturi/save.blade.php
@@ -40,6 +40,7 @@
                         novalidate
                         action="{{ $isEdit ? route('facturi-furnizori.facturi.update', $factura) : route('facturi-furnizori.facturi.store') }}"
                         method="POST"
+                        enctype="multipart/form-data"
                     >
                         @csrf
                         @if ($isEdit)

--- a/resources/views/facturiFurnizori/facturi/show.blade.php
+++ b/resources/views/facturiFurnizori/facturi/show.blade.php
@@ -78,6 +78,39 @@
                 @endif
             </div>
 
+            <div class="border border-dark rounded-3 p-3 bg-white mb-3" id="factura-fisiere">
+                <h6 class="text-uppercase text-muted mb-3">Fișiere atașate</h6>
+                @if ($factura->fisiere->isEmpty())
+                    <p class="text-muted mb-0">Factura nu are fișiere atașate.</p>
+                @else
+                    <ul class="list-group list-group-flush">
+                        @foreach ($factura->fisiere as $fisier)
+                            <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+                                <div class="me-2">
+                                    <i class="fa-solid fa-file-pdf text-danger me-2"></i>
+                                    {{ $fisier->nume_original ?: basename($fisier->cale) }}
+                                </div>
+                                <div class="d-flex align-items-center gap-2">
+                                    <a
+                                        class="btn btn-sm btn-outline-primary"
+                                        href="{{ route('facturi-furnizori.facturi.fisiere.vizualizeaza', [$factura, $fisier]) }}"
+                                        target="_blank"
+                                    >
+                                        <i class="fa-solid fa-eye me-1"></i>Vezi
+                                    </a>
+                                    <a
+                                        class="btn btn-sm btn-outline-secondary"
+                                        href="{{ route('facturi-furnizori.facturi.fisiere.descarca', [$factura, $fisier]) }}"
+                                    >
+                                        <i class="fa-solid fa-download me-1"></i>Descarcă
+                                    </a>
+                                </div>
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
+            </div>
+
             <div class="border border-dark rounded-3 p-3 bg-white">
                 <h6 class="text-uppercase text-muted mb-3">Calupuri asociate</h6>
                 @if ($factura->calupuri->isEmpty())

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -259,6 +259,11 @@
                                         <i class="fa-solid fa-boxes-stacked me-1"></i>Gestiune piese
                                     </a>
                                 </li>
+                                <li>
+                                    <a class="dropdown-item" href="{{ route('service-masini.index') }}">
+                                        <i class="fa-solid fa-screwdriver-wrench me-1"></i>Service mașini
+                                    </a>
+                                </li>
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     <a class="dropdown-item" href="{{ route('mesaje-trimise-sms.index') }}">

--- a/resources/views/service/gestiune-piese/index.blade.php
+++ b/resources/views/service/gestiune-piese/index.blade.php
@@ -67,7 +67,7 @@
 
             @if (! $hasTable)
                 <div class="alert alert-warning mx-3" role="alert">
-                    Datele din <code>gestiune_piese</code> nu sunt disponibile în acest mediu.
+                    Datele din <code>service_gestiune_piese</code> nu sunt disponibile în acest mediu.
                 </div>
             @endif
 

--- a/resources/views/service/masini/export.blade.php
+++ b/resources/views/service/masini/export.blade.php
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ro">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Service mașini - {{ $masina->denumire }}</title>
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            font-size: 12px;
+            color: #1a1a1a;
+        }
+
+        h1 {
+            font-size: 20px;
+            margin-bottom: 10px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 15px;
+        }
+
+        th,
+        td {
+            border: 1px solid #ccc;
+            padding: 6px 8px;
+            text-align: left;
+        }
+
+        th {
+            background-color: #f0f0f0;
+        }
+
+        .meta {
+            margin-bottom: 15px;
+        }
+
+        .meta div {
+            margin-bottom: 4px;
+        }
+
+        .small {
+            font-size: 11px;
+            color: #666;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Service mașini</h1>
+
+    <div class="meta">
+        <div><strong>Mașină:</strong> {{ $masina->denumire }} ({{ $masina->numar_inmatriculare }})</div>
+        @if ($masina->serie_sasiu)
+            <div><strong>Serie șasiu:</strong> {{ $masina->serie_sasiu }}</div>
+        @endif
+        @if ($filters['data_start'] ?? null)
+            <div><strong>De la:</strong> {{ \Carbon\Carbon::parse($filters['data_start'])->format('d.m.Y') }}</div>
+        @endif
+        @if ($filters['data_end'] ?? null)
+            <div><strong>Până la:</strong> {{ \Carbon\Carbon::parse($filters['data_end'])->format('d.m.Y') }}</div>
+        @endif
+        @if (($filters['piesa'] ?? '') !== '')
+            <div><strong>Denumire piesă:</strong> {{ $filters['piesa'] }}</div>
+        @endif
+        @if (($filters['cod'] ?? '') !== '')
+            <div><strong>Cod piesă:</strong> {{ $filters['cod'] }}</div>
+        @endif
+        <div class="small">Generat la {{ now()->format('d.m.Y H:i') }}</div>
+    </div>
+
+    <table>
+        <thead>
+            <tr>
+                <th style="width: 80px;">Data</th>
+                <th style="width: 80px;">Tip</th>
+                <th>Denumire</th>
+                <th style="width: 100px;">Cod</th>
+                <th style="width: 80px;">Cantitate</th>
+                <th style="width: 130px;">Mecanic</th>
+                <th style="width: 130px;">Utilizator</th>
+                <th>Observații</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($entries as $entry)
+                <tr>
+                    <td>{{ optional($entry->data_montaj)->format('d.m.Y') ?? '—' }}</td>
+                    <td>{{ $entry->tip === 'piesa' ? 'Piesă' : 'Manual' }}</td>
+                    <td>
+                        @if ($entry->tip === 'piesa')
+                            {{ $entry->denumire_piesa ?? '—' }}
+                        @else
+                            {{ $entry->denumire_interventie ?? '—' }}
+                        @endif
+                    </td>
+                    <td>{{ $entry->tip === 'piesa' ? ($entry->cod_piesa ?? '—') : '—' }}</td>
+                    <td>
+                        @if ($entry->tip === 'piesa')
+                            {{ $entry->cantitate !== null ? number_format((float) $entry->cantitate, 2) : '—' }}
+                        @else
+                            —
+                        @endif
+                    </td>
+                    <td>{{ $entry->nume_mecanic ?? '—' }}</td>
+                    <td>{{ $entry->nume_utilizator ?? optional($entry->user)->name ?? '—' }}</td>
+                    <td>{{ $entry->observatii ?? '—' }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="8" style="text-align: center;">Nu există intervenții pentru filtrul selectat.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/resources/views/service/masini/index.blade.php
+++ b/resources/views/service/masini/index.blade.php
@@ -1,0 +1,505 @@
+@extends('layouts.app')
+
+@php
+    $filters = $filters ?? [];
+    $selectedMasinaId = optional($selectedMasina)->id;
+    $queryParams = collect($filters)
+        ->reject(fn ($value) => $value === null || $value === '')
+        ->toArray();
+    $editingEntry = $editingEntry ?? null;
+    $isEditingEntry = $editingEntry !== null;
+    $formContext = old('form_context');
+    $entryOldMatchesEditing = $isEditingEntry && $formContext === 'entry_update' && (int) old('entry_id') === optional($editingEntry)->id;
+    $useOldForEntry = $formContext === 'entry_store' || $entryOldMatchesEditing;
+    $createMasinaOld = $formContext === 'create_masina';
+@endphp
+
+@section('content')
+    <div class="mx-3 px-3 card mx-auto" style="border-radius: 40px 40px 40px 40px;">
+        <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+            <div class="col-lg-3">
+                <span class="badge culoare1 fs-5">
+                    <i class="fa-solid fa-screwdriver-wrench me-1"></i>Service mașini
+                </span>
+            </div>
+            <div class="col-lg-9 mb-2">
+                <form class="needs-validation" novalidate method="GET" action="{{ route('service-masini.index') }}">
+                    <div class="row gy-2 gx-3 align-items-end">
+                        <div class="col-lg-4 col-md-6">
+                            <label for="numar_inmatriculare" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-car me-1"></i>Nr. înmatriculare / Denumire mașină
+                            </label>
+                            <input type="text" class="form-control rounded-3" id="numar_inmatriculare"
+                                name="numar_inmatriculare" placeholder="Ex: B00ABC"
+                                value="{{ $filters['numar_inmatriculare'] ?? '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="piesa" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-puzzle-piece me-1"></i>Denumire piesă / intervenție
+                            </label>
+                            <input type="text" class="form-control rounded-3" id="piesa" name="piesa"
+                                placeholder="Ex: Filtru ulei"
+                                value="{{ $filters['piesa'] ?? '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="cod" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-barcode me-1"></i>Cod piesă
+                            </label>
+                            <input type="text" class="form-control rounded-3" id="cod" name="cod"
+                                placeholder="Cod piesă" value="{{ $filters['cod'] ?? '' }}" autocomplete="off">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="data_start" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-calendar-day me-1"></i>De la data
+                            </label>
+                            <input type="date" class="form-control rounded-3" id="data_start" name="data_start"
+                                value="{{ $filters['data_start'] ?? '' }}">
+                        </div>
+                        <div class="col-lg-4 col-md-6">
+                            <label for="data_end" class="form-label small text-muted mb-1">
+                                <i class="fa-solid fa-calendar-check me-1"></i>Până la data
+                            </label>
+                            <input type="date" class="form-control rounded-3" id="data_end" name="data_end"
+                                value="{{ $filters['data_end'] ?? '' }}">
+                        </div>
+                        <div class="col-lg-4 col-md-6 d-flex gap-2">
+                            <button class="btn btn-sm btn-primary text-white flex-grow-1 border border-dark rounded-3"
+                                type="submit">
+                                <i class="fas fa-search text-white me-1"></i>Caută
+                            </button>
+                            <a class="btn btn-sm btn-secondary text-white flex-grow-1 border border-dark rounded-3"
+                                href="{{ route('service-masini.index') }}">
+                                <i class="far fa-trash-alt text-white me-1"></i>Resetează
+                            </a>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="card-body">
+            @include('errors')
+
+            @if ($errors->has('general'))
+                <div class="alert alert-danger" role="alert">
+                    {{ $errors->first('general') }}
+                </div>
+            @endif
+
+            <div class="row g-4">
+                <div class="col-lg-4">
+                    <div class="card h-100 shadow-sm border-0">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold"><i class="fa-solid fa-car-side me-1"></i>Mașini</span>
+                        </div>
+                        <div class="card-body">
+                            <div class="list-group mb-4" style="max-height: 320px; overflow-y: auto;">
+                                @forelse ($masini as $masina)
+                                    @php
+                                        $masinaQuery = $queryParams;
+                                        $masinaQuery['masina_id'] = $masina->id;
+                                    @endphp
+                                    <a href="{{ route('service-masini.index', $masinaQuery) }}"
+                                        class="list-group-item list-group-item-action rounded-3 mb-2 {{ $selectedMasinaId === $masina->id ? 'active text-white' : '' }}">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div>
+                                                <div class="fw-semibold">{{ $masina->denumire }}</div>
+                                                <small class="text-muted {{ $selectedMasinaId === $masina->id ? 'text-white-50' : '' }}">
+                                                    {{ $masina->numar_inmatriculare }}
+                                                </small>
+                                            </div>
+                                            <i class="fa-solid fa-chevron-right small"></i>
+                                        </div>
+                                    </a>
+                                @empty
+                                    <div class="text-center text-muted py-4">
+                                        Nu există mașini adăugate momentan.
+                                    </div>
+                                @endforelse
+                            </div>
+
+                            <h6 class="fw-semibold mb-3"><i class="fa-solid fa-plus-circle me-1"></i>Adaugă mașină</h6>
+                            <form method="POST" action="{{ route('service-masini.store-masina') }}" class="row g-2">
+                                @csrf
+                                <input type="hidden" name="form_context" value="create_masina">
+                                <div class="col-12">
+                                    <label for="denumire" class="form-label small text-muted mb-1">Denumire mașină <span class="text-danger">*</span></label>
+                                    <input type="text" name="denumire" id="denumire" class="form-control rounded-3"
+                                        value="{{ $createMasinaOld ? old('denumire') : '' }}" required>
+                                    @if ($createMasinaOld && $errors->has('denumire'))
+                                        <div class="text-danger small mt-1">{{ $errors->first('denumire') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-12">
+                                    <label for="numar_inmatriculare_form" class="form-label small text-muted mb-1">Nr.
+                                        înmatriculare <span class="text-danger">*</span></label>
+                                    <input type="text" name="numar_inmatriculare" id="numar_inmatriculare_form"
+                                        class="form-control rounded-3" value="{{ $createMasinaOld ? old('numar_inmatriculare') : '' }}" required>
+                                    @if ($createMasinaOld && $errors->has('numar_inmatriculare'))
+                                        <div class="text-danger small mt-1">{{ $errors->first('numar_inmatriculare') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-12">
+                                    <label for="serie_sasiu" class="form-label small text-muted mb-1">Serie șasiu</label>
+                                    <input type="text" name="serie_sasiu" id="serie_sasiu" class="form-control rounded-3"
+                                        value="{{ $createMasinaOld ? old('serie_sasiu') : '' }}">
+                                    @if ($createMasinaOld && $errors->has('serie_sasiu'))
+                                        <div class="text-danger small mt-1">{{ $errors->first('serie_sasiu') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-12">
+                                    <label for="observatii" class="form-label small text-muted mb-1">Observații</label>
+                                    <textarea name="observatii" id="observatii" rows="2" class="form-control rounded-3">{{ $createMasinaOld ? old('observatii') : '' }}</textarea>
+                                    @if ($createMasinaOld && $errors->has('observatii'))
+                                        <div class="text-danger small mt-1">{{ $errors->first('observatii') }}</div>
+                                    @endif
+                                </div>
+                                <div class="col-12 d-grid">
+                                    <button type="submit" class="btn btn-sm btn-success rounded-3">
+                                        <i class="fa-solid fa-save me-1"></i>Salvează mașina
+                                    </button>
+                                </div>
+                            </form>
+
+                            @if ($selectedMasina)
+                                @php
+                                    $updateMasinaOld = $formContext === 'update_masina' && (int) old('masina_id') === $selectedMasinaId;
+                                @endphp
+                                <hr class="my-4">
+                                <h6 class="fw-semibold mb-3"><i class="fa-solid fa-pen-to-square me-1"></i>Editează mașina selectată</h6>
+                                <form method="POST" action="{{ route('service-masini.update-masina', $selectedMasina) }}" class="row g-2">
+                                    @csrf
+                                    @method('PUT')
+                                    <input type="hidden" name="form_context" value="update_masina">
+                                    <input type="hidden" name="masina_id" value="{{ $selectedMasinaId }}">
+                                    <div class="col-12">
+                                        <label for="denumire_edit" class="form-label small text-muted mb-1">Denumire mașină <span class="text-danger">*</span></label>
+                                        <input type="text" name="denumire" id="denumire_edit" class="form-control rounded-3"
+                                            value="{{ $updateMasinaOld ? old('denumire') : $selectedMasina->denumire }}" required>
+                                        @if ($updateMasinaOld && $errors->has('denumire'))
+                                            <div class="text-danger small mt-1">{{ $errors->first('denumire') }}</div>
+                                        @endif
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="numar_inmatriculare_edit" class="form-label small text-muted mb-1">Nr. înmatriculare <span class="text-danger">*</span></label>
+                                        <input type="text" name="numar_inmatriculare" id="numar_inmatriculare_edit"
+                                            class="form-control rounded-3"
+                                            value="{{ $updateMasinaOld ? old('numar_inmatriculare') : $selectedMasina->numar_inmatriculare }}"
+                                            required>
+                                        @if ($updateMasinaOld && $errors->has('numar_inmatriculare'))
+                                            <div class="text-danger small mt-1">{{ $errors->first('numar_inmatriculare') }}</div>
+                                        @endif
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="serie_sasiu_edit" class="form-label small text-muted mb-1">Serie șasiu</label>
+                                        <input type="text" name="serie_sasiu" id="serie_sasiu_edit" class="form-control rounded-3"
+                                            value="{{ $updateMasinaOld ? old('serie_sasiu') : $selectedMasina->serie_sasiu }}">
+                                        @if ($updateMasinaOld && $errors->has('serie_sasiu'))
+                                            <div class="text-danger small mt-1">{{ $errors->first('serie_sasiu') }}</div>
+                                        @endif
+                                    </div>
+                                    <div class="col-12">
+                                        <label for="observatii_edit" class="form-label small text-muted mb-1">Observații</label>
+                                        <textarea name="observatii" id="observatii_edit" rows="2" class="form-control rounded-3">{{ $updateMasinaOld ? old('observatii') : $selectedMasina->observatii }}</textarea>
+                                        @if ($updateMasinaOld && $errors->has('observatii'))
+                                            <div class="text-danger small mt-1">{{ $errors->first('observatii') }}</div>
+                                        @endif
+                                    </div>
+                                    @foreach ($filters as $key => $value)
+                                        @if ($value !== null && $value !== '')
+                                            <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                        @endif
+                                    @endforeach
+                                    <div class="col-12 d-grid">
+                                        <button type="submit" class="btn btn-sm btn-primary rounded-3">
+                                            <i class="fa-solid fa-rotate me-1"></i>Actualizează mașina
+                                        </button>
+                                    </div>
+                                </form>
+
+                                <form method="POST" action="{{ route('service-masini.destroy-masina', $selectedMasina) }}" class="mt-3"
+                                    onsubmit="return confirm('Ești sigur că vrei să ștergi această mașină și intervențiile asociate?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    @foreach ($filters as $key => $value)
+                                        @if ($value !== null && $value !== '')
+                                            <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                        @endif
+                                    @endforeach
+                                    <button type="submit" class="btn btn-sm btn-outline-danger w-100 rounded-3">
+                                        <i class="fa-solid fa-trash-can me-1"></i>Șterge mașina
+                                    </button>
+                                </form>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-lg-8">
+                    @if ($selectedMasina)
+                        <div class="card shadow-sm border-0 mb-4">
+                            <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+                                <div>
+                                    <h5 class="mb-0">{{ $selectedMasina->denumire }}</h5>
+                                    <small class="text-muted">Nr. înmatriculare: {{ $selectedMasina->numar_inmatriculare }}</small>
+                                </div>
+                                <a class="btn btn-outline-primary btn-sm rounded-3"
+                                    href="{{ route('service-masini.export', $queryParams + ['masina_id' => $selectedMasina->id]) }}">
+                                    <i class="fa-solid fa-file-pdf me-1"></i>Descarcă PDF
+                                </a>
+                            </div>
+                            <div class="card-body">
+                                @php
+                                    $entryFormAction = $isEditingEntry
+                                        ? route('service-masini.entries.update', [$selectedMasina, $editingEntry])
+                                        : route('service-masini.entries.store', $selectedMasina);
+                                    $defaultTip = $isEditingEntry ? $editingEntry->tip : 'piesa';
+                                    $defaultCantitate = $isEditingEntry && $editingEntry->cantitate !== null
+                                        ? number_format((float) $editingEntry->cantitate, 2, '.', '')
+                                        : '1';
+                                @endphp
+                                <form method="POST" action="{{ $entryFormAction }}" class="row g-3" id="service-entry-form">
+                                    @csrf
+                                    @if ($isEditingEntry)
+                                        @method('PUT')
+                                    @endif
+                                    @foreach ($filters as $key => $value)
+                                        @if ($value !== null && $value !== '')
+                                            <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                        @endif
+                                    @endforeach
+                                    <input type="hidden" name="form_context" value="{{ $isEditingEntry ? 'entry_update' : 'entry_store' }}">
+                                    @if ($isEditingEntry)
+                                        <input type="hidden" name="entry_id" value="{{ $editingEntry->id }}">
+                                    @endif
+
+                                    <div class="col-12">
+                                        <label class="form-label small text-muted mb-1">Tip intervenție <span class="text-danger">*</span></label>
+                                        <div class="d-flex gap-3">
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="tip" id="tip_piesa"
+                                                    value="piesa"
+                                                    {{ ($useOldForEntry ? old('tip', $defaultTip) : $defaultTip) === 'piesa' ? 'checked' : '' }}>
+                                                <label class="form-check-label" for="tip_piesa">
+                                                    Alocare piesă din gestiune
+                                                </label>
+                                            </div>
+                                            <div class="form-check">
+                                                <input class="form-check-input" type="radio" name="tip" id="tip_manual"
+                                                    value="manual"
+                                                    {{ ($useOldForEntry ? old('tip', $defaultTip) : $defaultTip) === 'manual' ? 'checked' : '' }}>
+                                                <label class="form-check-label" for="tip_manual">
+                                                    Intervenție manuală
+                                                </label>
+                                            </div>
+                                        </div>
+                                        @error('tip')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6" data-entry="piesa">
+                                        <label for="gestiune_piesa_id" class="form-label small text-muted mb-1">Piesă <span class="text-danger">*</span>
+                                            <small class="text-muted">(pentru alocări din gestiune)</small>
+                                        </label>
+                                        @php
+                                            $selectedPiece = $useOldForEntry ? (int) old('gestiune_piesa_id') : ($isEditingEntry ? (int) $editingEntry->gestiune_piesa_id : null);
+                                        @endphp
+                                        <select name="gestiune_piesa_id" id="gestiune_piesa_id"
+                                            class="form-select rounded-3">
+                                            <option value="">Selectează piesa</option>
+                                            @foreach ($availablePieces as $piesa)
+                                                <option value="{{ $piesa->id }}" @selected($selectedPiece === $piesa->id)>
+                                                    {{ $piesa->denumire }} ({{ $piesa->cod }}) - {{ number_format((float) $piesa->nr_bucati, 2) }} buc
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                        @error('gestiune_piesa_id')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-3" data-entry="piesa">
+                                        <label for="cantitate" class="form-label small text-muted mb-1">Cantitate <span class="text-danger">*</span>
+                                            <small class="text-muted">(pentru alocări din gestiune)</small>
+                                        </label>
+                                        <input type="number" step="0.01" min="0" class="form-control rounded-3"
+                                            id="cantitate" name="cantitate"
+                                            value="{{ $useOldForEntry ? old('cantitate') : $defaultCantitate }}">
+                                        @error('cantitate')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6" data-entry="manual">
+                                        <label for="denumire_interventie" class="form-label small text-muted mb-1">Denumire
+                                            intervenție <span class="text-danger">*</span>
+                                            <small class="text-muted">(pentru intervenții manuale)</small>
+                                        </label>
+                                        <input type="text" class="form-control rounded-3" id="denumire_interventie"
+                                            name="denumire_interventie"
+                                            value="{{ $useOldForEntry ? old('denumire_interventie') : ($isEditingEntry ? $editingEntry->denumire_interventie : '') }}">
+                                        @error('denumire_interventie')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6">
+                                        <label for="data_montaj" class="form-label small text-muted mb-1">Data intervenției <span class="text-danger">*</span></label>
+                                        <input type="date" class="form-control rounded-3" id="data_montaj" name="data_montaj"
+                                            value="{{ $useOldForEntry ? old('data_montaj') : ($isEditingEntry ? optional($editingEntry->data_montaj)->toDateString() : now()->toDateString()) }}"
+                                            required>
+                                        @error('data_montaj')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-md-6">
+                                        <label for="nume_mecanic" class="form-label small text-muted mb-1">Nume mecanic <span class="text-danger">*</span></label>
+                                        <input type="text" class="form-control rounded-3" id="nume_mecanic" name="nume_mecanic"
+                                            value="{{ $useOldForEntry ? old('nume_mecanic') : ($isEditingEntry ? $editingEntry->nume_mecanic : '') }}" required>
+                                        @error('nume_mecanic')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12">
+                                        <label for="observatii_interventie" class="form-label small text-muted mb-1">Observații</label>
+                                        <textarea name="observatii" id="observatii_interventie" rows="3" class="form-control rounded-3">{{ $useOldForEntry ? old('observatii') : ($isEditingEntry ? $editingEntry->observatii : '') }}</textarea>
+                                        @error('observatii')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div class="col-12 d-flex justify-content-end gap-2">
+                                        @if ($isEditingEntry)
+                                            <a class="btn btn-outline-secondary rounded-3"
+                                                href="{{ route('service-masini.index', $queryParams + ['masina_id' => $selectedMasina->id]) }}">
+                                                Renunță
+                                            </a>
+                                        @endif
+                                        <button type="submit" class="btn btn-primary rounded-3">
+                                            <i class="fa-solid fa-paper-plane me-1"></i>{{ $isEditingEntry ? 'Actualizează intervenția' : 'Salvează intervenția' }}
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+
+                        <div class="card shadow-sm border-0">
+                            <div class="card-header">
+                                <h6 class="mb-0"><i class="fa-solid fa-clipboard-list me-1"></i>Istoric intervenții</h6>
+                            </div>
+                            <div class="table-responsive">
+                                <table class="table table-striped table-hover mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th style="min-width: 110px;">Data</th>
+                                            <th style="min-width: 120px;">Tip</th>
+                                            <th style="min-width: 180px;">Denumire</th>
+                                            <th style="min-width: 120px;">Cod</th>
+                                            <th style="min-width: 90px;">Cantitate</th>
+                                            <th style="min-width: 150px;">Mecanic</th>
+                                            <th style="min-width: 150px;">Utilizator</th>
+                                            <th>Observații</th>
+                                            <th class="text-end" style="min-width: 140px;">Acțiuni</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @forelse ($entries as $entry)
+                                            <tr>
+                                                <td>{{ optional($entry->data_montaj)->format('d.m.Y') ?? '—' }}</td>
+                                                <td>
+                                                    @if ($entry->tip === 'piesa')
+                                                        <span class="badge bg-primary">Piesă</span>
+                                                    @else
+                                                        <span class="badge bg-secondary">Manual</span>
+                                                    @endif
+                                                </td>
+                                                <td>
+                                                    @if ($entry->tip === 'piesa')
+                                                        {{ $entry->denumire_piesa ?? '—' }}
+                                                    @else
+                                                        {{ $entry->denumire_interventie ?? '—' }}
+                                                    @endif
+                                                </td>
+                                                <td>{{ $entry->tip === 'piesa' ? ($entry->cod_piesa ?? '—') : '—' }}</td>
+                                                <td>
+                                                    @if ($entry->tip === 'piesa')
+                                                        {{ $entry->cantitate !== null ? number_format((float) $entry->cantitate, 2) : '—' }}
+                                                    @else
+                                                        —
+                                                    @endif
+                                                </td>
+                                                <td>{{ $entry->nume_mecanic ?? '—' }}</td>
+                                                <td>{{ $entry->nume_utilizator ?? optional($entry->user)->name ?? '—' }}</td>
+                                                <td class="text-wrap" style="max-width: 220px;">{{ $entry->observatii ?? '—' }}</td>
+                                                <td class="text-end">
+                                                    <div class="d-flex justify-content-end gap-2">
+                                                        <a class="btn btn-outline-primary btn-sm"
+                                                            href="{{ route('service-masini.index', $queryParams + ['masina_id' => $selectedMasina->id, 'entry_id' => $entry->id]) }}">
+                                                            Editează
+                                                        </a>
+                                                        <form method="POST" class="d-inline"
+                                                            action="{{ route('service-masini.entries.destroy', [$selectedMasina, $entry]) }}"
+                                                            onsubmit="return confirm('Sigur dorești să ștergi această intervenție?');">
+                                                            @csrf
+                                                            @method('DELETE')
+                                                            @foreach ($filters as $key => $value)
+                                                                @if ($value !== null && $value !== '')
+                                                                    <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                                                @endif
+                                                            @endforeach
+                                                            <button type="submit" class="btn btn-outline-danger btn-sm">Șterge</button>
+                                                        </form>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        @empty
+                                            <tr>
+                                                <td colspan="9" class="text-center text-muted py-4">
+                                                    Nu există intervenții pentru această mașină.
+                                                </td>
+                                            </tr>
+                                        @endforelse
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="card-footer">
+                                {{ $entries->links() }}
+                            </div>
+                        </div>
+                    @else
+                        <div class="alert alert-info" role="alert">
+                            Adaugă o mașină pentru a începe să înregistrezi intervenții.
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('page-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            function toggleEntryFields() {
+                const selectedType = document.querySelector('input[name="tip"]:checked')?.value || 'piesa';
+
+                document.querySelectorAll('#service-entry-form [data-entry="piesa"]').forEach(function (element) {
+                    element.classList.toggle('d-none', selectedType !== 'piesa');
+                });
+
+                document.querySelectorAll('#service-entry-form [data-entry="manual"]').forEach(function (element) {
+                    element.classList.toggle('d-none', selectedType !== 'manual');
+                });
+            }
+
+            document.querySelectorAll('input[name="tip"]').forEach(function (radio) {
+                radio.addEventListener('change', toggleEntryFields);
+            });
+
+            toggleEntryFields();
+        });
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,8 +31,10 @@ use App\Http\Controllers\DocumentWordController;
 use App\Http\Controllers\KeyPerformanceIndicatorController;
 use App\Http\Controllers\OfertaCursaController;
 use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorController;
+use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorFisierController;
 use App\Http\Controllers\FacturiFurnizori\PlataCalupController;
-use App\Http\Controllers\GestiunePieseController;
+use App\Http\Controllers\Service\GestiunePieseController;
+use App\Http\Controllers\Service\ServiceMasiniController;
 use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\SeederCenterController;
@@ -169,6 +171,23 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('/gestiune-piese', [GestiunePieseController::class, 'index'])
         ->name('gestiune-piese.index');
 
+    Route::get('/service-masini', [ServiceMasiniController::class, 'index'])
+        ->name('service-masini.index');
+    Route::post('/service-masini', [ServiceMasiniController::class, 'storeMasina'])
+        ->name('service-masini.store-masina');
+    Route::put('/service-masini/{masina}', [ServiceMasiniController::class, 'updateMasina'])
+        ->name('service-masini.update-masina');
+    Route::delete('/service-masini/{masina}', [ServiceMasiniController::class, 'destroyMasina'])
+        ->name('service-masini.destroy-masina');
+    Route::post('/service-masini/{masina}/entries', [ServiceMasiniController::class, 'storeEntry'])
+        ->name('service-masini.entries.store');
+    Route::put('/service-masini/{masina}/entries/{entry}', [ServiceMasiniController::class, 'updateEntry'])
+        ->name('service-masini.entries.update');
+    Route::delete('/service-masini/{masina}/entries/{entry}', [ServiceMasiniController::class, 'destroyEntry'])
+        ->name('service-masini.entries.destroy');
+    Route::get('/service-masini/export/pdf', [ServiceMasiniController::class, 'export'])
+        ->name('service-masini.export');
+
 
     Route::get('/rapoarte/incasari-utilizatori', [RaportController::class, 'incasariUtilizatori']);
     Route::get('/rapoarte/documente-transportatori', [RaportController::class, 'documenteTransportatori']);
@@ -213,6 +232,15 @@ Route::group(['middleware' => 'auth'], function () {
 
             Route::resource('facturi', FacturaFurnizorController::class)
                 ->parameters(['facturi' => 'factura']);
+
+            Route::get('facturi/{factura}/fisiere/{fisier}/vizualizeaza', [FacturaFurnizorFisierController::class, 'vizualizeaza'])
+                ->name('facturi.fisiere.vizualizeaza');
+
+            Route::get('facturi/{factura}/fisiere/{fisier}/descarca', [FacturaFurnizorFisierController::class, 'descarca'])
+                ->name('facturi.fisiere.descarca');
+
+            Route::delete('facturi/{factura}/fisiere/{fisier}', [FacturaFurnizorFisierController::class, 'destroy'])
+                ->name('facturi.fisiere.destroy');
 
             Route::resource('plati-calupuri', PlataCalupController::class)
                 ->parameters(['plati-calupuri' => 'plataCalup']);

--- a/tests/Feature/Service/GestiunePieseTest.php
+++ b/tests/Feature/Service/GestiunePieseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature;
+namespace Tests\Feature\Service;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -18,6 +18,6 @@ class GestiunePieseTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Gestiune piese');
-        $response->assertSee('gestiune_piese nu sunt disponibile');
+        $response->assertSee('service_gestiune_piese nu sunt disponibile');
     }
 }

--- a/tests/Feature/Service/ServiceMasiniTest.php
+++ b/tests/Feature/Service/ServiceMasiniTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Feature\Service;
+
+use App\Models\Service\GestiunePiesa;
+use App\Models\Service\Masina;
+use App\Models\Service\MasinaServiceEntry;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServiceMasiniTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_displays_masini(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create(['denumire' => 'Camion Test', 'numar_inmatriculare' => 'B01ABC']);
+
+        $response = $this->actingAs($user)->get(route('service-masini.index', ['masina_id' => $masina->id]));
+
+        $response->assertOk();
+        $response->assertSee('Service mașini');
+        $response->assertSee('Camion Test');
+    }
+
+    public function test_it_creates_a_new_masina(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('service-masini.store-masina'), [
+            'denumire' => 'Duba Test',
+            'numar_inmatriculare' => 'CT09XYZ',
+            'serie_sasiu' => 'SERIE1234567',
+            'observatii' => 'Test observatii',
+        ]);
+
+        $masina = Masina::query()->first();
+
+        $response->assertRedirect(route('service-masini.index', ['masina_id' => $masina->id]));
+        $this->assertDatabaseHas('service_masini', [
+            'denumire' => 'Duba Test',
+            'numar_inmatriculare' => 'CT09XYZ',
+        ]);
+    }
+
+    public function test_it_allocates_piece_and_decrements_stock(): void
+    {
+        $user = User::factory()->create(['name' => 'Test User']);
+        $masina = Masina::factory()->create();
+        $piesa = GestiunePiesa::factory()->create(['nr_bucati' => 5]);
+
+        $response = $this->actingAs($user)->post(route('service-masini.entries.store', $masina), [
+            'tip' => 'piesa',
+            'gestiune_piesa_id' => $piesa->id,
+            'cantitate' => 2,
+            'data_montaj' => now()->toDateString(),
+            'nume_mecanic' => 'Ion Mecanic',
+            'observatii' => 'Test piesă',
+        ]);
+
+        $response->assertRedirect();
+
+        $entry = MasinaServiceEntry::query()->first();
+        $this->assertNotNull($entry);
+        $this->assertSame('piesa', $entry->tip);
+        $this->assertSame($masina->id, $entry->masina_id);
+        $this->assertSame($piesa->id, $entry->gestiune_piesa_id);
+        $this->assertSame('Ion Mecanic', $entry->nume_mecanic);
+        $this->assertSame('Test User', $entry->nume_utilizator);
+        $this->assertEquals(2.0, (float) $entry->cantitate);
+
+        $piesa->refresh();
+        $this->assertEquals(3.0, (float) $piesa->nr_bucati);
+    }
+
+    public function test_it_stores_manual_intervention(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('service-masini.entries.store', $masina), [
+            'tip' => 'manual',
+            'denumire_interventie' => 'Schimb ulei',
+            'data_montaj' => now()->toDateString(),
+            'nume_mecanic' => 'Mecanic Test',
+            'observatii' => 'Ulei 5W40',
+        ]);
+
+        $response->assertRedirect();
+
+        $this->assertDatabaseHas('service_masina_service_entries', [
+            'masina_id' => $masina->id,
+            'tip' => 'manual',
+            'denumire_interventie' => 'Schimb ulei',
+        ]);
+    }
+
+    public function test_it_exports_pdf(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        MasinaServiceEntry::factory()->create([
+            'masina_id' => $masina->id,
+            'tip' => 'manual',
+            'denumire_interventie' => 'Verificare lumini',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('service-masini.export', ['masina_id' => $masina->id]));
+
+        $response->assertOk();
+        $this->assertStringContainsString('application/pdf', $response->headers->get('content-type'));
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Service Mașini controller to support updating and deleting vehicles and interventions while keeping inventory counts in sync
- add dedicated request classes that share validation for creating/updating interventions and enforce unique license plates when editing vehicles
- refresh the Service Mașini blade view to expose edit/delete actions, reuse the intervention form for updates, and clean up duplicate status messaging
- register RESTful routes for the new update/destroy actions

## Testing
- `php -l app/Http/Controllers/Service/ServiceMasiniController.php`
- `php -l app/Http/Requests/Service/MasinaServiceEntryRequest.php`
- `php -l app/Http/Requests/Service/StoreMasinaServiceEntryRequest.php`
- `php -l app/Http/Requests/Service/UpdateMasinaRequest.php`
- `php -l app/Http/Requests/Service/UpdateMasinaServiceEntryRequest.php`


------
https://chatgpt.com/codex/tasks/task_e_68ef532dd76883268836b2f0fdc2ce05