### PR TITLE
Redesign service sheet PDF layout

### DIFF
--- a/resources/views/pdf/service-sheet.blade.php
+++ b/resources/views/pdf/service-sheet.blade.php
@@ -7,7 +7,7 @@
     <style>
         @page {
             size: A4 portrait;
-            margin: 25px;
+            margin: 18mm 15mm 18mm 15mm;
         }
 
         * {
@@ -17,10 +17,12 @@
         html,
         body {
             font-family: DejaVu Sans, sans-serif;
-            font-size: 12px;
-            color: #1a1a1a;
+            font-size: 11px;
+            color: #111827;
             margin: 0;
             padding: 0;
+            line-height: 1.35;
+            background: #ffffff;
         }
 
         h1,
@@ -32,85 +34,158 @@
             margin: 0;
             padding: 0;
             font-weight: 600;
+            color: #0f172a;
+            letter-spacing: 0.02em;
+            text-transform: uppercase;
+        }
+
+        .sheet {
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .sheet-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            border-bottom: 2px solid #e2e8f0;
+            padding-bottom: 10px;
+        }
+
+        .sheet-header .logo {
+            height: 58px;
+            width: auto;
+        }
+
+        .sheet-header .title-block {
+            text-align: right;
+        }
+
+        .sheet-header .title-block h1 {
+            font-size: 22px;
+            margin-bottom: 4px;
+        }
+
+        .sheet-header .title-block span {
+            display: block;
+            font-size: 12px;
+            letter-spacing: 0.12em;
+            color: #475569;
+        }
+
+        .meta-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 12px;
+        }
+
+        .meta-card {
+            border: 1px solid #cbd5f5;
+            border-radius: 8px;
+            padding: 10px 12px;
+            background: #f8fafc;
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .meta-card span.label {
+            font-size: 10px;
+            color: #475569;
+            letter-spacing: 0.08em;
+        }
+
+        .meta-card span.value {
+            font-size: 15px;
+            font-weight: 600;
+            color: #0f172a;
+            text-transform: uppercase;
+        }
+
+        .section-title {
+            font-size: 16px;
+            letter-spacing: 0.08em;
+            padding-bottom: 6px;
+            border-bottom: 1px solid #cbd5f5;
+        }
+
+        .entry-table,
+        .parts-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 8px;
+        }
+
+        .entry-table th,
+        .entry-table td,
+        .parts-table th,
+        .parts-table td {
+            border: 1px solid #d0d7e2;
+            padding: 7px 8px;
+            vertical-align: top;
+        }
+
+        .entry-table thead th,
+        .parts-table thead th {
+            background: #e9effa;
+            font-size: 11px;
+            color: #1e293b;
+            letter-spacing: 0.04em;
+        }
+
+        .entry-table tbody td.number,
+        .parts-table tbody td.number {
+            width: 46px;
+            text-align: center;
+            font-weight: 600;
+        }
+
+        .notes-area {
+            margin-top: 12px;
+            border: 1px dashed #94a3b8;
+            border-radius: 6px;
+            min-height: 80px;
+            padding: 10px 12px;
+            background: #f8fafc;
+        }
+
+        .notes-area span {
+            display: block;
+            font-size: 10px;
+            text-transform: uppercase;
+            color: #64748b;
+            letter-spacing: 0.08em;
+        }
+
+        .signature-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 20px;
+            margin-top: 40px;
+        }
+
+        .signature-block {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            min-width: 220px;
+        }
+
+        .signature-block span.label {
+            font-size: 10px;
+            color: #475569;
+            letter-spacing: 0.06em;
+        }
+
+        .signature-line {
+            border-bottom: 1px solid #1e293b;
+            height: 18px;
         }
 
         .page-break {
             page-break-before: always;
-        }
-
-        .meta-table,
-        .summary-table,
-        .blank-table {
-            width: 100%;
-            border-collapse: collapse;
-            table-layout: fixed;
-        }
-
-        .meta-table td {
-            padding: 4px 6px;
-            vertical-align: top;
-        }
-
-        .summary-table th,
-        .summary-table td,
-        .blank-table th,
-        .blank-table td {
-            border: 1px solid #cfd2d6;
-            padding: 6px 8px;
-            vertical-align: top;
-            word-break: break-word;
-        }
-
-        .summary-table th,
-        .blank-table th {
-            background-color: #f3f4f6;
-            font-weight: 600;
-        }
-
-        .summary-table td,
-        .blank-table td {
-            min-height: 28px;
-        }
-
-        .summary-table .col-index,
-        .blank-table .col-index {
-            width: 8%;
-            text-align: center;
-        }
-
-        .summary-table .col-descriere,
-        .blank-table .col-descriere {
-            width: 92%;
-        }
-
-        .section-title {
-            font-size: 18px;
-            margin-bottom: 12px;
-        }
-
-        .meta-section {
-            margin-bottom: 16px;
-        }
-
-        .meta-grid {
-            width: 100%;
-            border: 1px solid #cfd2d6;
-            border-radius: 6px;
-            overflow: hidden;
-        }
-
-        .meta-grid tr:nth-child(even) td {
-            background: #f9fafb;
-        }
-
-        .meta-grid strong {
-            display: inline-block;
-            min-width: 140px;
-        }
-
-        .blank-table-caption {
-            font-size: 16px;
-            margin-bottom: 10px;
         }
     </style>
 </head>

