### PR TITLE
Add CRUD interface for service parts management

### DIFF
--- a/app/Http/Middleware/RestrictMechanicAccess.php
+++ b/app/Http/Middleware/RestrictMechanicAccess.php
@@ -36,12 +36,19 @@ class RestrictMechanicAccess
         $route = $request->route();
         $routeName = $route?->getName();
 
+        if ($routeName && str_starts_with($routeName, 'gestiune-piese.')) {
+            if ($routeName !== 'gestiune-piese.index') {
+                abort(403);
+            }
+
+            return $next($request);
+        }
+
         if ($routeName && in_array($routeName, $allowedRouteNames, true)) {
             return $next($request);
         }
 
         $allowedPrefixes = [
-            'gestiune-piese',
             'service-masini',
         ];
 

--- a/app/Http/Requests/Service/GestiunePiesaRequest.php
+++ b/app/Http/Requests/Service/GestiunePiesaRequest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Requests\Service;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class GestiunePiesaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'factura_id' => ['nullable', 'integer', 'exists:service_ff_facturi,id'],
+            'denumire' => ['required', 'string', 'max:255'],
+            'cod' => ['nullable', 'string', 'max:255'],
+            'cantitate_initiala' => ['nullable', 'numeric', 'min:0'],
+            'nr_bucati' => ['nullable', 'numeric', 'min:0'],
+            'pret' => ['nullable', 'numeric', 'min:0'],
+            'tva_cota' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'pret_brut' => ['nullable', 'numeric', 'min:0'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $numericFields = [
+            'cantitate_initiala',
+            'nr_bucati',
+            'pret',
+            'tva_cota',
+            'pret_brut',
+        ];
+
+        $normalized = [];
+
+        foreach ($numericFields as $field) {
+            $value = $this->input($field);
+
+            if (is_string($value)) {
+                $value = str_replace([' ', ','], ['', '.'], $value);
+            }
+
+            if ($value === '') {
+                $value = null;
+            }
+
+            if ($value !== null) {
+                $normalized[$field] = is_numeric($value) ? (float) $value : $value;
+            }
+        }
+
+        if (! empty($normalized)) {
+            $this->merge($normalized);
+        }
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $initial = $this->input('cantitate_initiala');
+            $remaining = $this->input('nr_bucati');
+
+            if ($initial !== null && $remaining !== null && (float) $remaining > (float) $initial) {
+                $validator->errors()->add('nr_bucati', 'Stocul disponibil nu poate depăși cantitatea inițială.');
+            }
+        });
+    }
+
+    public function validated($key = null, $default = null): array
+    {
+        $data = parent::validated($key, $default);
+
+        $initial = $data['cantitate_initiala'] ?? null;
+        $remaining = $data['nr_bucati'] ?? null;
+
+        if ($initial === null && $remaining !== null) {
+            $data['cantitate_initiala'] = $remaining;
+        } elseif ($initial !== null && $remaining === null) {
+            $data['nr_bucati'] = $initial;
+        }
+
+        return $data;
+    }
+}

--- a/resources/views/service/gestiune-piese/create.blade.php
+++ b/resources/views/service/gestiune-piese/create.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="mx-3 px-3 card mx-auto" style="border-radius: 40px 40px 40px 40px; max-width: 900px;">
+        <div class="card-header d-flex justify-content-between align-items-center" style="border-radius: 40px 40px 0px 0px;">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-plus me-1"></i>Adaugă piesă în gestiune
+            </span>
+            <a href="{{ route('gestiune-piese.index') }}" class="btn btn-sm btn-outline-secondary rounded-3">
+                <i class="fa-solid fa-arrow-left me-1"></i>Înapoi la listă
+            </a>
+        </div>
+
+        <div class="card-body">
+            @include('errors')
+
+            <form method="POST" action="{{ route('gestiune-piese.store') }}" class="mt-3">
+                @csrf
+
+                @include('service.gestiune-piese.partials.form')
+
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                    <a href="{{ route('gestiune-piese.index') }}" class="btn btn-outline-secondary rounded-3">
+                        Renunță
+                    </a>
+                    <button type="submit" class="btn btn-primary rounded-3">
+                        <i class="fa-solid fa-save me-1"></i>Salvează piesa
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/service/gestiune-piese/edit.blade.php
+++ b/resources/views/service/gestiune-piese/edit.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@php
+    $piesa = $piesa ?? null;
+@endphp
+
+@section('content')
+    <div class="mx-3 px-3 card mx-auto" style="border-radius: 40px 40px 40px 40px; max-width: 900px;">
+        <div class="card-header d-flex justify-content-between align-items-center" style="border-radius: 40px 40px 0px 0px;">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-pen-to-square me-1"></i>Editează piesa
+            </span>
+            <a href="{{ route('gestiune-piese.index') }}" class="btn btn-sm btn-outline-secondary rounded-3">
+                <i class="fa-solid fa-arrow-left me-1"></i>Înapoi la listă
+            </a>
+        </div>
+
+        <div class="card-body">
+            @include('errors')
+
+            <form method="POST" action="{{ route('gestiune-piese.update', $piesa) }}" class="mt-3">
+                @csrf
+                @method('PUT')
+
+                @include('service.gestiune-piese.partials.form')
+
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mt-4">
+                    <div class="text-muted small">
+                        Ultima actualizare: {{ optional($piesa->updated_at)->format('d.m.Y H:i') ?? 'n/a' }}
+                    </div>
+                    <div class="d-flex gap-2">
+                        <a href="{{ route('gestiune-piese.index') }}" class="btn btn-outline-secondary rounded-3">
+                            Renunță
+                        </a>
+                        <button type="submit" class="btn btn-primary rounded-3">
+                            <i class="fa-solid fa-save me-1"></i>Actualizează piesa
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/service/gestiune-piese/index.blade.php
+++ b/resources/views/service/gestiune-piese/index.blade.php
@@ -11,6 +11,8 @@
     $dataFactura = $dataFactura ?? '';
     $invoiceColumn = $invoiceColumn ?? null;
     $stockDetails = $stockDetails ?? [];
