### PR TITLE
Add VAT-aware product pricing and navigation links across operations

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
@@ -48,6 +48,7 @@ class FacturaFurnizorController extends Controller
             'furnizor' => $request->string('furnizor')->toString() ?: null,
             'departament' => $request->string('departament')->toString() ?: null,
             'moneda' => $request->string('moneda')->toString() ?: null,
+            'numar_factura' => $request->string('numar_factura')->toString() ?: null,
             'scadenta_de_la' => $request->string('scadenta_de_la')->toString() ?: null,
             'scadenta_pana' => $request->string('scadenta_pana')->toString() ?: null,
             'calup' => $request->string('calup')->toString() ?: null,
@@ -67,6 +68,10 @@ class FacturaFurnizorController extends Controller
 
         if ($filters['moneda']) {
             $query->where('moneda', strtoupper($filters['moneda']));
+        }
+
+        if ($filters['numar_factura']) {
+            $query->where('numar_factura', $filters['numar_factura']);
         }
 
         if ($filters['scadenta_de_la']) {
@@ -278,8 +283,11 @@ class FacturaFurnizorController extends Controller
                 $pret = isset($row['pret']) && $row['pret'] !== ''
                     ? round((float) $row['pret'], 2)
                     : null;
+                $tvaCota = isset($row['tva_cota']) && $row['tva_cota'] !== ''
+                    ? round((float) $row['tva_cota'], 2)
+                    : null;
 
-                if ($denumire === '' && $cod === '' && $nrBucati === null && $pret === null) {
+                if ($denumire === '' && $cod === '' && $nrBucati === null && $pret === null && $tvaCota === null) {
                     return null;
                 }
 
@@ -287,11 +295,26 @@ class FacturaFurnizorController extends Controller
                     return null;
                 }
 
+                $valoareTva = null;
+                $pretBrut = null;
+
+                if ($pret !== null && $tvaCota !== null) {
+                    $rate = $tvaCota / 100;
+                    $quantityForCalc = $nrBucati !== null && $nrBucati > 0 ? $nrBucati : 1;
+                    $totalNet = round($pret * $quantityForCalc, 2);
+                    $totalTva = round($totalNet * $rate, 2);
+                    $valoareTva = round($quantityForCalc > 0 ? $totalTva / $quantityForCalc : 0, 2);
+                    $pretBrut = round($pret + $valoareTva, 2);
+                }
+
                 return [
                     'denumire' => $denumire,
                     'cod' => $cod !== '' ? $cod : null,
                     'nr_bucati' => $nrBucati,
                     'pret' => $pret,
+                    'tva_cota' => $tvaCota,
+                    'valoare_tva' => $valoareTva,
+                    'pret_brut' => $pretBrut,
                 ];
             })
             ->filter()

--- a/app/Http/Controllers/Service/GestiunePieseController.php
+++ b/app/Http/Controllers/Service/GestiunePieseController.php
@@ -92,19 +92,26 @@ class GestiunePieseController extends Controller
 
                 $sort = $request->query('sort');
                 $direction = strtolower($request->query('direction', 'desc')) === 'asc' ? 'asc' : 'desc';
+                $customSortApplied = false;
 
                 if ($sort === 'factura_data_factura' && $invoiceDateAlias) {
                     $query->orderBy('ff.data_factura', $direction);
+                    $customSortApplied = true;
                 } elseif ($sort && in_array($sort, $columns, true)) {
                     $query->orderBy("gp.$sort", $direction);
-                } elseif ($invoiceDateAlias) {
-                    $query->orderBy('ff.data_factura', 'desc');
-                } elseif (in_array('updated_at', $columns, true)) {
-                    $query->orderBy('gp.updated_at', 'desc');
-                } elseif (in_array('created_at', $columns, true)) {
-                    $query->orderBy('gp.created_at', 'desc');
-                } elseif (in_array('id', $columns, true)) {
-                    $query->orderBy('gp.id', 'desc');
+                    $customSortApplied = true;
+                }
+
+                if (! $customSortApplied) {
+                    if (in_array('nr_bucati', $columns, true)) {
+                        $query->orderByRaw('CASE WHEN gp.nr_bucati IS NULL OR gp.nr_bucati = 0 THEN 1 ELSE 0 END');
+                    }
+
+                    if (in_array('created_at', $columns, true)) {
+                        $query->orderBy('gp.created_at', 'desc');
+                    } elseif (in_array('id', $columns, true)) {
+                        $query->orderBy('gp.id', 'desc');
+                    }
                 }
 
                 $items = $query->simplePaginate(100)->withQueryString();

