### PR TITLE
Prefill service sheet defaults and add mechanic field

### DIFF
--- a/app/Http/Controllers/Service/ServiceSheetController.php
+++ b/app/Http/Controllers/Service/ServiceSheetController.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Http\Controllers\Service;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Service\StoreServiceSheetRequest;
+use App\Http\Requests\Service\UpdateServiceSheetRequest;
+use App\Models\Service\Masina;
+use App\Models\Service\ServiceSheet;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class ServiceSheetController extends Controller
+{
+    public function create(Masina $masina): View
+    {
+        return view('service.masini.service-sheet.create', [
+            'masina' => $masina,
+        ]);
+    }
+
+    public function store(StoreServiceSheetRequest $request, Masina $masina): BinaryFileResponse
+    {
+        $sheet = DB::transaction(function () use ($request, $masina) {
+            $data = $request->validated();
+
+            /** @var \App\Models\Service\ServiceSheet $sheet */
+            $sheet = $masina->serviceSheets()->create([
+                'km_bord' => (int) $data['km_bord'],
+                'data_service' => $data['data_service'],
+            ]);
+
+            $sheet->items()->createMany(
+                collect($data['items'])
+                    ->map(function (array $item, int $index) {
+                        return [
+                            'position' => $index + 1,
+                            'description' => $item['description'],
+                            'quantity' => $item['quantity'] ?: null,
+                            'notes' => $item['notes'] ?: null,
+                        ];
+                    })
+                    ->all()
+            );
+
+            return $sheet->fresh(['masina', 'items']);
+        });
+
+        session()->flash('status', 'Foaia de service a fost salvată.');
+
+        return $this->downloadSheet($sheet);
+    }
+
+    public function edit(Masina $masina, ServiceSheet $sheet): View
+    {
+        $this->ensureSheetBelongsToMasina($masina, $sheet);
+
+        return view('service.masini.service-sheet.edit', [
+            'masina' => $masina,
+            'sheet' => $sheet->loadMissing('items'),
+        ]);
+    }
+
+    public function update(UpdateServiceSheetRequest $request, Masina $masina, ServiceSheet $sheet): RedirectResponse
+    {
+        $this->ensureSheetBelongsToMasina($masina, $sheet);
+
+        DB::transaction(function () use ($request, $sheet): void {
+            $data = $request->validated();
+
+            $sheet->update([
+                'km_bord' => (int) $data['km_bord'],
+                'data_service' => $data['data_service'],
+            ]);
+
+            $sheet->items()->delete();
+            $sheet->items()->createMany(
+                collect($data['items'])
+                    ->map(function (array $item, int $index) {
+                        return [
+                            'position' => $index + 1,
+                            'description' => $item['description'],
+                            'quantity' => $item['quantity'] ?: null,
+                            'notes' => $item['notes'] ?: null,
+                        ];
+                    })
+                    ->all()
+            );
+        });
+
+        return redirect()
+            ->route('service-masini.index', [
+                'masina_id' => $masina->id,
+                'view' => 'service-sheets',
+            ])
+            ->with('status', 'Foaia de service a fost actualizată.');
+    }
+
+    public function destroy(Masina $masina, ServiceSheet $sheet): RedirectResponse
+    {
+        $this->ensureSheetBelongsToMasina($masina, $sheet);
+
+        $sheet->delete();
+
+        return redirect()
+            ->route('service-masini.index', [
+                'masina_id' => $masina->id,
+                'view' => 'service-sheets',
+            ])
+            ->with('status', 'Foaia de service a fost ștearsă.');
+    }
+
+    public function download(Masina $masina, ServiceSheet $sheet): BinaryFileResponse
+    {
+        $this->ensureSheetBelongsToMasina($masina, $sheet);
+
+        return $this->downloadSheet($sheet->loadMissing('masina', 'items'));
+    }
+
+    protected function downloadSheet(ServiceSheet $sheet): BinaryFileResponse
+    {
+        $sheet->loadMissing('masina', 'items');
+
+        $items = $sheet->items
+            ->sortBy('position')
+            ->values()
+            ->map(function ($item, int $index) {
+                return [
+                    'index' => $index + 1,
+                    'description' => $item->description,
+                    'quantity' => $item->quantity ?? '',
+                    'notes' => $item->notes ?? '',
+                ];
+            });
+
+        $pdf = Pdf::loadView('pdf.service-sheet', [
+            'masina' => $sheet->masina,
+            'km_bord' => (int) $sheet->km_bord,
+            'data_service' => $sheet->data_service,
+            'items' => $items,
+        ]);
+
+        $identifier = $sheet->masina->numar_inmatriculare ?: $sheet->masina->denumire ?: 'masina';
+        $filename = 'foaie-service-' . Str::slug($identifier) . '-' . $sheet->id . '.pdf';
+
+        return $pdf->download($filename);
+    }
+
+    protected function ensureSheetBelongsToMasina(Masina $masina, ServiceSheet $sheet): void
+    {
+        if ($sheet->masina_id !== $masina->id) {
+            abort(404);
+        }
+    }
+}

--- a/app/Http/Requests/Service/ServiceSheetRequest.php
+++ b/app/Http/Requests/Service/ServiceSheetRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+abstract class ServiceSheetRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $items = collect($this->input('items', []))
+            ->map(function ($item) {
+                $item = is_array($item) ? $item : [];
+
+                return [
+                    'description' => trim((string) ($item['description'] ?? '')),
+                    'quantity' => trim((string) ($item['quantity'] ?? '')),
+                    'notes' => trim((string) ($item['notes'] ?? '')),
+                ];
+            })
+            ->filter(function (array $item) {
+                return $item['description'] !== ''
+                    || $item['quantity'] !== ''
+                    || $item['notes'] !== '';
+            })
+            ->values()
+            ->all();
+
+        $this->merge([
+            'items' => $items,
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'km_bord' => ['required', 'integer', 'min:0', 'max:1000000'],
+            'data_service' => ['required', 'date'],
+            'items' => ['required', 'array', 'min:1'],
+            'items.*.description' => ['required', 'string', 'max:255'],
+            'items.*.quantity' => ['nullable', 'string', 'max:50'],
+            'items.*.notes' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'km_bord' => 'km bord',
+            'data_service' => 'data service',
+            'items.*.description' => 'descriere intervenție',
+            'items.*.quantity' => 'cantitate',
+            'items.*.notes' => 'observații / manoperă',
+        ];
+    }
+}

--- a/app/Http/Requests/Service/StoreServiceSheetRequest.php
+++ b/app/Http/Requests/Service/StoreServiceSheetRequest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+class StoreServiceSheetRequest extends ServiceSheetRequest
+{
+}

