### PR TITLE
Add initial quantity support for supplier parts and stock insights

### DIFF
--- a/app/Models/Service/GestiunePiesa.php
+++ b/app/Models/Service/GestiunePiesa.php
@@ -5,7 +5,9 @@ namespace App\Models\Service;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\FacturiFurnizori\FacturaFurnizor;
+use App\Models\Service\MasinaServiceEntry;
 
 class GestiunePiesa extends Model
 {
@@ -17,6 +19,7 @@ class GestiunePiesa extends Model
         'factura_id',
         'denumire',
         'cod',
+        'cantitate_initiala',
         'nr_bucati',
         'pret',
         'tva_cota',
@@ -24,6 +27,7 @@ class GestiunePiesa extends Model
     ];
 
     protected $casts = [
+        'cantitate_initiala' => 'decimal:2',
         'nr_bucati' => 'decimal:2',
         'pret' => 'decimal:2',
         'tva_cota' => 'decimal:2',
@@ -38,5 +42,28 @@ class GestiunePiesa extends Model
     public function factura(): BelongsTo
     {
         return $this->belongsTo(FacturaFurnizor::class, 'factura_id');
+    }
+
+    public function serviceEntries(): HasMany
+    {
+        return $this->hasMany(MasinaServiceEntry::class, 'gestiune_piesa_id');
+    }
+
+    public function getCantitateUtilizataAttribute(): float
+    {
+        $initial = $this->cantitate_initiala;
+
+        if ($initial === null) {
+            $initial = $this->nr_bucati;
+        }
+
+        if ($initial === null) {
+            return 0.0;
+        }
+
+        $remaining = $this->nr_bucati ?? 0.0;
+        $used = (float) $initial - (float) $remaining;
+
+        return $used > 0 ? round($used, 2) : 0.0;
     }
 }

--- a/database/factories/Service/GestiunePiesaFactory.php
+++ b/database/factories/Service/GestiunePiesaFactory.php
@@ -19,11 +19,14 @@ class GestiunePiesaFactory extends Factory
         $tvaCota = $this->faker->randomElement([11.00, 21.00]);
         $pretBrut = round($pret * (1 + ($tvaCota / 100)), 2);
 
+        $cantitateInitiala = $this->faker->randomFloat(2, 1, 20);
+
         return [
             'factura_id' => FacturaFurnizor::factory(),
             'denumire' => $this->faker->words(3, true),
             'cod' => strtoupper($this->faker->bothify('PIE###')),
-            'nr_bucati' => $this->faker->randomFloat(2, 1, 20),
+            'cantitate_initiala' => $cantitateInitiala,
+            'nr_bucati' => $cantitateInitiala,
             'pret' => $pret,
             'tva_cota' => $tvaCota,
             'pret_brut' => $pretBrut,

--- a/database/migrations/2025_03_18_000000_add_cantitate_initiala_to_gestiune_piese_table.php
+++ b/database/migrations/2025_03_18_000000_add_cantitate_initiala_to_gestiune_piese_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_gestiune_piese', function (Blueprint $table) {
+            if (! Schema::hasColumn('service_gestiune_piese', 'cantitate_initiala')) {
+                $table->decimal('cantitate_initiala', 10, 2)->nullable()->after('nr_bucati');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_gestiune_piese', function (Blueprint $table) {
+            if (Schema::hasColumn('service_gestiune_piese', 'cantitate_initiala')) {
+                $table->dropColumn('cantitate_initiala');
+            }
+        });
+    }
+};

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -18,7 +18,10 @@
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
         <div class="col-lg-1 mb-2">
             <span class="badge culoare1 fs-5">
-                <i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi<br>furnizori
+                <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
+                    <span><i class="fa-solid fa-file-invoice-dollar me-1"></i>Facturi</span>
+                    <span class="ms-4">furnizori</span>
+                </span>
             </span>
         </div>
         <div class="col-lg-8 mb-0" id="formularFacturi">