--- a/resources/views/pdf/service-sheet/blank-table.blade.php
+++ b/resources/views/pdf/service-sheet/blank-table.blade.php
@@ -1,26 +1,59 @@
-<div class="meta-section">
-    <h2 class="blank-table-caption">Tabel completare intervenții</h2>
-    <p style="margin-bottom: 12px; color: #4b5563;">Spațiu dedicat completării manuale pentru intervenții suplimentare.</p>
-</div>
+<div class="sheet">
+    <div class="sheet-header">
+        <img class="logo" src="{{ public_path('images/logo3.jpg') }}" alt="Logo">
+        <div class="title-block">
+            <h1>Foaie Service</h1>
+            <span>Fisa iesire service auto</span>
+        </div>
+    </div>
 
-<table class="blank-table">
-    <thead>
-        <tr>
-            <th class="col-index">Nr. crt.</th>
-            <th class="col-descriere">Descriere intervenție</th>
-        </tr>
-    </thead>
-    <tbody>
-        @for ($i = 1; $i <= 14; $i++)
-            <tr>
-                <td class="col-index">{{ $i }}</td>
-                <td class="col-descriere">&nbsp;</td>
-            </tr>
-        @endfor
-    </tbody>
-</table>
+    <div class="meta-grid">
+        <div class="meta-card">
+            <span class="label">Nr. auto</span>
+            <span class="value">{{ $masina->numar_inmatriculare }}</span>
+        </div>
+        <div class="meta-card">
+            <span class="label">Km bord</span>
+            <span class="value">{{ number_format($km_bord, 0, ',', '.') }}</span>
+        </div>
+        <div class="meta-card">
+            <span class="label">Data completare</span>
+            <span class="value">{{ now()->format('d.m.Y') }}</span>
+        </div>
+    </div>
 
-<div style="margin-top: 28px; font-size: 13px;">
-    <strong>NUME MECANIC AUTO:</strong>
-    <span style="display: inline-block; min-width: 280px; border-bottom: 1px solid #cfd2d6; height: 18px; margin-left: 8px;"></span>
+    <div>
+        <h2 class="section-title">Piese si materiale utilizate</h2>
+        <table class="parts-table">
+            <thead>
+                <tr>
+                    <th style="width: 46px;">Nr.</th>
+                    <th>Denumire piesa</th>
+                    <th style="width: 28%;">Cod piesa</th>
+                    <th style="width: 16%;">Cantitate</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for ($i = 1; $i <= 18; $i++)
+                    <tr>
+                        <td class="number">{{ $i }}</td>
+                        <td>&nbsp;</td>
+                        <td></td>
+                        <td></td>
+                    </tr>
+                @endfor
+            </tbody>
+        </table>
+    </div>
+
+    <div class="signature-row" style="margin-top: 60px;">
+        <div class="signature-block">
+            <span class="label">Mecanic auto</span>
+            <div class="signature-line"></div>
+        </div>
+        <div class="signature-block" style="align-items: flex-end; text-align: right;">
+            <span class="label">Client / reprezentant</span>
+            <div class="signature-line" style="width: 220px;"></div>
+        </div>
+    </div>
 </div>