--- a/app/Http/Requests/FacturiFurnizori/FacturaFurnizorRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/FacturaFurnizorRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\FacturiFurnizori;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Validator;
 
 class FacturaFurnizorRequest extends FormRequest
@@ -37,6 +38,9 @@ class FacturaFurnizorRequest extends FormRequest
             'produse.*.cod' => ['nullable', 'string', 'max:100'],
             'produse.*.nr_bucati' => ['nullable', 'numeric'],
             'produse.*.pret' => ['nullable', 'numeric'],
+            'produse.*.tva_cota' => ['nullable', 'numeric', Rule::in([11, 21])],
+            'produse.*.valoare_tva' => ['nullable', 'numeric'],
+            'produse.*.pret_brut' => ['nullable', 'numeric'],
             'fisiere_pdf' => ['nullable', 'array'],
             'fisiere_pdf.*' => ['file', 'mimes:pdf', 'max:10240'],
         ];
@@ -58,12 +62,24 @@ class FacturaFurnizorRequest extends FormRequest
                 $pret = array_key_exists('pret', $row) && $row['pret'] !== ''
                     ? $row['pret']
                     : null;
+                $tvaCota = array_key_exists('tva_cota', $row) && $row['tva_cota'] !== ''
+                    ? $row['tva_cota']
+                    : null;
+                $valoareTva = array_key_exists('valoare_tva', $row) && $row['valoare_tva'] !== ''
+                    ? $row['valoare_tva']
+                    : null;
+                $pretBrut = array_key_exists('pret_brut', $row) && $row['pret_brut'] !== ''
+                    ? $row['pret_brut']
+                    : null;
 
                 return [
                     'denumire' => $denumire,
                     'cod' => $cod,
                     'nr_bucati' => $nrBucati,
                     'pret' => $pret,
+                    'tva_cota' => $tvaCota,
+                    'valoare_tva' => $valoareTva,
+                    'pret_brut' => $pretBrut,
                 ];
             })
             ->toArray();
@@ -83,10 +99,16 @@ class FacturaFurnizorRequest extends FormRequest
                 $cod = trim((string) ($produs['cod'] ?? ''));
                 $nrBucati = $produs['nr_bucati'] ?? null;
                 $pret = $produs['pret'] ?? null;
+                $tvaCota = $produs['tva_cota'] ?? null;
+                $valoareTva = $produs['valoare_tva'] ?? null;
+                $pretBrut = $produs['pret_brut'] ?? null;
 
                 $hasOtherData = $cod !== ''
                     || ($nrBucati !== null && $nrBucati !== '')
-                    || ($pret !== null && $pret !== '');
+                    || ($pret !== null && $pret !== '')
+                    || ($tvaCota !== null && $tvaCota !== '')
+                    || ($valoareTva !== null && $valoareTva !== '')
+                    || ($pretBrut !== null && $pretBrut !== '');
 
                 if ($hasOtherData && $denumire === '') {
                     $innerValidator->errors()->add("produse.$index.denumire", 'Denumirea produsului este obligatorie.');

--- a/app/Models/Service/GestiunePiesa.php
+++ b/app/Models/Service/GestiunePiesa.php
@@ -19,11 +19,17 @@ class GestiunePiesa extends Model
         'cod',
         'nr_bucati',
         'pret',
+        'tva_cota',
+        'valoare_tva',
+        'pret_brut',
     ];
 
     protected $casts = [
         'nr_bucati' => 'decimal:2',
         'pret' => 'decimal:2',
+        'tva_cota' => 'decimal:2',
+        'valoare_tva' => 'decimal:2',
+        'pret_brut' => 'decimal:2',
     ];
 
     protected static function newFactory()

--- a/database/factories/Service/GestiunePiesaFactory.php
+++ b/database/factories/Service/GestiunePiesaFactory.php
@@ -15,12 +15,20 @@ class GestiunePiesaFactory extends Factory
 
     public function definition(): array
     {
+        $pret = $this->faker->randomFloat(2, 10, 500);
+        $tvaCota = $this->faker->randomElement([11.00, 21.00]);
+        $valoareTva = round($pret * ($tvaCota / 100), 2);
+        $pretBrut = round($pret + $valoareTva, 2);
+
         return [
             'factura_id' => FacturaFurnizor::factory(),
             'denumire' => $this->faker->words(3, true),
             'cod' => strtoupper($this->faker->bothify('PIE###')),
             'nr_bucati' => $this->faker->randomFloat(2, 1, 20),
-            'pret' => $this->faker->randomFloat(2, 10, 500),
+            'pret' => $pret,
+            'tva_cota' => $tvaCota,
+            'valoare_tva' => $valoareTva,
+            'pret_brut' => $pretBrut,
         ];
     }
 }