--- a/resources/views/service/gestiune-piese/index.blade.php
+++ b/resources/views/service/gestiune-piese/index.blade.php
@@ -10,6 +10,7 @@
     $cod = $cod ?? '';
     $dataFactura = $dataFactura ?? '';
     $invoiceColumn = $invoiceColumn ?? null;
+    $stockDetails = $stockDetails ?? [];
 @endphp
 
 @section('content')
@@ -111,6 +112,7 @@
                                 @if ($invoiceColumn)
                                     <th class="culoare2 text-white" style="min-width: 130px;">Factură</th>
                                 @endif
+                                <th class="culoare2 text-white" style="min-width: 150px;">Detalii stoc</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -121,6 +123,14 @@
                                     </td>
                                     @php
                                         $invoiceId = $invoiceColumn ? ($row->{$invoiceColumn} ?? null) : null;
+                                        $pieceId = isset($row->id) ? (int) $row->id : 0;
+                                        $stockInfo = $stockDetails[$pieceId] ?? null;
+                                        $pieceName = $row->denumire ?? '';
+                                        $pieceCode = $row->cod ?? '';
+                                        $initialValue = $stockInfo['initial'] ?? null;
+                                        $remainingValue = $stockInfo['remaining'] ?? null;
+                                        $usedValue = $stockInfo['used'] ?? 0;
+                                        $machinesData = $stockInfo['machines'] ?? [];
                                     @endphp
                                     @foreach ($columns as $column)
                                         @php
@@ -150,10 +160,36 @@
                                             @endif
                                         </td>
                                     @endif
+                                    @php
+                                        $initialDisplay = $initialValue !== null ? number_format((float) $initialValue, 2, '.', '') : '';
+                                        $remainingDisplay = $remainingValue !== null ? number_format((float) $remainingValue, 2, '.', '') : '';
+                                        $usedDisplay = number_format((float) $usedValue, 2, '.', '');
+                                        $machinesJson = e(json_encode($machinesData, JSON_UNESCAPED_UNICODE));
+                                    @endphp
+                                    <td class="text-center">
+                                        @if ($pieceId > 0)
+                                            <button
+                                                type="button"
+                                                class="btn btn-sm btn-outline-secondary"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#stockDetailsModal"
+                                                data-piece-name="{{ $pieceName }}"
+                                                data-piece-code="{{ $pieceCode }}"
+                                                data-piece-initial="{{ $initialDisplay }}"
+                                                data-piece-remaining="{{ $remainingDisplay }}"
+                                                data-piece-used="{{ $usedDisplay }}"
+                                                data-piece-machines="{{ $machinesJson }}"
+                                            >
+                                                <i class="fa-solid fa-circle-info me-1"></i>Detalii
+                                            </button>
+                                        @else
+                                            —
+                                        @endif
+                                    </td>
                                 </tr>
                             @empty
                                 <tr>
-                                    <td colspan="{{ count($columns) + 1 + ($invoiceColumn ? 1 : 0) }}"
+                                    <td colspan="{{ count($columns) + 2 + ($invoiceColumn ? 1 : 0) }}"
                                         class="text-center text-muted py-4">
                                         Nu există înregistrări care să corespundă filtrelor alese.
                                     </td>
@@ -170,3 +206,132 @@
         </div>
     </div>
 @endsection