--- a/resources/views/pdf/service-sheet/summary.blade.php
+++ b/resources/views/pdf/service-sheet/summary.blade.php
@@ -1,36 +1,74 @@
-<div class="meta-section">
-    <h1 class="section-title">Foaie service</h1>
-    <table class="meta-grid">
-        <tbody>
-            <tr>
-                <td><strong>Mașină:</strong> {{ $masina->denumire }}</td>
-                <td><strong>Nr. înmatriculare:</strong> {{ $masina->numar_inmatriculare }}</td>
-            </tr>
-            <tr>
-                <td><strong>Serie șasiu:</strong> {{ $masina->serie_sasiu ?? '—' }}</td>
-                <td><strong>Km bord:</strong> {{ number_format($km_bord, 0, ',', '.') }}</td>
-            </tr>
-            <tr>
-                <td><strong>Data service:</strong> {{ $data_service->format('d.m.Y') }}</td>
-                <td><strong>Generat la:</strong> {{ now()->format('d.m.Y H:i') }}</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+<div class="sheet">
+    <div class="sheet-header">
+        <img class="logo" src="{{ public_path('images/logo3.jpg') }}" alt="Logo">
+        <div class="title-block">
+            <h1>Foaie Service</h1>
+            <span>Fisa intrare service auto</span>
+        </div>
+    </div>
 
-<table class="summary-table">
-    <thead>
-        <tr>
-            <th class="col-index">Nr. crt.</th>
-            <th class="col-descriere">Descriere intervenție</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach ($items as $item)
-            <tr>
-                <td class="col-index">{{ $item['index'] }}</td>
-                <td class="col-descriere">{{ $item['descriere'] }}</td>
-            </tr>
-        @endforeach
-    </tbody>
-</table>
+    <div class="meta-grid">
+        <div class="meta-card">
+            <span class="label">Nr. auto</span>
+            <span class="value">{{ $masina->numar_inmatriculare }}</span>
+        </div>
+        <div class="meta-card">
+            <span class="label">Km bord</span>
+            <span class="value">{{ number_format($km_bord, 0, ',', '.') }}</span>
+        </div>
+        <div class="meta-card">
+            <span class="label">Data service</span>
+            <span class="value">{{ $data_service->format('d.m.Y') }}</span>
+        </div>
+    </div>
+
+    <div>
+        <h2 class="section-title">Fisa intrare service</h2>
+        <table class="entry-table">
+            <thead>
+                <tr>
+                    <th style="width: 46px;">Nr.</th>
+                    <th>Descriere interventie</th>
+                    <th style="width: 28%;">Observatii</th>
+                </tr>
+            </thead>
+            <tbody>
+                @php
+                    $rowsRendered = 0;
+                @endphp
+                @foreach ($items as $item)
+                    @php $rowsRendered++; @endphp
+                    <tr>
+                        <td class="number">{{ $item['index'] }}</td>
+                        <td>{{ $item['descriere'] }}</td>
+                        <td></td>
+                    </tr>
+                @endforeach
+                @if ($rowsRendered < 12)
+                    @for ($i = $rowsRendered + 1; $i <= 12; $i++)
+                        <tr>
+                            <td class="number">{{ $i }}</td>
+                            <td>&nbsp;</td>
+                            <td></td>
+                        </tr>
+                    @endfor
+                @endif
+            </tbody>
+        </table>
+    </div>
+
+    <div class="notes-area">
+        <span>Observatii suplimentare / recomandari</span>
+    </div>
+
+    <div class="signature-row">
+        <div class="signature-block">
+            <span class="label">Receptie service</span>
+            <div class="signature-line"></div>
+        </div>
+        <div class="signature-block" style="align-items: flex-end; text-align: right;">
+            <span class="label">Client / reprezentant</span>
+            <div class="signature-line" style="width: 220px;"></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- restyle the shared PDF layout with modern typography, spacing, and reusable classes for headers, metadata, tables, and signatures
- rebuild the service sheet summary to feature the new logo, key vehicle metadata cards, intervention table, notes, and signature areas similar to the provided mockups
- revamp the blank table page into a dedicated "Fisa iesire service" sheet with a three-column parts table and mechanic/client signature blocks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f2103e72c88326919ad4502d52e129