--- a/database/migrations/2025_03_17_020000_add_tva_columns_to_gestiune_piese_table.php
+++ b/database/migrations/2025_03_17_020000_add_tva_columns_to_gestiune_piese_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('service_gestiune_piese', function (Blueprint $table) {
+            $table->decimal('tva_cota', 5, 2)->nullable()->after('pret');
+            $table->decimal('valoare_tva', 12, 2)->nullable()->after('tva_cota');
+            $table->decimal('pret_brut', 12, 2)->nullable()->after('valoare_tva');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('service_gestiune_piese', function (Blueprint $table) {
+            $table->dropColumn(['tva_cota', 'valoare_tva', 'pret_brut']);
+        });
+    }
+};

--- a/resources/views/facturiFurnizori/facturi/form.blade.php
+++ b/resources/views/facturiFurnizori/facturi/form.blade.php
@@ -9,6 +9,9 @@
             'cod' => $piesa->cod,
             'nr_bucati' => $piesa->nr_bucati,
             'pret' => $piesa->pret,
+            'tva_cota' => $piesa->tva_cota,
+            'valoare_tva' => $piesa->valoare_tva,
+            'pret_brut' => $piesa->pret_brut,
         ];
     })->toArray() ?? []));
     if ($produseColectie->isEmpty()) {
@@ -17,6 +20,9 @@
             'cod' => '',
             'nr_bucati' => '',
             'pret' => '',
+            'tva_cota' => '',
+            'valoare_tva' => '',
+            'pret_brut' => '',
         ]]);
     }
     $produse = $produseColectie->values()->toArray();
@@ -218,10 +224,13 @@
                 <table class="table table-sm table-bordered align-middle mb-0" id="produse-table">
                     <thead class="text-white rounded culoare2">
                         <tr>
-                            <th style="min-width: 220px;">Denumire</th>
+                            <th style="min-width: 200px;">Denumire</th>
                             <th style="min-width: 140px;">Cod</th>
                             <th style="min-width: 120px;">Cantitate</th>
-                            <th style="min-width: 120px;">Preț</th>
+                            <th style="min-width: 120px;">Preț NET/buc</th>
+                            <th style="min-width: 110px;">Cotă TVA</th>
+                            <th style="min-width: 120px;">TVA/buc</th>
+                            <th style="min-width: 140px;">Preț BRUT/buc</th>
                             <th style="width: 70px;" class="text-center">Acțiuni</th>
                         </tr>
                     </thead>
@@ -259,6 +268,7 @@
                                         min="0"
                                         name="produse[{{ $index }}][nr_bucati]"
                                         class="form-control form-control-sm {{ $errors->has('produse.' . $index . '.nr_bucati') ? 'is-invalid' : '' }}"
+                                        data-produs-field="quantity"
                                         value="{{ $produs['nr_bucati'] }}"
                                         placeholder="0"
                                     >
@@ -272,10 +282,57 @@
                                         step="0.01"
                                         name="produse[{{ $index }}][pret]"
                                         class="form-control form-control-sm {{ $errors->has('produse.' . $index . '.pret') ? 'is-invalid' : '' }}"
+                                        data-produs-field="net-price"
                                         value="{{ $produs['pret'] }}"
                                         placeholder="0.00"
                                     >
                                     @error('produse.' . $index . '.pret')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td>