--- a/app/Http/Requests/Service/UpdateServiceSheetRequest.php
+++ b/app/Http/Requests/Service/UpdateServiceSheetRequest.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+class UpdateServiceSheetRequest extends ServiceSheetRequest
+{
+}

--- a/app/Models/Service/Masina.php
+++ b/app/Models/Service/Masina.php
@@ -28,4 +28,9 @@ class Masina extends Model
     {
         return $this->hasMany(MasinaServiceEntry::class);
     }
+
+    public function serviceSheets(): HasMany
+    {
+        return $this->hasMany(ServiceSheet::class);
+    }
 }

--- a/app/Models/Service/ServiceSheet.php
+++ b/app/Models/Service/ServiceSheet.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models\Service;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ServiceSheet extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'masina_id',
+        'km_bord',
+        'data_service',
+    ];
+
+    protected $casts = [
+        'data_service' => 'date',
+    ];
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\Service\ServiceSheetFactory::new();
+    }
+
+    public function masina(): BelongsTo
+    {
+        return $this->belongsTo(Masina::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(ServiceSheetItem::class)->orderBy('position');
+    }
+}

--- a/app/Models/Service/ServiceSheetItem.php
+++ b/app/Models/Service/ServiceSheetItem.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models\Service;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ServiceSheetItem extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'service_sheet_id',
+        'position',
+        'description',
+        'quantity',
+        'notes',
+    ];
+
+    protected static function newFactory()
+    {
+        return \Database\Factories\Service\ServiceSheetItemFactory::new();
+    }
+
+    public function sheet(): BelongsTo
+    {
+        return $this->belongsTo(ServiceSheet::class, 'service_sheet_id');
+    }
+}

--- a/database/factories/Service/ServiceSheetFactory.php
+++ b/database/factories/Service/ServiceSheetFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories\Service;
+
+use App\Models\Service\Masina;
+use App\Models\Service\ServiceSheet;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceSheetFactory extends Factory
+{
+    protected $model = ServiceSheet::class;
+
+    public function definition(): array
+    {
+        return [
+            'masina_id' => Masina::factory(),
+            'km_bord' => $this->faker->numberBetween(0, 400000),
+            'data_service' => $this->faker->date(),
+        ];
+    }
+}

--- a/database/factories/Service/ServiceSheetItemFactory.php
+++ b/database/factories/Service/ServiceSheetItemFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories\Service;
+
+use App\Models\Service\ServiceSheet;
+use App\Models\Service\ServiceSheetItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServiceSheetItemFactory extends Factory
+{
+    protected $model = ServiceSheetItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'service_sheet_id' => ServiceSheet::factory(),
+            'position' => $this->faker->numberBetween(1, 20),
+            'description' => $this->faker->sentence(3),
+            'quantity' => (string) $this->faker->numberBetween(1, 5),
+            'notes' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_03_19_000000_create_service_sheets_table.php
+++ b/database/migrations/2025_03_19_000000_create_service_sheets_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('service_sheets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('masina_id')->constrained('service_masini')->cascadeOnDelete();
+            $table->unsignedInteger('km_bord');
+            $table->date('data_service');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_sheets');
+    }
+};

--- a/database/migrations/2025_03_19_000100_create_service_sheet_items_table.php
+++ b/database/migrations/2025_03_19_000100_create_service_sheet_items_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('service_sheet_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('service_sheet_id')->constrained('service_sheets')->cascadeOnDelete();
+            $table->unsignedInteger('position');
+            $table->string('description');
+            $table->string('quantity')->nullable();
+            $table->string('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_sheet_items');
+    }
+};