+    $authenticatedUser = auth()->user();
+    $canManagePieces = $authenticatedUser && ! $authenticatedUser->hasRole('mecanic');
 @endphp
 
 @section('content')
@@ -61,7 +63,13 @@
                     </div>
                 </form>
             </div>
-            <div class="col-lg-3 mt-2 mt-lg-0">
+            <div class="col-lg-3 mt-2 mt-lg-0 d-flex flex-column align-items-lg-end gap-2">
+                @if ($canManagePieces)
+                    <a class="btn btn-sm btn-success text-white border border-dark rounded-3"
+                        href="{{ route('gestiune-piese.create') }}">
+                        <i class="fa-solid fa-plus me-1"></i>Adaugă piesă
+                    </a>
+                @endif
                 @include('partials.operations-navigation')
             </div>
         </div>
@@ -113,6 +121,9 @@
                                     <th class="culoare2 text-white" style="min-width: 130px;">Factură</th>
                                 @endif
                                 <th class="culoare2 text-white" style="min-width: 150px;">Detalii stoc</th>
+                                @if ($canManagePieces)
+                                    <th class="culoare2 text-white text-center" style="min-width: 180px;">Acțiuni</th>
+                                @endif
                             </tr>
                         </thead>
                         <tbody>
@@ -185,10 +196,33 @@
                                             —
                                         @endif
                                     </td>
+                                    @if ($canManagePieces)
+                                        <td>
+                                            @if ($pieceId > 0)
+                                                <div class="d-flex flex-column flex-lg-row gap-2 justify-content-center">
+                                                    <a class="btn btn-sm btn-outline-primary rounded-3"
+                                                        href="{{ route('gestiune-piese.edit', $pieceId) }}">
+                                                        <i class="fa-solid fa-pen-to-square me-1"></i>Editează
+                                                    </a>
+                                                    <form method="POST" class="d-inline"
+                                                        action="{{ route('gestiune-piese.destroy', $pieceId) }}"
+                                                        onsubmit="return confirm('Sigur vrei să ștergi această piesă?');">
+                                                        @csrf
+                                                        @method('DELETE')
+                                                        <button type="submit" class="btn btn-sm btn-outline-danger rounded-3">
+                                                            <i class="fa-solid fa-trash-can me-1"></i>Șterge
+                                                        </button>
+                                                    </form>
+                                                </div>
+                                            @else
+                                                —
+                                            @endif
+                                        </td>
+                                    @endif
                                 </tr>
                             @empty
                                 <tr>
-                                    <td colspan="{{ count($columns) + 2 + ($invoiceColumn ? 1 : 0) }}"
+                                    <td colspan="{{ count($columns) + 2 + ($invoiceColumn ? 1 : 0) + ($canManagePieces ? 1 : 0) }}"
                                         class="text-center text-muted py-4">
                                         Nu există înregistrări care să corespundă filtrelor alese.
                                     </td>

