### PR TITLE
Hide login code button after initial request

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -808,12 +808,36 @@ const trimitereCodAutentificarePrinEmail = createApp({
         return {
             email: email,
             mesajDeAfisat: '',
+            statusMessage: '',
+            showStatusMessage: false,
+            isSending: false,
+            flashObserver: null,
+            hasSentRequest: false,
+        }
+    },
+    mounted() {
+        this.observeFlashMessages();
+        this.checkForAlerts();
+    },
+    beforeUnmount() {
+        if (this.flashObserver) {
+            this.flashObserver.disconnect();
         }
     },
     methods: {
         trimiteEmail() {
-            // console.log('da');
+            if (this.isSending) {
+                return;
+            }
+
+            this.mesajDeAfisat = '';
+
             if (this.email) {
+                this.isSending = true;
+                this.hasSentRequest = true;
+                this.statusMessage = 'Se trimite codul de autentificare…';
+                this.showStatusMessage = true;
+
                 axios.get('/axios/trimitere-cod-autentificare-prin-email', {
                     params: { email: this.email }
                 })
@@ -821,9 +845,54 @@ const trimitereCodAutentificarePrinEmail = createApp({
                         response => {
                             this.mesajDeAfisat = response.data.raspuns;
                         }
-                    );
+                    )
+                    .catch(() => {
+                        this.mesajDeAfisat = "<span class='text-danger' style='font-size:80%'>A apărut o eroare neașteptată. Încearcă din nou.</span>";
+                        this.showStatusMessage = false;
+                        this.statusMessage = '';
+                    })
+                    .finally(() => {
+                        this.isSending = false;
+                    });
             } else {
                 this.mesajDeAfisat = "<span class='text-danger' style='font-size:80%'>Introdu emailul.</span>";
+                this.showStatusMessage = false;
+                this.statusMessage = '';
+                this.isSending = false;
+                this.hasSentRequest = false;
+            }
+        },
+        observeFlashMessages() {
+            if (typeof MutationObserver === 'undefined') {
+                return;
+            }
+
+            if (this.flashObserver) {
+                this.flashObserver.disconnect();
+            }
+
+            this.flashObserver = new MutationObserver(() => {
+                this.checkForAlerts();
+            });
+
+            if (this.$el) {
+                this.flashObserver.observe(this.$el, {
+                    childList: true,
+                    subtree: true,
+                });
+            }
+        },
+        checkForAlerts() {
+            if (!this.$el) {
+                return;
+            }
+
+            const alertExists = this.$el.querySelector('.alert');
+
+            if (alertExists) {
+                this.isSending = false;
+                this.showStatusMessage = false;
+                this.statusMessage = '';
             }
         },
     }

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -81,17 +81,21 @@
                         </div>
 
                         <div class="row">
-                            <div class="col-md-12 mb-0 text-center">
-                                <button type="button" class="btn btn-sm py-0 px-1 btn-primary text-white shadow-sm rounded-3"
-                                    {{-- style="background-color:#56af71" --}}
-                                    @click="trimiteEmail();"
-                                >
-                                    Trimite cod pe email
-                                </button>
-                            </div>
-                            <div class="col-md-12 mb-0 text-center">
-                                <div v-if="mesajDeAfisat" v-html="mesajDeAfisat">
-                                    {{-- @{{ mesajDeAfisat }} --}}
+                            <div class="col-md-12 mb-3">
+                                <div class="d-flex flex-column align-items-center text-center gap-2">
+                                    <button v-if="!hasSentRequest" type="button" class="btn btn-sm py-0 px-1 btn-primary text-white shadow-sm rounded-3"
+                                        {{-- style="background-color:#56af71" --}}
+                                        @click="trimiteEmail();"
+                                        :disabled="isSending"
+                                        :class="{ 'disabled': isSending }"
+                                        :aria-busy="isSending"
+                                    >
+                                        Trimite cod pe email
+                                    </button>
+                                    <div v-if="showStatusMessage" class="text-muted small" role="status" aria-live="polite" v-text="statusMessage"></div>
+                                    <div v-if="mesajDeAfisat" v-html="mesajDeAfisat">
+                                        {{-- @{{ mesajDeAfisat }} --}}
+                                    </div>
                                 </div>
                             </div>
                             <div class="col-md-12 mb-3">


### PR DESCRIPTION
## Summary
- hide the "Trimite cod pe email" control once a request has been initiated so the action cannot be repeated without refreshing
- track the one-time request state in the Vue helper while still clearing the loading notice when alerts appear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f24d4235288326a4ba39a374b09e39