--- a/resources/views/pdf/service-sheet.blade.php
+++ b/resources/views/pdf/service-sheet.blade.php
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="ro">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Foaie service - {{ $masina->denumire }}</title>
+    <style>
+        @page {
+            size: A4 portrait;
+            margin: 25px;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html,
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            font-size: 12px;
+            color: #1a1a1a;
+            margin: 0;
+            padding: 0;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            margin: 0;
+            padding: 0;
+            font-weight: 600;
+        }
+
+        .page-break {
+            page-break-before: always;
+        }
+
+        .meta-table,
+        .summary-table,
+        .blank-table {
+            width: 100%;
+            border-collapse: collapse;
+            table-layout: fixed;
+        }
+
+        .meta-table td {
+            padding: 4px 6px;
+            vertical-align: top;
+        }
+
+        .summary-table th,
+        .summary-table td,
+        .blank-table th,
+        .blank-table td {
+            border: 1px solid #cfd2d6;
+            padding: 6px 8px;
+            vertical-align: top;
+            word-break: break-word;
+        }
+
+        .summary-table th,
+        .blank-table th {
+            background-color: #f3f4f6;
+            font-weight: 600;
+        }
+
+        .summary-table td,
+        .blank-table td {
+            min-height: 28px;
+        }
+
+        .summary-table .col-index,
+        .blank-table .col-index {
+            width: 8%;
+            text-align: center;
+        }
+
+        .summary-table .col-description,
+        .blank-table .col-description {
+            width: 44%;
+        }
+
+        .summary-table .col-quantity,
+        .blank-table .col-quantity {
+            width: 18%;
+            text-align: center;
+        }
+
+        .summary-table .col-notes,
+        .blank-table .col-notes {
+            width: 30%;
+        }
+
+        .section-title {
+            font-size: 18px;
+            margin-bottom: 12px;
+        }
+
+        .meta-section {
+            margin-bottom: 16px;
+        }
+
+        .meta-grid {
+            width: 100%;
+            border: 1px solid #cfd2d6;
+            border-radius: 6px;
+            overflow: hidden;
+        }
+
+        .meta-grid tr:nth-child(even) td {
+            background: #f9fafb;
+        }
+
+        .meta-grid strong {
+            display: inline-block;
+            min-width: 140px;
+        }
+
+        .blank-table-caption {
+            font-size: 16px;
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+
+<body>
+    @include('pdf.service-sheet.summary')
+
+    <div class="page-break"></div>
+
+    @include('pdf.service-sheet.blank-table')
+</body>
+
+</html>

--- a/resources/views/pdf/service-sheet/blank-table.blade.php
+++ b/resources/views/pdf/service-sheet/blank-table.blade.php
@@ -1,0 +1,30 @@
+<div class="meta-section">
+    <h2 class="blank-table-caption">Tabel completare intervenții</h2>
+    <p style="margin-bottom: 12px; color: #4b5563;">Spațiu dedicat completării manuale pentru intervenții suplimentare.</p>
+</div>
+
+<table class="blank-table">
+    <thead>
+        <tr>
+            <th class="col-index">Nr. crt.</th>
+            <th class="col-description">Descriere intervenție</th>
+            <th class="col-quantity">Cantitate</th>
+            <th class="col-notes">Observații / manoperă</th>
+        </tr>
+    </thead>
+    <tbody>
+        @for ($i = 1; $i <= 14; $i++)
+            <tr>
+                <td class="col-index">{{ $i }}</td>
+                <td class="col-description">&nbsp;</td>
+                <td class="col-quantity">&nbsp;</td>
+                <td class="col-notes">&nbsp;</td>
+            </tr>
+        @endfor
+    </tbody>
+</table>
+
+<div style="margin-top: 28px; font-size: 13px;">
+    <strong>NUME MECANIC AUTO:</strong>
+    <span style="display: inline-block; min-width: 280px; border-bottom: 1px solid #cfd2d6; height: 18px; margin-left: 8px;"></span>
+</div>

--- a/resources/views/pdf/service-sheet/summary.blade.php
+++ b/resources/views/pdf/service-sheet/summary.blade.php
@@ -1,0 +1,40 @@
+<div class="meta-section">
+    <h1 class="section-title">Foaie service</h1>
+    <table class="meta-grid">
+        <tbody>
+            <tr>
+                <td><strong>Mașină:</strong> {{ $masina->denumire }}</td>
+                <td><strong>Nr. înmatriculare:</strong> {{ $masina->numar_inmatriculare }}</td>
+            </tr>
+            <tr>
+                <td><strong>Serie șasiu:</strong> {{ $masina->serie_sasiu ?? '—' }}</td>
+                <td><strong>Km bord:</strong> {{ number_format($km_bord, 0, ',', '.') }}</td>
+            </tr>
+            <tr>
+                <td><strong>Data service:</strong> {{ $data_service->format('d.m.Y') }}</td>
+                <td><strong>Generat la:</strong> {{ now()->format('d.m.Y H:i') }}</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<table class="summary-table">
+    <thead>
+        <tr>
+            <th class="col-index">Nr. crt.</th>
+            <th class="col-description">Descriere intervenție</th>
+            <th class="col-quantity">Cantitate</th>
+            <th class="col-notes">Observații / manoperă</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($items as $item)
+            <tr>
+                <td class="col-index">{{ $item['index'] }}</td>
+                <td class="col-description">{{ $item['description'] }}</td>
+                <td class="col-quantity">{{ $item['quantity'] !== '' ? $item['quantity'] : '—' }}</td>
+                <td class="col-notes">{{ $item['notes'] !== '' ? $item['notes'] : '—' }}</td>
+            </tr>
+        @endforeach
+    </tbody>
+</table>

--- a/resources/views/service/masini/index.blade.php
+++ b/resources/views/service/masini/index.blade.php
@@ -2,8 +2,11 @@
 
 @php
     $filters = $filters ?? [];
+    $viewMode = $viewMode ?? 'interventii';
+    $isServiceSheetView = $viewMode === 'service-sheets';
     $selectedMasinaId = optional($selectedMasina)->id;
     $queryParams = collect($filters)
+        ->merge(['view' => $viewMode])
         ->reject(fn ($value) => $value === null || $value === '')
         ->toArray();
     $editingEntry = $editingEntry ?? null;
@@ -32,6 +35,7 @@
             <div class="col-lg-6 mb-2">
                 <form class="needs-validation" novalidate method="GET" action="{{ route('service-masini.index') }}">
                     <div class="row gy-2 gx-3 align-items-end">
+                        <input type="hidden" name="view" value="{{ $viewMode }}">
                         <div class="col-lg-4 col-md-6">
                             <label for="numar_inmatriculare" class="form-label small text-muted mb-1">
                                 <i class="fa-solid fa-car me-1"></i>Nr. înmatriculare / Denumire mașină
@@ -40,21 +44,23 @@
                                 name="numar_inmatriculare" placeholder="Ex: B00ABC"
                                 value="{{ $filters['numar_inmatriculare'] ?? '' }}" autocomplete="off">
                         </div>
-                        <div class="col-lg-4 col-md-6">
-                            <label for="piesa" class="form-label small text-muted mb-1">
-                                <i class="fa-solid fa-puzzle-piece me-1"></i>Denumire piesă / intervenție
-                            </label>
-                            <input type="text" class="form-control rounded-3" id="piesa" name="piesa"
-                                placeholder="Ex: Filtru ulei"
-                                value="{{ $filters['piesa'] ?? '' }}" autocomplete="off">
-                        </div>
-                        <div class="col-lg-4 col-md-6">
-                            <label for="cod" class="form-label small text-muted mb-1">
-                                <i class="fa-solid fa-barcode me-1"></i>Cod piesă
-                            </label>
-                            <input type="text" class="form-control rounded-3" id="cod" name="cod"
-                                placeholder="Cod piesă" value="{{ $filters['cod'] ?? '' }}" autocomplete="off">
-                        </div>
+                        @unless ($isServiceSheetView)
+                            <div class="col-lg-4 col-md-6">
+                                <label for="piesa" class="form-label small text-muted mb-1">
+                                    <i class="fa-solid fa-puzzle-piece me-1"></i>Denumire piesă / intervenție
+                                </label>
+                                <input type="text" class="form-control rounded-3" id="piesa" name="piesa"
+                                    placeholder="Ex: Filtru ulei"
+                                    value="{{ $filters['piesa'] ?? '' }}" autocomplete="off">
+                            </div>
+                            <div class="col-lg-4 col-md-6">
+                                <label for="cod" class="form-label small text-muted mb-1">
+                                    <i class="fa-solid fa-barcode me-1"></i>Cod piesă
+                                </label>
+                                <input type="text" class="form-control rounded-3" id="cod" name="cod"
+                                    placeholder="Cod piesă" value="{{ $filters['cod'] ?? '' }}" autocomplete="off">
+                            </div>
+                        @endunless
                         <div class="col-lg-4 col-md-6">
                             <label for="data_start" class="form-label small text-muted mb-1">
                                 <i class="fa-solid fa-calendar-day me-1"></i>De la data
@@ -75,7 +81,7 @@
                                 <i class="fas fa-search text-white me-1"></i>Caută
                             </button>
                             <a class="btn btn-sm btn-secondary text-white flex-grow-1 border border-dark rounded-3"
-                                href="{{ route('service-masini.index') }}">
+                                href="{{ route('service-masini.index', ['view' => $viewMode]) }}">
                                 <i class="far fa-trash-alt text-white me-1"></i>Resetează
                             </a>
                         </div>
@@ -156,107 +162,181 @@
                                     <h5 class="mb-0">{{ $selectedMasina->denumire }}</h5>
                                     <small class="text-muted">Nr. înmatriculare: {{ $selectedMasina->numar_inmatriculare }}</small>
                                 </div>
-                                <div class="d-flex flex-wrap gap-2">
-                                    <button type="button" class="btn btn-success btn-sm rounded-3"
-                                        data-bs-toggle="modal" data-bs-target="#createEntryModal">
-                                        <i class="fa-solid fa-plus-circle me-1"></i>Adaugă intervenție
-                                    </button>
-                                    <a class="btn btn-outline-primary btn-sm rounded-3"
-                                        href="{{ route('service-masini.export', $queryParams + ['masina_id' => $selectedMasina->id]) }}">
-                                        <i class="fa-solid fa-file-pdf me-1"></i>Descarcă PDF
-                                    </a>
+                                <div class="d-flex flex-wrap gap-2 align-items-center">
+                                    @php
+                                        $tabQuery = array_merge($queryParams, ['masina_id' => $selectedMasina->id]);
+                                    @endphp
+                                    <div class="btn-group btn-group-sm" role="group" aria-label="Comutare listă intervenții sau foi">
+                                        <a class="btn {{ $isServiceSheetView ? 'btn-outline-primary' : 'btn-primary' }}"
+                                            href="{{ route('service-masini.index', array_merge($tabQuery, ['view' => 'interventii'])) }}">
+                                            <i class="fa-solid fa-list me-1"></i>Intervenții
+                                        </a>
+                                        <a class="btn {{ $isServiceSheetView ? 'btn-primary' : 'btn-outline-primary' }}"
+                                            href="{{ route('service-masini.index', array_merge($tabQuery, ['view' => 'service-sheets'])) }}">
+                                            <i class="fa-solid fa-file-lines me-1"></i>Foi service
+                                        </a>
+                                    </div>
+
+                                    @if ($isServiceSheetView)
+                                        <a class="btn btn-success btn-sm rounded-3"
+                                            href="{{ route('service-masini.sheet.create', $selectedMasina) }}">
+                                            <i class="fa-solid fa-plus-circle me-1"></i>Adaugă foaie service
+                                        </a>
+                                    @else
+                                        <button type="button" class="btn btn-success btn-sm rounded-3"
+                                            data-bs-toggle="modal" data-bs-target="#createEntryModal">
+                                            <i class="fa-solid fa-plus-circle me-1"></i>Adaugă intervenție
+                                        </button>
+                                        <a class="btn btn-outline-secondary btn-sm rounded-3"
+                                            href="{{ route('service-masini.sheet.create', $selectedMasina) }}">
+                                            <i class="fa-solid fa-file-lines me-1"></i>Foaie service
+                                        </a>
+                                        <a class="btn btn-outline-primary btn-sm rounded-3"
+                                            href="{{ route('service-masini.export', $queryParams + ['masina_id' => $selectedMasina->id]) }}">
+                                            <i class="fa-solid fa-file-pdf me-1"></i>Descarcă PDF
+                                        </a>
+                                    @endif
                                 </div>
                             </div>
                         </div>
 
                         <div class="card shadow-sm border-0">
                             <div class="table-responsive">
-                                <table class="table table-striped table-hover mb-0">
-                                    <thead class="table-light">
-                                        <tr>
-                                            <th style="min-width: 110px;">Data</th>
-                                            <th style="min-width: 120px;">Tip</th>
-                                            <th style="min-width: 180px;">Denumire</th>
-                                            <th style="min-width: 120px;">Cod</th>
-                                            <th style="min-width: 90px;">Cantitate</th>
-                                            <th style="min-width: 150px;">Mecanic</th>
-                                            <th style="min-width: 150px;">Utilizator</th>
-                                            <th>Obs</th>
-                                            <th class="text-end" style="min-width: 140px;">Acțiuni</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        @forelse ($entries as $entry)
+                                @if ($isServiceSheetView)
+                                    <table class="table table-striped table-hover mb-0">
+                                        <thead class="table-light">
                                             <tr>
-                                                <td>{{ optional($entry->data_montaj)->format('d.m.Y') ?? '—' }}</td>
-                                                <td>
-                                                    @if ($entry->tip === 'piesa')
-                                                        <span class="badge bg-primary">Piesă</span>
-                                                    @else
-                                                        <span class="badge bg-secondary">Manual</span>
-                                                    @endif
-                                                </td>
-                                                <td>
-                                                    @if ($entry->tip === 'piesa')
-                                                        {{ $entry->denumire_piesa ?? '—' }}
-                                                    @else
-                                                        {{ $entry->denumire_interventie ?? '—' }}
-                                                    @endif
-                                                </td>
-                                                <td>{{ $entry->tip === 'piesa' ? ($entry->cod_piesa ?? '—') : '—' }}</td>
-                                                <td>
-                                                    @if ($entry->tip === 'piesa')
-                                                        {{ $entry->cantitate !== null ? number_format((float) $entry->cantitate, 2) : '—' }}
-                                                    @else
-                                                        —
-                                                    @endif
-                                                </td>
-                                                <td>{{ $entry->nume_mecanic ?? '—' }}</td>
-                                                <td>{{ $entry->nume_utilizator ?? optional($entry->user)->name ?? '—' }}</td>
-                                                <td class="text-center">
-                                                    @if ($entry->observatii)
-                                                        <button type="button" class="btn btn-link p-0 text-decoration-none"
-                                                            data-bs-toggle="tooltip" data-bs-trigger="hover focus"
-                                                            title="{{ $entry->observatii }}" aria-label="Vizualizează observațiile">
-                                                            <i class="fa-solid fa-circle-info"></i>
-                                                        </button>
-                                                    @else
-                                                        —
-                                                    @endif
-                                                </td>
-                                                <td class="text-end">
-                                                    <div class="d-flex justify-content-end gap-2">
-                                                        <a class="btn btn-outline-primary btn-sm"
-                                                            href="{{ route('service-masini.index', $queryParams + ['masina_id' => $selectedMasina->id, 'entry_id' => $entry->id]) }}">
-                                                            Editează
-                                                        </a>
-                                                        <form method="POST" class="d-inline"
-                                                            action="{{ route('service-masini.entries.destroy', [$selectedMasina, $entry]) }}"
-                                                            onsubmit="return confirm('Sigur dorești să ștergi această intervenție?');">
-                                                            @csrf
-                                                            @method('DELETE')
-                                                            @foreach ($filters as $key => $value)
-                                                                @if ($value !== null && $value !== '')
-                                                                    <input type="hidden" name="{{ $key }}" value="{{ $value }}">
-                                                                @endif
-                                                            @endforeach
-                                                            <button type="submit" class="btn btn-outline-danger btn-sm">Șterge</button>
-                                                        </form>
-                                                    </div>
-                                                </td>
+                                                <th style="min-width: 140px;">Data service</th>
+                                                <th style="min-width: 120px;">Km bord</th>
+                                                <th style="min-width: 150px;">Număr poziții</th>
+                                                <th style="min-width: 160px;">Creată la</th>
+                                                <th class="text-end" style="min-width: 200px;">Acțiuni</th>
                                             </tr>
-                                        @empty
+                                        </thead>
+                                        <tbody>
+                                            @forelse ($serviceSheets as $sheet)
+                                                <tr>
+                                                    <td>{{ optional($sheet->data_service)->format('d.m.Y') ?? '—' }}</td>
+                                                    <td>{{ number_format((int) $sheet->km_bord) }}</td>
+                                                    <td>{{ $sheet->items_count }}</td>
+                                                    <td>{{ optional($sheet->created_at)->format('d.m.Y H:i') ?? '—' }}</td>
+                                                    <td class="text-end">
+                                                        <div class="d-flex justify-content-end gap-2">
+                                                            <a class="btn btn-outline-primary btn-sm"
+                                                                href="{{ route('service-masini.sheet.download', [$selectedMasina, $sheet]) }}">
+                                                                <i class="fa-solid fa-file-arrow-down me-1"></i>PDF
+                                                            </a>
+                                                            <a class="btn btn-outline-secondary btn-sm"
+                                                                href="{{ route('service-masini.sheet.edit', [$selectedMasina, $sheet]) }}">
+                                                                Editează
+                                                            </a>
+                                                            <form method="POST" class="d-inline"
+                                                                action="{{ route('service-masini.sheet.destroy', [$selectedMasina, $sheet]) }}"
+                                                                onsubmit="return confirm('Sigur dorești să ștergi această foaie de service?');">
+                                                                @csrf
+                                                                @method('DELETE')
+                                                                <button type="submit" class="btn btn-outline-danger btn-sm">Șterge</button>
+                                                            </form>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            @empty
+                                                <tr>
+                                                    <td colspan="5" class="text-center text-muted py-4">
+                                                        Nu există foi de service pentru această mașină.
+                                                    </td>
+                                                </tr>
+                                            @endforelse
+                                        </tbody>
+                                    </table>
+                                @else
+                                    <table class="table table-striped table-hover mb-0">
+                                        <thead class="table-light">
                                             <tr>
-                                                <td colspan="9" class="text-center text-muted py-4">
-                                                    Nu există intervenții pentru această mașină.
-                                                </td>
+                                                <th style="min-width: 110px;">Data</th>
+                                                <th style="min-width: 120px;">Tip</th>
+                                                <th style="min-width: 180px;">Denumire</th>
+                                                <th style="min-width: 120px;">Cod</th>
+                                                <th style="min-width: 90px;">Cantitate</th>
+                                                <th style="min-width: 150px;">Mecanic</th>
+                                                <th style="min-width: 150px;">Utilizator</th>
+                                                <th>Obs</th>
+                                                <th class="text-end" style="min-width: 140px;">Acțiuni</th>
                                             </tr>
-                                        @endforelse
-                                    </tbody>
-                                </table>
+                                        </thead>
+                                        <tbody>
+                                            @forelse ($entries as $entry)
+                                                <tr>
+                                                    <td>{{ optional($entry->data_montaj)->format('d.m.Y') ?? '—' }}</td>
+                                                    <td>
+                                                        @if ($entry->tip === 'piesa')
+                                                            <span class="badge bg-primary">Piesă</span>
+                                                        @else
+                                                            <span class="badge bg-secondary">Manual</span>
+                                                        @endif
+                                                    </td>
+                                                    <td>
+                                                        @if ($entry->tip === 'piesa')
+                                                            {{ $entry->denumire_piesa ?? '—' }}
+                                                        @else
+                                                            {{ $entry->denumire_interventie ?? '—' }}
+                                                        @endif
+                                                    </td>
+                                                    <td>{{ $entry->tip === 'piesa' ? ($entry->cod_piesa ?? '—') : '—' }}</td>
+                                                    <td>
+                                                        @if ($entry->tip === 'piesa')
+                                                            {{ $entry->cantitate !== null ? number_format((float) $entry->cantitate, 2) : '—' }}
+                                                        @else
+                                                            —
+                                                        @endif
+                                                    </td>
+                                                    <td>{{ $entry->nume_mecanic ?? '—' }}</td>
+                                                    <td>{{ $entry->nume_utilizator ?? optional($entry->user)->name ?? '—' }}</td>
+                                                    <td class="text-center">
+                                                        @if ($entry->observatii)
+                                                            <button type="button" class="btn btn-link p-0 text-decoration-none"
+                                                                data-bs-toggle="tooltip" data-bs-trigger="hover focus"
+                                                                title="{{ $entry->observatii }}" aria-label="Vizualizează observațiile">
+                                                                <i class="fa-solid fa-circle-info"></i>
+                                                            </button>
+                                                        @else
+                                                            —
+                                                        @endif
+                                                    </td>
+                                                    <td class="text-end">
+                                                        <div class="d-flex justify-content-end gap-2">
+                                                            <a class="btn btn-outline-primary btn-sm"
+                                                                href="{{ route('service-masini.index', $queryParams + ['masina_id' => $selectedMasina->id, 'entry_id' => $entry->id]) }}">
+                                                                Editează
+                                                            </a>
+                                                            <form method="POST" class="d-inline"
+                                                                action="{{ route('service-masini.entries.destroy', [$selectedMasina, $entry]) }}"
+                                                                onsubmit="return confirm('Sigur dorești să ștergi această intervenție?');">
+                                                                @csrf
+                                                                @method('DELETE')
+                                                                @foreach ($filters as $key => $value)
+                                                                    @if ($value !== null && $value !== '')
+                                                                        <input type="hidden" name="{{ $key }}" value="{{ $value }}">
+                                                                    @endif
+                                                                @endforeach
+                                                                <button type="submit" class="btn btn-outline-danger btn-sm">Șterge</button>
+                                                            </form>
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            @empty
+                                                <tr>
+                                                    <td colspan="9" class="text-center text-muted py-4">
+                                                        Nu există intervenții pentru această mașină.
+                                                    </td>
+                                                </tr>
+                                            @endforelse
+                                        </tbody>
+                                    </table>
+                                @endif
                             </div>
                             <div class="card-footer">
-                                {{ $entries->links() }}
+                                {{ $isServiceSheetView ? $serviceSheets->links() : $entries->links() }}
                             </div>
                         </div>
                     @else
@@ -269,7 +349,8 @@
         </div>
     </div>
     @if ($selectedMasina)
-        @php
+        @if (! $isServiceSheetView)
+            @php
             $createEntryTip = $createEntryOld ? old('tip', 'piesa') : 'piesa';
             $createEntrySelectedPiece = $createEntryOld ? (int) old('gestiune_piesa_id') : null;
             $createEntryCantitate = $createEntryOld ? old('cantitate', '1') : '1';
@@ -277,7 +358,7 @@
             $createEntryMechanic = $createEntryOld ? old('nume_mecanic') : '';
             $createEntryObservatii = $createEntryOld ? old('observatii') : '';
             $createEntryDenumire = $createEntryOld ? old('denumire_interventie') : '';
-        @endphp
+            @endphp
         <div class="modal fade" id="createEntryModal" tabindex="-1" aria-labelledby="createEntryModalLabel"
             aria-hidden="true">
             <div class="modal-dialog modal-lg modal-dialog-scrollable">
@@ -404,7 +485,7 @@
             </div>
         </div>
 
-        @if ($isEditingEntry)
+        @if ($isEditingEntry && ! $isServiceSheetView)
             @php
                 $editEntryTip = $entryOldMatchesEditing ? old('tip', $editingEntry->tip ?? 'piesa') : ($editingEntry->tip ?? 'piesa');
                 $editEntrySelectedPiece = $entryOldMatchesEditing
@@ -554,10 +635,10 @@
                 </div>
             </div>
         @endif
-    @endif
+        @endif
 
-    <div class="modal fade" id="createMasinaModal" tabindex="-1" aria-labelledby="createMasinaModalLabel"
-        aria-hidden="true">
+        <div class="modal fade" id="createMasinaModal" tabindex="-1" aria-labelledby="createMasinaModalLabel"
+            aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
             <form method="POST" action="{{ route('service-masini.store-masina') }}" class="modal-content">
                 @csrf

--- a/resources/views/service/masini/service-sheet/_form.blade.php
+++ b/resources/views/service/masini/service-sheet/_form.blade.php
@@ -1,0 +1,249 @@
+@php
+    $sheet = $sheet ?? null;
+    $isEdit = (bool) $sheet;
+    $formAction = $formAction ?? ($isEdit ? route('service-masini.sheet.update', [$masina, $sheet]) : route('service-masini.sheet.store', $masina));
+    $httpMethod = $httpMethod ?? ($isEdit ? 'PUT' : 'POST');
+    $formTitle = $formTitle ?? ($isEdit ? 'Editează foaia de service' : 'Foaie service');
+    $submitLabel = $submitLabel ?? ($isEdit ? 'Salvează modificările' : 'Generează PDF');
+    $submitIcon = $submitIcon ?? ($isEdit ? 'fa-floppy-disk' : 'fa-file-arrow-down');
+    $downloadUrl = $downloadUrl ?? ($isEdit ? route('service-masini.sheet.download', [$masina, $sheet]) : null);
+
+    $rawItems = old('items');
+    if (is_array($rawItems) && count($rawItems) > 0) {
+        $items = array_values($rawItems);
+    } elseif ($isEdit) {
+        $items = $sheet->items
+            ->sortBy('position')
+            ->map(fn ($item) => [
+                'description' => $item->description,
+                'quantity' => $item->quantity,
+                'notes' => $item->notes,
+            ])
+            ->values()
+            ->toArray();
+    } else {
+        $defaultDescriptions = [
+            'schimb ulei + filtre',
+            'verificare lumini',
+            'verificare placute frana si gresat culisoare',
+            'verificare jocuri roti',
+        ];
+
+        $items = collect($defaultDescriptions)
+            ->map(fn ($description) => [
+                'description' => $description,
+                'quantity' => '',
+                'notes' => '',
+            ])
+            ->all();
+    }
+
+    $kmValue = old('km_bord', $isEdit ? $sheet->km_bord : '');
+    $dateValue = old('data_service', $isEdit ? optional($sheet->data_service)->toDateString() : now()->toDateString());
+@endphp
+
+<div class="mx-3 px-3 card mx-auto" style="border-radius: 40px; max-width: 1000px;">
+    <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2"
+        style="border-radius: 40px 40px 0 0;">
+        <div>
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-file-lines me-1"></i>{{ $formTitle }}
+            </span>
+            <div class="mt-2">
+                <h5 class="mb-0">{{ $masina->denumire }}</h5>
+                <small class="text-muted">Nr. înmatriculare: {{ $masina->numar_inmatriculare }}</small>
+            </div>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+            @if ($downloadUrl)
+                <a href="{{ $downloadUrl }}" class="btn btn-outline-primary btn-sm rounded-3">
+                    <i class="fa-solid fa-file-arrow-down me-1"></i>Descarcă PDF
+                </a>
+            @endif
+            <a href="{{ route('service-masini.index', ['masina_id' => $masina->id, 'view' => 'service-sheets']) }}"
+                class="btn btn-outline-secondary btn-sm rounded-3">
+                <i class="fa-solid fa-arrow-left me-1"></i>Înapoi la service mașini
+            </a>
+        </div>
+    </div>
+
+    <div class="card-body">
+        @include('errors')
+
+        <form method="POST" action="{{ $formAction }}" id="service-sheet-form" class="d-flex flex-column gap-4">
+            @csrf
+            @if ($httpMethod !== 'POST')
+                @method($httpMethod)
+            @endif
+
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="km_bord" class="form-label small text-muted mb-1">Km bord</label>
+                    <input type="number" min="0" class="form-control rounded-3" id="km_bord" name="km_bord"
+                        value="{{ $kmValue }}" placeholder="Ex: 125000" required>
+                    @error('km_bord')
+                        <div class="text-danger small mt-1">{{ $message }}</div>
+                    @enderror
+                </div>
+                <div class="col-md-6">
+                    <label for="data_service" class="form-label small text-muted mb-1">Data service</label>
+                    <input type="date" class="form-control rounded-3" id="data_service" name="data_service"
+                        value="{{ $dateValue }}" required>
+                    @error('data_service')
+                        <div class="text-danger small mt-1">{{ $message }}</div>
+                    @enderror
+                </div>
+            </div>
+
+            <div>
+                <div class="d-flex flex-wrap justify-content-between align-items-center mb-3 gap-2">
+                    <h6 class="mb-0"><i class="fa-solid fa-list-check me-1"></i>Necesar schimb piese și manoperă</h6>
+                    <button type="button" class="btn btn-outline-primary btn-sm rounded-3" id="add-service-item">
+                        <i class="fa-solid fa-plus me-1"></i>Adaugă rând
+                    </button>
+                </div>
+
+                <div id="service-items" class="d-flex flex-column gap-3">
+                    @foreach ($items as $index => $item)
+                        <div class="card border-0 shadow-sm service-item-row">
+                            <div class="card-body">
+                                <div class="row g-3 align-items-end">
+                                    <div class="col-lg-6">
+                                        <label for="items_{{ $index }}_description" class="form-label small text-muted mb-1">Descriere intervenție</label>
+                                        <input type="text" class="form-control rounded-3"
+                                            id="items_{{ $index }}_description"
+                                            name="items[{{ $index }}][description]"
+                                            value="{{ $item['description'] ?? '' }}" placeholder="Ex: Schimb ulei" required>
+                                        @error('items.' . $index . '.description')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                    <div class="col-lg-3">
+                                        <label for="items_{{ $index }}_quantity" class="form-label small text-muted mb-1">Cantitate</label>
+                                        <input type="text" class="form-control rounded-3"
+                                            id="items_{{ $index }}_quantity"
+                                            name="items[{{ $index }}][quantity]"
+                                            value="{{ $item['quantity'] ?? '' }}" placeholder="Ex: 2 buc">
+                                        @error('items.' . $index . '.quantity')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                    <div class="col-lg-3">
+                                        <label for="items_{{ $index }}_notes" class="form-label small text-muted mb-1">Observații / manoperă</label>
+                                        <input type="text" class="form-control rounded-3"
+                                            id="items_{{ $index }}_notes"
+                                            name="items[{{ $index }}][notes]"
+                                            value="{{ $item['notes'] ?? '' }}" placeholder="Ex: Manoperă 1h">
+                                        @error('items.' . $index . '.notes')
+                                            <div class="text-danger small mt-1">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+                                    <div class="col-12 text-end">
+                                        <button type="button" class="btn btn-link text-danger text-decoration-none px-0" data-remove-item>
+                                            <i class="fa-solid fa-trash-can me-1"></i>Elimină rândul
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-end gap-2">
+                <a href="{{ route('service-masini.index', ['masina_id' => $masina->id, 'view' => 'service-sheets']) }}"
+                    class="btn btn-outline-secondary rounded-3">Renunță</a>
+                <button type="submit" class="btn btn-primary rounded-3">
+                    <i class="fa-solid {{ $submitIcon }} me-1"></i>{{ $submitLabel }}
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<template id="service-item-template">
+    <div class="card border-0 shadow-sm service-item-row">
+        <div class="card-body">
+            <div class="row g-3 align-items-end">
+                <div class="col-lg-6">
+                    <label class="form-label small text-muted mb-1" data-for="description">Descriere intervenție</label>
+                    <input type="text" class="form-control rounded-3" data-name="description"
+                        placeholder="Ex: Schimb ulei" required>
+                </div>
+                <div class="col-lg-3">
+                    <label class="form-label small text-muted mb-1" data-for="quantity">Cantitate</label>
+                    <input type="text" class="form-control rounded-3" data-name="quantity" placeholder="Ex: 2 buc">
+                </div>
+                <div class="col-lg-3">
+                    <label class="form-label small text-muted mb-1" data-for="notes">Observații / manoperă</label>
+                    <input type="text" class="form-control rounded-3" data-name="notes" placeholder="Ex: Manoperă 1h">
+                </div>
+                <div class="col-12 text-end">
+                    <button type="button" class="btn btn-link text-danger text-decoration-none px-0" data-remove-item>
+                        <i class="fa-solid fa-trash-can me-1"></i>Elimină rândul
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+@push('page-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const container = document.getElementById('service-items');
+            const template = document.getElementById('service-item-template');
+            const addButton = document.getElementById('add-service-item');
+
+            function updateIndices() {
+                const rows = container.querySelectorAll('.service-item-row');
+
+                rows.forEach((row, index) => {
+                    row.querySelectorAll('[data-name]').forEach((input) => {
+                        const field = input.dataset.name;
+                        const id = `items_${index}_${field}`;
+
+                        input.name = `items[${index}][${field}]`;
+                        input.id = id;
+                    });
+
+                    row.querySelectorAll('[data-for]').forEach((label) => {
+                        const field = label.dataset.for;
+                        label.setAttribute('for', `items_${index}_${field}`);
+                    });
+                });
+            }
+
+            if (addButton) {
+                addButton.addEventListener('click', () => {
+                    const clone = document.importNode(template.content, true);
+                    container.appendChild(clone);
+                    updateIndices();
+                });
+            }
+
+            container.addEventListener('click', (event) => {
+                const removeButton = event.target.closest('[data-remove-item]');
+
+                if (!removeButton) {
+                    return;
+                }
+
+                const rows = container.querySelectorAll('.service-item-row');
+
+                if (rows.length <= 1) {
+                    return;
+                }
+
+                const row = removeButton.closest('.service-item-row');
+
+                if (row) {
+                    row.remove();
+                    updateIndices();
+                }
+            });
+
+            updateIndices();
+        });
+    </script>
+@endpush