+                                    <select
+                                        name="produse[{{ $index }}][tva_cota]"
+                                        class="form-select form-select-sm {{ $errors->has('produse.' . $index . '.tva_cota') ? 'is-invalid' : '' }}"
+                                        data-produs-field="tva-rate"
+                                    >
+                                        <option value="">Cotă TVA</option>
+                                        <option value="11" @selected((float) ($produs['tva_cota'] ?? 0) === 11.0)>11%</option>
+                                        <option value="21" @selected((float) ($produs['tva_cota'] ?? 0) === 21.0)>21%</option>
+                                    </select>
+                                    @error('produse.' . $index . '.tva_cota')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        name="produse[{{ $index }}][valoare_tva]"
+                                        class="form-control form-control-sm bg-light {{ $errors->has('produse.' . $index . '.valoare_tva') ? 'is-invalid' : '' }}"
+                                        data-produs-field="tva-value"
+                                        value="{{ $produs['valoare_tva'] }}"
+                                        placeholder="0.00"
+                                        readonly
+                                        tabindex="-1"
+                                    >
+                                    @error('produse.' . $index . '.valoare_tva')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </td>
+                                <td>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        name="produse[{{ $index }}][pret_brut]"
+                                        class="form-control form-control-sm bg-light {{ $errors->has('produse.' . $index . '.pret_brut') ? 'is-invalid' : '' }}"
+                                        data-produs-field="gross-price"
+                                        value="{{ $produs['pret_brut'] }}"
+                                        placeholder="0.00"
+                                        readonly
+                                        tabindex="-1"
+                                    >
+                                    @error('produse.' . $index . '.pret_brut')
                                         <div class="invalid-feedback">{{ $message }}</div>
                                     @enderror
                                 </td>
@@ -315,6 +372,7 @@
                             min="0"
                             name="produse[__INDEX__][nr_bucati]"
                             class="form-control form-control-sm"
+                            data-produs-field="quantity"
                             placeholder="0"
                         >
                     </td>
@@ -324,7 +382,43 @@
                             step="0.01"
                             name="produse[__INDEX__][pret]"
                             class="form-control form-control-sm"
+                            data-produs-field="net-price"
                             placeholder="0.00"
+                        >
+                    </td>
+                    <td>
+                        <select
+                            name="produse[__INDEX__][tva_cota]"
+                            class="form-select form-select-sm"
+                            data-produs-field="tva-rate"
+                        >
+                            <option value="">Cotă TVA</option>
+                            <option value="11">11%</option>
+                            <option value="21">21%</option>
+                        </select>
+                    </td>
+                    <td>
+                        <input
+                            type="number"
+                            step="0.01"
+                            name="produse[__INDEX__][valoare_tva]"
+                            class="form-control form-control-sm bg-light"
+                            data-produs-field="tva-value"
+                            placeholder="0.00"
+                            readonly
+                            tabindex="-1"
+                        >
+                    </td>
+                    <td>
+                        <input
+                            type="number"
+                            step="0.01"
+                            name="produse[__INDEX__][pret_brut]"
+                            class="form-control form-control-sm bg-light"
+                            data-produs-field="gross-price"
+                            placeholder="0.00"
+                            readonly
+                            tabindex="-1"
                         >
                     </td>
                     <td class="text-center">
@@ -360,6 +454,60 @@
                 return;
             }
 
+            const roundTwo = (value) => Math.round(value * 100) / 100;
+
+            const formatNumber = (value) => {
+                if (!Number.isFinite(value)) {
+                    return '';
+                }
+
+                return value.toFixed(2);
+            };
+
+            const recalculateRow = (row) => {
+                const quantityInput = row.querySelector('[data-produs-field="quantity"]');
+                const netPriceInput = row.querySelector('[data-produs-field="net-price"]');
+                const tvaRateSelect = row.querySelector('[data-produs-field="tva-rate"]');
+                const tvaValueInput = row.querySelector('[data-produs-field="tva-value"]');
+                const grossPriceInput = row.querySelector('[data-produs-field="gross-price"]');
+
+                if (!netPriceInput || !tvaRateSelect || !tvaValueInput || !grossPriceInput) {
+                    return;
+                }
+
+                const netPrice = Number.parseFloat(netPriceInput.value);
+                const tvaRate = Number.parseFloat(tvaRateSelect.value);
+                const quantity = quantityInput ? Number.parseFloat(quantityInput.value) : NaN;
+
+                if (!Number.isFinite(netPrice) || !Number.isFinite(tvaRate)) {
+                    tvaValueInput.value = '';
+                    grossPriceInput.value = '';
+                    return;
+                }
+
+                const qtyForCalc = Number.isFinite(quantity) && quantity > 0 ? quantity : 1;
+                const totalNet = roundTwo(netPrice * qtyForCalc);
+                const totalTva = roundTwo(totalNet * (tvaRate / 100));
+                const tvaPerUnit = roundTwo(qtyForCalc > 0 ? totalTva / qtyForCalc : 0);
+                const grossPerUnit = roundTwo(netPrice + tvaPerUnit);
+
+                tvaValueInput.value = formatNumber(tvaPerUnit);
+                grossPriceInput.value = formatNumber(grossPerUnit);
+            };
+
+            const attachRowListeners = (row) => {
+                const inputs = row.querySelectorAll('[data-produs-field="quantity"], [data-produs-field="net-price"], [data-produs-field="tva-rate"]');
+
+                inputs.forEach((input) => {
+                    input.addEventListener('input', () => recalculateRow(row));
+                    input.addEventListener('change', () => recalculateRow(row));
+                });
+
+                recalculateRow(row);
+            };
+
+            produseTableBody.querySelectorAll('tr[data-index]').forEach(attachRowListeners);
+
             const getNextIndex = () => {
                 const indexes = Array.from(produseTableBody.querySelectorAll('tr[data-index]'))
                     .map((row) => Number.parseInt(row.getAttribute('data-index') ?? '0', 10));
@@ -375,6 +523,11 @@
                 const newIndex = getNextIndex();
                 const html = template.innerHTML.replace(/__INDEX__/g, String(newIndex));
                 produseTableBody.insertAdjacentHTML('beforeend', html);
+                const newRow = produseTableBody.querySelector(`tr[data-index="${newIndex}"]`);
+
+                if (newRow) {
+                    attachRowListeners(newRow);
+                }
             });
 
             produseTableBody.addEventListener('click', (event) => {

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -21,7 +21,7 @@
                 <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi furnizori
             </span>
         </div>
-        <div class="col-lg-8 mb-0" id="formularFacturi">
+        <div class="col-lg-7 mb-0" id="formularFacturi">
             <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ url()->current() }}">
                 <div class="row gy-1 gx-4 mb-2 custom-search-form d-flex justify-content-center">
                     <div class="col-lg-2 col-md-6">