+
+<div class="modal fade" id="stockDetailsModal" tabindex="-1" aria-labelledby="stockDetailsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-scrollable modal-lg">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="stockDetailsModalLabel">Detalii stoc</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Închide"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <h5 class="mb-1" data-stock-details="name">—</h5>
+                    <div class="text-muted small d-none" data-stock-details="code"></div>
+                </div>
+                <dl class="row mb-4">
+                    <dt class="col-sm-5 col-lg-4">Cantitate inițială</dt>
+                    <dd class="col-sm-7 col-lg-8" data-stock-details="initial">—</dd>
+                    <dt class="col-sm-5 col-lg-4">Cantitate alocată</dt>
+                    <dd class="col-sm-7 col-lg-8" data-stock-details="used">0.00</dd>
+                    <dt class="col-sm-5 col-lg-4">Cantitate rămasă</dt>
+                    <dd class="col-sm-7 col-lg-8" data-stock-details="remaining">—</dd>
+                </dl>
+                <h6 class="mb-2">Alocări pe mașini</h6>
+                <div class="table-responsive mb-2">
+                    <table class="table table-sm table-striped mb-0">
+                        <thead>
+                            <tr>
+                                <th>Mașină</th>
+                                <th class="text-end">Cantitate</th>
+                            </tr>
+                        </thead>
+                        <tbody data-stock-details="machines-body"></tbody>
+                    </table>
+                </div>
+                <div class="text-muted" data-stock-details="machines-empty">Nu există alocări pentru această piesă.</div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Închide</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('page-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const modal = document.getElementById('stockDetailsModal');
+
+            if (!modal) {
+                return;
+            }
+
+            const nameEl = modal.querySelector('[data-stock-details="name"]');
+            const codeEl = modal.querySelector('[data-stock-details="code"]');
+            const initialEl = modal.querySelector('[data-stock-details="initial"]');
+            const usedEl = modal.querySelector('[data-stock-details="used"]');
+            const remainingEl = modal.querySelector('[data-stock-details="remaining"]');
+            const machinesBody = modal.querySelector('[data-stock-details="machines-body"]');
+            const noMachinesEl = modal.querySelector('[data-stock-details="machines-empty"]');
+
+            modal.addEventListener('show.bs.modal', function (event) {
+                const trigger = event.relatedTarget;
+
+                if (!trigger) {
+                    return;
+                }
+
+                const name = trigger.getAttribute('data-piece-name') || '—';
+                const code = trigger.getAttribute('data-piece-code') || '';
+                const initial = trigger.getAttribute('data-piece-initial');
+                const remaining = trigger.getAttribute('data-piece-remaining');
+                const used = trigger.getAttribute('data-piece-used');
+                const machinesJson = trigger.getAttribute('data-piece-machines') || '[]';
+
+                let machines = [];
+
+                try {
+                    const parsed = JSON.parse(machinesJson);
+                    machines = Array.isArray(parsed) ? parsed : [];
+                } catch (error) {
+                    machines = [];
+                }
+
+                nameEl.textContent = name || '—';
+
+                if (code) {
+                    codeEl.textContent = `Cod: ${code}`;
+                    codeEl.classList.remove('d-none');
+                } else {
+                    codeEl.textContent = '';
+                    codeEl.classList.add('d-none');
+                }
+
+                initialEl.textContent = initial && initial !== '' ? initial : '—';
+                usedEl.textContent = used && used !== '' ? used : '0.00';
+                remainingEl.textContent = remaining && remaining !== '' ? remaining : '—';
+
+                machinesBody.innerHTML = '';
+
+                if (!machines.length) {
+                    noMachinesEl.classList.remove('d-none');
+                    return;
+                }
+
+                noMachinesEl.classList.add('d-none');
+
+                machines.forEach((machine) => {
+                    const row = document.createElement('tr');
+                    const masinaCell = document.createElement('td');
+                    const number = machine.numar_inmatriculare || '';
+                    const label = machine.denumire || '';
+                    masinaCell.textContent = number
+                        ? label
+                            ? `${number} – ${label}`
+                            : number
+                        : label || '—';
+
+                    const qtyCell = document.createElement('td');
+                    qtyCell.className = 'text-end';
+                    const qty = Number.parseFloat(machine.cantitate ?? 0);
+                    qtyCell.textContent = Number.isFinite(qty) ? qty.toFixed(2) : '0.00';
+
+                    row.appendChild(masinaCell);
+                    row.appendChild(qtyCell);
+                    machinesBody.appendChild(row);
+                });
+            });
+        });
+    </script>
+@endpush


### PR DESCRIPTION
## Summary
- add a migration and persistence logic to track each supplier part's initial quantity while preserving existing service allocations
- expose the editable initial quantity in the supplier invoice form and show stock/usage details in the gestiune piese UI with a new modal
- extend automated coverage for the new quantity handling and validation rules

## Testing
- `php artisan test` *(fails: missing vendor/autoload.php in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0bcfa2c5883268ee7e8ca46772dea