--- a/resources/views/service/masini/service-sheet/create.blade.php
+++ b/resources/views/service/masini/service-sheet/create.blade.php
@@ -1,0 +1,7 @@
+@extends('layouts.app')
+
+@section('content')
+    @include('service.masini.service-sheet._form', [
+        'masina' => $masina,
+    ])
+@endsection

--- a/resources/views/service/masini/service-sheet/edit.blade.php
+++ b/resources/views/service/masini/service-sheet/edit.blade.php
@@ -1,0 +1,8 @@
+@extends('layouts.app')
+
+@section('content')
+    @include('service.masini.service-sheet._form', [
+        'masina' => $masina,
+        'sheet' => $sheet,
+    ])
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorFisierController;
 use App\Http\Controllers\FacturiFurnizori\PlataCalupController;
 use App\Http\Controllers\Service\GestiunePieseController;
 use App\Http\Controllers\Service\ServiceMasiniController;
+use App\Http\Controllers\Service\ServiceSheetController;
 use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\SeederCenterController;
@@ -187,6 +188,18 @@ Route::group(['middleware' => ['auth', 'restrict-mechanic-access']], function ()
         ->name('service-masini.entries.destroy');
     Route::get('/service-masini/export/pdf', [ServiceMasiniController::class, 'export'])
         ->name('service-masini.export');
+    Route::get('/service-masini/{masina}/foaie-service', [ServiceSheetController::class, 'create'])
+        ->name('service-masini.sheet.create');
+    Route::post('/service-masini/{masina}/foaie-service', [ServiceSheetController::class, 'store'])
+        ->name('service-masini.sheet.store');
+    Route::get('/service-masini/{masina}/foaie-service/{sheet}/edit', [ServiceSheetController::class, 'edit'])
+        ->name('service-masini.sheet.edit');
+    Route::put('/service-masini/{masina}/foaie-service/{sheet}', [ServiceSheetController::class, 'update'])
+        ->name('service-masini.sheet.update');
+    Route::delete('/service-masini/{masina}/foaie-service/{sheet}', [ServiceSheetController::class, 'destroy'])
+        ->name('service-masini.sheet.destroy');
+    Route::get('/service-masini/{masina}/foaie-service/{sheet}/pdf', [ServiceSheetController::class, 'download'])
+        ->name('service-masini.sheet.download');
 
 
     Route::get('/rapoarte/incasari-utilizatori', [RaportController::class, 'incasariUtilizatori']);

--- a/tests/Feature/Service/ServiceSheetTest.php
+++ b/tests/Feature/Service/ServiceSheetTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Service;
+
+use App\Models\Service\Masina;
+use App\Models\Service\ServiceSheet;
+use App\Models\Service\ServiceSheetItem;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ServiceSheetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_service_sheet_store_persists_and_downloads_pdf(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create([
+            'denumire' => 'Autoutilitara Test',
+            'numar_inmatriculare' => 'B12XYZ',
+        ]);
+
+        $response = $this->actingAs($user)->post(route('service-masini.sheet.store', $masina), [
+            'km_bord' => 125000,
+            'data_service' => '2024-05-01',
+            'items' => [
+                [
+                    'description' => 'Schimb ulei motor',
+                    'quantity' => '1',
+                    'notes' => 'Manoperă 1h',
+                ],
+                [
+                    'description' => 'Filtru aer',
+                    'quantity' => '1',
+                    'notes' => '',
+                ],
+            ],
+        ]);
+
+        $response->assertOk();
+        $this->assertSame('application/pdf', $response->headers->get('content-type'));
+        $this->assertStringContainsString('foaie-service-b12xyz', strtolower($response->headers->get('content-disposition')));
+
+        $this->assertDatabaseHas('service_sheets', [
+            'masina_id' => $masina->id,
+            'km_bord' => 125000,
+            'data_service' => '2024-05-01',
+        ]);
+
+        $sheet = ServiceSheet::query()->where('masina_id', $masina->id)->firstOrFail();
+
+        $this->assertDatabaseHas('service_sheet_items', [
+            'service_sheet_id' => $sheet->id,
+            'position' => 1,
+            'description' => 'Schimb ulei motor',
+            'quantity' => '1',
+            'notes' => 'Manoperă 1h',
+        ]);
+
+        $this->assertDatabaseHas('service_sheet_items', [
+            'service_sheet_id' => $sheet->id,
+            'position' => 2,
+            'description' => 'Filtru aer',
+            'quantity' => '1',
+            'notes' => null,
+        ]);
+    }
+
+    public function test_service_sheet_index_view_lists_records(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        $sheet = ServiceSheet::factory()
+            ->for($masina)
+            ->create([
+                'km_bord' => 23456,
+                'data_service' => '2024-04-15',
+            ]);
+
+        ServiceSheetItem::factory()->count(3)->for($sheet)->sequence(
+            ['position' => 1],
+            ['position' => 2],
+            ['position' => 3],
+        )->create();
+
+        $response = $this->actingAs($user)->get(route('service-masini.index', [
+            'masina_id' => $masina->id,
+            'view' => 'service-sheets',
+        ]));
+
+        $response->assertOk();
+        $response->assertSee('Foi service');
+        $response->assertSee('15.04.2024');
+        $response->assertSee('23,456');
+        $response->assertSee('3');
+    }
+
+    public function test_service_sheet_can_be_updated_and_deleted(): void
+    {
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        $sheet = ServiceSheet::factory()
+            ->for($masina)
+            ->create([
+                'km_bord' => 1000,
+                'data_service' => '2024-01-10',
+            ]);
+
+        ServiceSheetItem::factory()->count(2)->for($sheet)->sequence(
+            ['position' => 1, 'description' => 'Inițial 1'],
+            ['position' => 2, 'description' => 'Inițial 2'],
+        )->create();
+
+        $updateResponse = $this->actingAs($user)->put(route('service-masini.sheet.update', [$masina, $sheet]), [
+            'km_bord' => 2500,
+            'data_service' => '2024-02-20',
+            'items' => [
+                [
+                    'description' => 'Revizie completă',
+                    'quantity' => '2',
+                    'notes' => 'Include filtre',
+                ],
+            ],
+        ]);
+
+        $updateResponse->assertRedirect(route('service-masini.index', [
+            'masina_id' => $masina->id,
+            'view' => 'service-sheets',
+        ]));
+
+        $this->assertDatabaseHas('service_sheets', [
+            'id' => $sheet->id,
+            'km_bord' => 2500,
+            'data_service' => '2024-02-20',
+        ]);
+
+        $this->assertDatabaseMissing('service_sheet_items', [
+            'service_sheet_id' => $sheet->id,
+            'description' => 'Inițial 1',
+        ]);
+
+        $this->assertDatabaseHas('service_sheet_items', [
+            'service_sheet_id' => $sheet->id,
+            'position' => 1,
+            'description' => 'Revizie completă',
+            'quantity' => '2',
+            'notes' => 'Include filtre',
+        ]);
+
+        $deleteResponse = $this->actingAs($user)->delete(route('service-masini.sheet.destroy', [$masina, $sheet]));
+        $deleteResponse->assertRedirect(route('service-masini.index', [
+            'masina_id' => $masina->id,
+            'view' => 'service-sheets',
+        ]));
+
+        $this->assertDatabaseMissing('service_sheets', [
+            'id' => $sheet->id,
+        ]);
+        $this->assertDatabaseMissing('service_sheet_items', [
+            'service_sheet_id' => $sheet->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- prefill new service sheet forms with the standard maintenance tasks requested
- add a mechanic name line to the blank page of the service sheet PDF

## Testing
- ❌ `php artisan test` (fails because vendor/autoload.php is missing; composer install cannot complete in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68f1e9223b2c8326b43aec8162822eba