@@ -66,6 +66,20 @@
                             >
                         </div>
                         <datalist id="filter-departament-suggestions"></datalist>
+                    </div>
+                    <div class="col-lg-2 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-hashtag text-muted" title="Caută după număr factură"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-numar-factura"
+                                name="numar_factura"
+                                placeholder="Număr factură"
+                                value="{{ $filters['numar_factura'] }}"
+                                autocomplete="off"
+                            >
+                        </div>
                     </div>
                     <div class="col-lg-2 col-md-6">
                         <select name="moneda" id="filter-moneda" class="form-select bg-white rounded-3">
@@ -115,8 +129,9 @@
                 </div>
             </form>
         </div>
-        <div class="col-lg-2 text-lg-end mt-3 mt-lg-0">
+        <div class="col-lg-3 text-lg-end mt-3 mt-lg-0">
             <div class="d-flex flex-column align-items-stretch align-items-lg-end gap-2">
+                @include('partials.operations-navigation')
                 <a class="btn btn-sm btn-success text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.create') }}" role="button">
                     <i class="fas fa-plus-square text-white me-1"></i>Adaugă factură
                 </a>

--- a/resources/views/partials/operations-navigation.blade.php
+++ b/resources/views/partials/operations-navigation.blade.php
@@ -1,0 +1,19 @@
+@php
+    $links = [
+        ['route' => 'facturi-furnizori.facturi.index', 'pattern' => 'facturi-furnizori.facturi.*', 'label' => 'Facturi furnizori'],
+        ['route' => 'gestiune-piese.index', 'pattern' => 'gestiune-piese.*', 'label' => 'Gestiune piese'],
+        ['route' => 'service-masini.index', 'pattern' => 'service-masini.*', 'label' => 'Service mașini'],
+    ];
+@endphp
+
+<div class="d-flex flex-wrap justify-content-center justify-content-lg-end gap-2">
+    @foreach ($links as $link)
+        @php
+            $isActive = request()->routeIs($link['pattern']);
+            $btnClass = $isActive ? 'btn-primary text-white' : 'btn-outline-primary';
+        @endphp
+        <a href="{{ route($link['route']) }}" class="btn btn-sm {{ $btnClass }} border border-dark rounded-3">
+            {{ $link['label'] }}
+        </a>
+    @endforeach
+</div>

--- a/resources/views/service/gestiune-piese/index.blade.php
+++ b/resources/views/service/gestiune-piese/index.blade.php
@@ -15,12 +15,12 @@
 @section('content')
     <div class="mx-3 px-3 card mx-auto" style="border-radius: 40px 40px 40px 40px;">
         <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
-            <div class="col-lg-3">
+            <div class="col-lg-3 mb-2 mb-lg-0">
                 <span class="badge culoare1 fs-5">
                     <i class="fa-solid fa-warehouse me-1"></i>Gestiune piese
                 </span>
             </div>
