### PR TITLE
Block factura deletion when pieces are mounted on cars

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
@@ -297,6 +297,12 @@ class FacturaFurnizorController extends Controller
             return back()->with('error', 'Factura atasata unui calup nu poate fi stearsa.');
         }
 
+        $arePieseMontate = $factura->piese()->whereHas('serviceEntries')->exists();
+
+        if ($arePieseMontate) {
+            return back()->with('error', 'Factura nu poate fi stearsa deoarece are piese montate pe masini.');
+        }
+
         $factura->loadMissing('fisiere');
 
         foreach ($factura->fisiere as $fisier) {

--- a/database/migrations/2025_03_17_020000_update_gestiune_piesa_fk_on_service_entries.php
+++ b/database/migrations/2025_03_17_020000_update_gestiune_piesa_fk_on_service_entries.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_masina_service_entries', function (Blueprint $table) {
+            $table->dropForeign(['gestiune_piesa_id']);
+        });
+
+        Schema::table('service_masina_service_entries', function (Blueprint $table) {
+            $table->foreign('gestiune_piesa_id')
+                ->references('id')
+                ->on('service_gestiune_piese')
+                ->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_masina_service_entries', function (Blueprint $table) {
+            $table->dropForeign(['gestiune_piesa_id']);
+        });
+
+        Schema::table('service_masina_service_entries', function (Blueprint $table) {
+            $table->foreign('gestiune_piesa_id')
+                ->references('id')
+                ->on('service_gestiune_piese')
+                ->nullOnDelete();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- restore the original service entry table definition so the base migration remains unchanged
- add a schema migration that redefines the gestiune piesa foreign key with restrict-on-delete semantics
- prevent factura deletions in the controller when any of its pieces are still mounted on cars

## Testing
- not run (vendor dependencies unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f1d7a57fa483269c8a0aaad0c142cc