### PR TITLE
Stream service sheet PDF with centred layout

### DIFF
--- a/resources/views/pdf/service-sheet.blade.php
+++ b/resources/views/pdf/service-sheet.blade.php
@@ -7,7 +7,7 @@
     <style>
         @page {
             size: A4 portrait;
-            margin: 25px;
+            margin: 20mm 20mm 20mm 20mm;
         }
 
         * {
@@ -18,99 +18,106 @@
         body {
             font-family: DejaVu Sans, sans-serif;
             font-size: 12px;
-            color: #1a1a1a;
+            color: #0f172a;
             margin: 0;
             padding: 0;
+            line-height: 1.4;
+            background: #ffffff;
         }
 
         h1,
         h2,
-        h3,
-        h4,
-        h5,
-        h6 {
+        h3 {
             margin: 0;
-            padding: 0;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .page {
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+
+        .page-header {
+            text-align: center;
+        }
+
+        .page-header img {
+            width: 180px;
+            height: auto;
+        }
+
+        .page-title {
+            font-size: 28px;
+            margin-top: 6px;
+        }
+
+        .section-heading {
+            text-align: center;
+            font-size: 16px;
+            letter-spacing: 0.08em;
+        }
+
+        .info-table,
+        .parts-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .info-table th,
+        .info-table td,
+        .parts-table th,
+        .parts-table td {
+            border: 1px solid #0f172a;
+            padding: 8px 10px;
+            text-align: left;
+        }
+
+        .info-table th {
+            width: 33.33%;
+            background: #f1f5f9;
+            font-size: 12px;
+        }
+
+        .info-table td {
+            font-size: 14px;
             font-weight: 600;
+        }
+
+        .interventions-list {
+            margin: 0;
+            padding-left: 22px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .mechanic-label {
+            font-size: 12px;
+            font-weight: 600;
+            margin-bottom: 6px;
+        }
+
+        .mechanic-line {
+            border-bottom: 1px solid #0f172a;
+            height: 22px;
+            margin-bottom: 18px;
+        }
+
+        .parts-table th {
+            background: #f1f5f9;
+            text-transform: uppercase;
+            font-size: 12px;
+        }
+
+        .parts-table td {
+            height: 26px;
         }
 
         .page-break {
             page-break-before: always;
-        }
-
-        .meta-table,
-        .summary-table,
-        .blank-table {
-            width: 100%;
-            border-collapse: collapse;
-            table-layout: fixed;
-        }
-
-        .meta-table td {
-            padding: 4px 6px;
-            vertical-align: top;
-        }
-
-        .summary-table th,
-        .summary-table td,
-        .blank-table th,
-        .blank-table td {
-            border: 1px solid #cfd2d6;
-            padding: 6px 8px;
-            vertical-align: top;
-            word-break: break-word;
-        }
-
-        .summary-table th,
-        .blank-table th {
-            background-color: #f3f4f6;
-            font-weight: 600;
-        }
-
-        .summary-table td,
-        .blank-table td {
-            min-height: 28px;
-        }
-
-        .summary-table .col-index,
-        .blank-table .col-index {
-            width: 8%;
-            text-align: center;
-        }
-
-        .summary-table .col-descriere,
-        .blank-table .col-descriere {
-            width: 92%;
-        }
-
-        .section-title {
-            font-size: 18px;
-            margin-bottom: 12px;
-        }
-
-        .meta-section {
-            margin-bottom: 16px;
-        }
-
-        .meta-grid {
-            width: 100%;
-            border: 1px solid #cfd2d6;
-            border-radius: 6px;
-            overflow: hidden;
-        }
-
-        .meta-grid tr:nth-child(even) td {
-            background: #f9fafb;
-        }
-
-        .meta-grid strong {
-            display: inline-block;
-            min-width: 140px;
-        }
-
-        .blank-table-caption {
-            font-size: 16px;
-            margin-bottom: 10px;
         }
     </style>
 </head>

--- a/resources/views/pdf/service-sheet/blank-table.blade.php
+++ b/resources/views/pdf/service-sheet/blank-table.blade.php
@@ -1,26 +1,32 @@
-<div class="meta-section">
-    <h2 class="blank-table-caption">Tabel completare intervenții</h2>
-    <p style="margin-bottom: 12px; color: #4b5563;">Spațiu dedicat completării manuale pentru intervenții suplimentare.</p>
-</div>
+<div class="page">
+    <div class="page-header">
+        <img src="{{ public_path('images/logo3.jpg') }}" alt="Logo">
+        <h1 class="page-title">Foaie Service</h1>
+    </div>
 
-<table class="blank-table">
-    <thead>
-        <tr>
-            <th class="col-index">Nr. crt.</th>
-            <th class="col-descriere">Descriere intervenție</th>
-        </tr>
-    </thead>
-    <tbody>
-        @for ($i = 1; $i <= 14; $i++)
+    <h2 class="section-heading">Fisa iesire service auto</h2>
+
+    <div>
+        <div class="mechanic-label">Nume mecanic auto</div>
+        <div class="mechanic-line"></div>
+    </div>
+
+    <table class="parts-table">
+        <thead>
             <tr>
-                <td class="col-index">{{ $i }}</td>
-                <td class="col-descriere">&nbsp;</td>
+                <th style="width: 50%;">Denumire piesa</th>
+                <th style="width: 30%;">Cod piesa</th>
+                <th style="width: 20%;">Cantitate</th>
             </tr>
-        @endfor
-    </tbody>
-</table>
-
-<div style="margin-top: 28px; font-size: 13px;">
-    <strong>NUME MECANIC AUTO:</strong>
-    <span style="display: inline-block; min-width: 280px; border-bottom: 1px solid #cfd2d6; height: 18px; margin-left: 8px;"></span>
+        </thead>
+        <tbody>
+            @for ($i = 0; $i < 22; $i++)
+                <tr>
+                    <td>&nbsp;</td>
+                    <td>&nbsp;</td>
+                    <td>&nbsp;</td>
+                </tr>
+            @endfor
+        </tbody>
+    </table>
 </div>

--- a/resources/views/pdf/service-sheet/summary.blade.php
+++ b/resources/views/pdf/service-sheet/summary.blade.php
@@ -1,36 +1,29 @@
-<div class="meta-section">
-    <h1 class="section-title">Foaie service</h1>
-    <table class="meta-grid">
-        <tbody>
-            <tr>
-                <td><strong>Mașină:</strong> {{ $masina->denumire }}</td>
-                <td><strong>Nr. înmatriculare:</strong> {{ $masina->numar_inmatriculare }}</td>
-            </tr>
-            <tr>
-                <td><strong>Serie șasiu:</strong> {{ $masina->serie_sasiu ?? '—' }}</td>
-                <td><strong>Km bord:</strong> {{ number_format($km_bord, 0, ',', '.') }}</td>
-            </tr>
-            <tr>
-                <td><strong>Data service:</strong> {{ $data_service->format('d.m.Y') }}</td>
-                <td><strong>Generat la:</strong> {{ now()->format('d.m.Y H:i') }}</td>
-            </tr>
-        </tbody>
-    </table>
-</div>
+<div class="page">
+    <div class="page-header">
+        <img src="{{ public_path('images/logo3.jpg') }}" alt="Logo">
+        <h1 class="page-title">Foaie Service</h1>
+    </div>
 
-<table class="summary-table">
-    <thead>
+    <table class="info-table">
         <tr>
-            <th class="col-index">Nr. crt.</th>
-            <th class="col-descriere">Descriere intervenție</th>
+            <th>Nr. auto</th>
+            <th>Km bord</th>
+            <th>Data service</th>
         </tr>
-    </thead>
-    <tbody>
-        @foreach ($items as $item)
-            <tr>
-                <td class="col-index">{{ $item['index'] }}</td>
-                <td class="col-descriere">{{ $item['descriere'] }}</td>
-            </tr>
-        @endforeach
-    </tbody>
-</table>
+        <tr>
+            <td>{{ $masina->numar_inmatriculare }}</td>
+            <td>{{ number_format($km_bord, 0, ',', '.') }}</td>
+            <td>{{ $data_service->format('d.m.Y') }}</td>
+        </tr>
+    </table>
+
+    <h2 class="section-heading">Fisa intrare service</h2>
+
+    <ol class="interventions-list">
+        @forelse ($items as $item)
+            <li>{{ $item['descriere'] }}</li>
+        @empty
+            <li>&nbsp;</li>
+        @endforelse
+    </ol>
+</div>


### PR DESCRIPTION
## Summary
- stream the generated service sheet PDF response and alphabetize the intervention list
- refresh the shared PDF stylesheet with centred logos, wider margins, and simplified typography
- rebuild both PDF pages to show the required metadata table, sorted intervention list, mechanic name line, and three-column parts table

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2103e72c88326919ad4502d52e129