-            <div class="col-lg-9 mb-2" id="formularGestiunePiese">
+            <div class="col-lg-6 mb-2" id="formularGestiunePiese">
                 <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ route('gestiune-piese.index') }}">
                     <div class="row gy-1 gx-4 mb-2 custom-search-form d-flex justify-content-center">
                         <div class="col-lg-4 col-md-6">
@@ -59,6 +59,9 @@
                         </a>
                     </div>
                 </form>
+            </div>
+            <div class="col-lg-3 mt-2 mt-lg-0">
+                @include('partials.operations-navigation')
             </div>
         </div>
 

--- a/resources/views/service/masini/index.blade.php
+++ b/resources/views/service/masini/index.blade.php
@@ -24,12 +24,12 @@
 @section('content')
     <div class="mx-3 px-3 card mx-auto" style="border-radius: 40px 40px 40px 40px;">
         <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
-            <div class="col-lg-3">
+            <div class="col-lg-3 mb-2 mb-lg-0">
                 <span class="badge culoare1 fs-5">
                     <i class="fa-solid fa-screwdriver-wrench me-1"></i>Service mașini
                 </span>
             </div>
-            <div class="col-lg-9 mb-2">
+            <div class="col-lg-6 mb-2">
                 <form class="needs-validation" novalidate method="GET" action="{{ route('service-masini.index') }}">
                     <div class="row gy-2 gx-3 align-items-end">
                         <div class="col-lg-4 col-md-6">
@@ -81,6 +81,9 @@
                         </div>
                     </div>
                 </form>
+            </div>
+            <div class="col-lg-3 mt-2 mt-lg-0">
+                @include('partials.operations-navigation')
             </div>
         </div>
 

--- a/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
+++ b/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
@@ -91,12 +91,14 @@ class FacturaFurnizorTest extends TestCase
                     'cod' => 'FU-01',
                     'nr_bucati' => '2',
                     'pret' => '35.50',
+                    'tva_cota' => '11',
                 ],
                 [
                     'denumire' => 'Ulei motor',
                     'cod' => null,
                     'nr_bucati' => '1',
                     'pret' => '250',
+                    'tva_cota' => '21',
                 ],
             ],
         ];
@@ -114,8 +116,14 @@ class FacturaFurnizorTest extends TestCase
         $this->assertCount(2, $factura->piese);
         $this->assertEquals('Filtru ulei', $factura->piese[0]->denumire);
         $this->assertSame('35.50', $factura->piese[0]->pret);
+        $this->assertSame('11.00', $factura->piese[0]->tva_cota);
+        $this->assertSame('3.91', $factura->piese[0]->valoare_tva);
+        $this->assertSame('39.41', $factura->piese[0]->pret_brut);
         $this->assertEquals('Ulei motor', $factura->piese[1]->denumire);
         $this->assertSame('250.00', $factura->piese[1]->pret);
+        $this->assertSame('21.00', $factura->piese[1]->tva_cota);
+        $this->assertSame('52.50', $factura->piese[1]->valoare_tva);
+        $this->assertSame('302.50', $factura->piese[1]->pret_brut);
     }
 
     public function test_it_replaces_products_when_updating_an_invoice(): void
@@ -149,6 +157,7 @@ class FacturaFurnizorTest extends TestCase
                     'cod' => 'PF-02',
                     'nr_bucati' => 4,
                     'pret' => 120,
+                    'tva_cota' => 21,
                 ],
             ],
         ];
@@ -163,6 +172,9 @@ class FacturaFurnizorTest extends TestCase
         $this->assertCount(1, $factura->piese);
         $this->assertEquals('Plăcuțe frână', $factura->piese[0]->denumire);
         $this->assertSame('120.00', $factura->piese[0]->pret);
+        $this->assertSame('21.00', $factura->piese[0]->tva_cota);
+        $this->assertSame('25.20', $factura->piese[0]->valoare_tva);
+        $this->assertSame('145.20', $factura->piese[0]->pret_brut);
         $this->assertDatabaseMissing('service_gestiune_piese', [
             'factura_id' => $factura->id,
             'denumire' => 'Produs vechi',


### PR DESCRIPTION
## Summary
- store VAT rate, value, and gross unit price for invoice products and auto-calculate them in the form
- add an exact invoice-number filter plus shared navigation buttons between supplier invoices, parts stock, and service pages
- ensure parts with stock move to the top by default while keeping zero-stock items at the end and expose new VAT data via migration and factories

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f087c1dcfc832697c6c9f89a5eebfd