--- a/resources/views/service/gestiune-piese/partials/form.blade.php
+++ b/resources/views/service/gestiune-piese/partials/form.blade.php
@@ -1,0 +1,72 @@
+@php
+    $editing = isset($piesa);
+@endphp
+
+<div class="row g-3">
+    <div class="col-lg-6">
+        <label for="denumire" class="form-label small text-muted mb-1">Denumire piesă <span class="text-danger">*</span></label>
+        <input type="text" name="denumire" id="denumire" class="form-control rounded-3"
+            value="{{ old('denumire', $editing ? $piesa->denumire : '') }}" required>
+        @error('denumire')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-6">
+        <label for="cod" class="form-label small text-muted mb-1">Cod piesă</label>
+        <input type="text" name="cod" id="cod" class="form-control rounded-3"
+            value="{{ old('cod', $editing ? $piesa->cod : '') }}">
+        @error('cod')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-4">
+        <label for="cantitate_initiala" class="form-label small text-muted mb-1">Cantitate inițială</label>
+        <input type="number" step="0.01" min="0" name="cantitate_initiala" id="cantitate_initiala"
+            class="form-control rounded-3" value="{{ old('cantitate_initiala', $editing ? $piesa->cantitate_initiala : '') }}">
+        <small class="text-muted">Dacă lipsește, valoarea va fi completată din stocul curent.</small>
+        @error('cantitate_initiala')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-4">
+        <label for="nr_bucati" class="form-label small text-muted mb-1">Stoc curent</label>
+        <input type="number" step="0.01" min="0" name="nr_bucati" id="nr_bucati"
+            class="form-control rounded-3" value="{{ old('nr_bucati', $editing ? $piesa->nr_bucati : '') }}">
+        @error('nr_bucati')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-4">
+        <label for="factura_id" class="form-label small text-muted mb-1">Factură furnizor (opțional)</label>
+        <input type="number" min="1" name="factura_id" id="factura_id" class="form-control rounded-3"
+            value="{{ old('factura_id', $editing ? $piesa->factura_id : '') }}">
+        <small class="text-muted">Completează ID-ul facturii pentru a lega piesa de o achiziție.</small>
+        @error('factura_id')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-4">
+        <label for="pret" class="form-label small text-muted mb-1">Preț net</label>
+        <input type="number" step="0.01" min="0" name="pret" id="pret" class="form-control rounded-3"
+            value="{{ old('pret', $editing ? $piesa->pret : '') }}">
+        @error('pret')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-4">
+        <label for="tva_cota" class="form-label small text-muted mb-1">Cotă TVA (%)</label>
+        <input type="number" step="0.01" min="0" max="100" name="tva_cota" id="tva_cota"
+            class="form-control rounded-3" value="{{ old('tva_cota', $editing ? $piesa->tva_cota : '') }}">
+        @error('tva_cota')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+    <div class="col-lg-4">
+        <label for="pret_brut" class="form-label small text-muted mb-1">Preț brut</label>
+        <input type="number" step="0.01" min="0" name="pret_brut" id="pret_brut"
+            class="form-control rounded-3" value="{{ old('pret_brut', $editing ? $piesa->pret_brut : '') }}">
+        @error('pret_brut')
+            <div class="text-danger small mt-1">{{ $message }}</div>
+        @enderror
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -169,8 +169,9 @@ Route::group(['middleware' => ['auth', 'restrict-mechanic-access']], function ()
 
     Route::get('/facturi-scadente', [FacturaScadentaController::class, 'index']);
 
-    Route::get('/gestiune-piese', [GestiunePieseController::class, 'index'])
-        ->name('gestiune-piese.index');
+    Route::resource('gestiune-piese', GestiunePieseController::class)
+        ->except(['show'])
+        ->parameters(['gestiune-piese' => 'gestiune_piesa']);
 
     Route::get('/service-masini', [ServiceMasiniController::class, 'index'])
         ->name('service-masini.index');

--- a/tests/Feature/Service/ServiceMasiniTest.php
+++ b/tests/Feature/Service/ServiceMasiniTest.php
@@ -97,6 +97,25 @@ class ServiceMasiniTest extends TestCase
         ]);
     }
 
+    public function test_service_entries_form_lists_newly_created_piece(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('gestiune-piese.store'), [
+            'denumire' => 'Curea accesorii',
+            'cod' => 'CA-001',
+            'cantitate_initiala' => 3,
+        ])->assertRedirect();
+
+        $masina = Masina::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('service-masini.index', ['masina_id' => $masina->id]));
+
+        $response->assertOk();
+        $response->assertSee('Curea accesorii', false);
+        $response->assertSee('(CA-001)', false);
+    }
+
     public function test_it_exports_pdf(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
## Summary
- add a dedicated form request and extend the service parts controller with create, update, and delete handling
- provide create/edit views and update the parts index with guarded management controls for non-mechanics
- tighten the mechanic access middleware and add feature coverage for new parts flows, including service machine availability

## Testing
- php artisan test *(fails: composer install requires GitHub authentication so dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68f5e58d6b28832691bd931f29aa8143