### PR TITLE
Fix role handling for mechanics and legacy admins

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -7,7 +7,6 @@ use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 use Illuminate\Http\Request;
-use App\Http\Requests\LoginRequest;
 use Illuminate\Support\Facades\Auth;
 
 class LoginController extends Controller
@@ -31,6 +30,17 @@ class LoginController extends Controller
      * @var string
      */
     protected $redirectTo = RouteServiceProvider::HOME;
+
+    protected function redirectTo()
+    {
+        $user = Auth::user();
+
+        if ($user && $user->hasRole('mecanic')) {
+            return '/gestiune-piese';
+        }
+
+        return $this->redirectTo;
+    }
 
     /**
      * Create a new controller instance.

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -68,5 +68,6 @@ class Kernel extends HttpKernel
 
         // Andrei
         'role' => \App\Http\Middleware\Role::class,
+        'restrict-mechanic-access' => \App\Http\Middleware\RestrictMechanicAccess::class,
     ];
 }

--- a/app/Http/Middleware/RestrictMechanicAccess.php
+++ b/app/Http/Middleware/RestrictMechanicAccess.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RestrictMechanicAccess
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if (! $user || ! $user->hasRole('mecanic')) {
+            return $next($request);
+        }
+
+        $allowedRouteNames = [
+            'gestiune-piese.index',
+            'service-masini.index',
+            'service-masini.store-masina',
+            'service-masini.update-masina',
+            'service-masini.destroy-masina',
+            'service-masini.entries.store',
+            'service-masini.entries.update',
+            'service-masini.entries.destroy',
+            'service-masini.export',
+            'logout',
+        ];
+
+        $route = $request->route();
+        $routeName = $route?->getName();
+
+        if ($routeName && in_array($routeName, $allowedRouteNames, true)) {
+            return $next($request);
+        }
+
+        $allowedPrefixes = [
+            'gestiune-piese',
+            'service-masini',
+        ];
+
+        $path = trim($request->path(), '/');
+
+        foreach ($allowedPrefixes as $prefix) {
+            if ($path === $prefix || str_starts_with($path, $prefix . '/')) {
+                return $next($request);
+            }
+        }
+
+        abort(403);
+    }
+}

--- a/app/Http/Middleware/Role.php
+++ b/app/Http/Middleware/Role.php
@@ -22,6 +22,6 @@ class Role
             }
         }
 
-        return redirect('login');
+        abort(403);
     }
 }

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -25,7 +25,23 @@ class RolesTableSeeder extends Seeder
             ['slug' => 'admin'],
             [
                 'name' => 'Administrator',
-                'description' => 'Legacy administrator role.',
+                'description' => 'Legacy administrator role mapped from users.role = 1.',
+            ]
+        );
+
+        Role::firstOrCreate(
+            ['slug' => 'dispecer'],
+            [
+                'name' => 'Dispecer',
+                'description' => 'Legacy dispatcher role mapped from users.role = 2.',
+            ]
+        );
+
+        Role::firstOrCreate(
+            ['slug' => 'mecanic'],
+            [
+                'name' => 'Mecanic',
+                'description' => 'Acces limitat la gestiunea pieselor și service-ul mașinilor.',
             ]
         );
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -41,6 +41,7 @@
         $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
         $impersonationActive = session()->has('impersonated_by');
         $impersonatorName = session('impersonated_by_name');
+        $isMechanic = auth()->user()->hasRole('mecanic');
     @endphp
     {{-- <div id="app"> --}}
     <header>
@@ -57,7 +58,21 @@
 
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <!-- Left Side Of Navbar -->
-                    <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                    @if ($isMechanic)
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                            <li class="nav-item me-3">
+                                <a class="nav-link active" href="{{ route('gestiune-piese.index') }}">
+                                    <i class="fa-solid fa-boxes-stacked me-1"></i>Gestiune piese
+                                </a>
+                            </li>
+                            <li class="nav-item me-3">
+                                <a class="nav-link active" href="{{ route('service-masini.index') }}">
+                                    <i class="fa-solid fa-screwdriver-wrench me-1"></i>Service mașini
+                                </a>
+                            </li>
+                        </ul>
+                    @else
+                        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                         {{-- <li class="nav-item me-3 dropdown">
                             <a class="nav-link active dropdown-toggle" href="about:blank" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 <i class="fa-solid fa-folder"></i>&nbsp;
@@ -305,7 +320,8 @@
                                 </ul>
                             </li>
                         @endcan
-                    </ul>
+                        </ul>
+                    @endif
 
                     <!-- Right Side Of Navbar -->
                     <ul class="navbar-nav ms-auto">

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,7 +79,7 @@ Route::get('oferte-curse', [OfertaCursaController::class, 'index'])->name('ofert
 
 Route::redirect('/', '/acasa');
 
-Route::group(['middleware' => 'auth'], function () {
+Route::group(['middleware' => ['auth', 'restrict-mechanic-access']], function () {
     Route::view('acasa', 'acasa');
     Route::view('various-tests', 'variousTests');
 
@@ -192,7 +192,7 @@ Route::group(['middleware' => 'auth'], function () {
     Route::get('/rapoarte/incasari-utilizatori', [RaportController::class, 'incasariUtilizatori']);
     Route::get('/rapoarte/documente-transportatori', [RaportController::class, 'documenteTransportatori']);
 
-    Route::group(['middleware' => 'role:1'], function () {
+    Route::group(['middleware' => 'role:super-admin,admin'], function () {
         Route::resource('/utilizatori', UserController::class)->parameters(['utilizatori' => 'user']);
     });
 

--- a/tests/Feature/UserRolesTest.php
+++ b/tests/Feature/UserRolesTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserRolesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_management_access_is_limited_to_admin_roles(): void
+    {
+        [$superAdminRole, $adminRole, $mechanicRole] = $this->createCoreRoles();
+
+        $admin = User::factory()->create(['role' => $adminRole->id]);
+        $admin->assignRole($adminRole);
+
+        $superAdmin = User::factory()->create(['role' => $superAdminRole->id]);
+        $superAdmin->assignRole($superAdminRole);
+
+        $mechanic = User::factory()->create(['role' => $mechanicRole->id]);
+        $mechanic->assignRole($mechanicRole);
+
+        $this->actingAs($admin)->get('/utilizatori')->assertOk();
+        $this->actingAs($superAdmin)->get('/utilizatori')->assertOk();
+        $this->actingAs($mechanic)->get('/utilizatori')->assertForbidden();
+    }
+
+    public function test_super_admin_role_cannot_be_assigned_through_user_forms(): void
+    {
+        [$superAdminRole, $adminRole] = $this->createCoreRoles();
+
+        $admin = User::factory()->create(['role' => $adminRole->id]);
+        $admin->assignRole($adminRole);
+
+        $response = $this->actingAs($admin)->post('/utilizatori', [
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'telefon' => '0123456789',
+            'role' => $superAdminRole->id,
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'activ' => 1,
+        ]);
+
+        $response->assertSessionHasErrors('role');
+        $this->assertDatabaseMissing('users', ['email' => 'test@example.com']);
+
+        $user = User::factory()->create([
+            'name' => 'Existing User',
+            'email' => 'existing@example.com',
+            'role' => $adminRole->id,
+        ]);
+        $user->assignRole($adminRole);
+
+        $updateResponse = $this->actingAs($admin)->put("/utilizatori/{$user->id}", [
+            'id' => $user->id,
+            'name' => 'Existing User',
+            'email' => 'existing@example.com',
+            'telefon' => '0123456789',
+            'role' => $superAdminRole->id,
+            'activ' => 1,
+        ]);
+
+        $updateResponse->assertSessionHasErrors('role');
+        $this->assertFalse($user->fresh()->hasRole('super-admin'));
+    }
+
+    public function test_legacy_super_admin_without_pivot_role_can_access_user_management(): void
+    {
+        [$superAdminRole, $adminRole] = $this->createCoreRoles();
+
+        $legacySuperAdmin = User::factory()->create([
+            'role' => $superAdminRole->id,
+        ]);
+
+        $this->actingAs($legacySuperAdmin)->get('/utilizatori')->assertOk();
+    }
+
+    public function test_mechanics_are_restricted_to_service_sections(): void
+    {
+        [, , $mechanicRole] = $this->createCoreRoles();
+
+        $mechanic = User::factory()->create(['role' => $mechanicRole->id]);
+        $mechanic->assignRole($mechanicRole);
+
+        $this->actingAs($mechanic)->get('/gestiune-piese')->assertOk();
+        $this->actingAs($mechanic)->get('/service-masini')->assertOk();
+        $this->actingAs($mechanic)->get('/acasa')->assertForbidden();
+    }
+
+    /**
+     * @return array{0: Role, 1: Role, 2: Role}
+     */
+    private function createCoreRoles(): array
+    {
+        $superAdmin = Role::firstOrCreate(
+            ['slug' => 'super-admin'],
+            [
+                'name' => 'Super Admin',
+                'description' => 'Full access.',
+            ]
+        );
+
+        $admin = Role::firstOrCreate(
+            ['slug' => 'admin'],
+            [
+                'name' => 'Administrator',
+                'description' => 'Administrator access.',
+            ]
+        );
+
+        $mechanic = Role::firstOrCreate(
+            ['slug' => 'mecanic'],
+            [
+                'name' => 'Mecanic',
+                'description' => 'Acces limitat la gestiune piese și service mașini.',
+            ]
+        );
+
+        return [$superAdmin, $admin, $mechanic];
+    }
+}


### PR DESCRIPTION
## Summary
- add middleware and navigation updates so mechanics only see and reach the service and parts modules
- harden user management by filtering Super Admin from assignable roles while still allowing existing Super Admins to edit their profile
- seed the new mechanic role, adjust login redirection, and cover the changes with authorization tests
- ensure legacy Super Admin records without pivot roles remain authorized and extend the seeder/tests for the mechanic role

## Testing
- php -l app/Http/Controllers/Auth/LoginController.php
- php -l app/Models/User.php
- php -l database/seeders/RolesTableSeeder.php
- php -l tests/Feature/UserRolesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68f11b79d4a08326a6151c9608fe278c