### PR TITLE
Align service piece stock with consumption usage

### DIFF
--- a/resources/views/service/gestiune-piese/partials/form.blade.php
+++ b/resources/views/service/gestiune-piese/partials/form.blade.php
@@ -1,5 +1,68 @@
 @php
     $editing = isset($piesa);
+
+    $normalizeDecimal = static function ($value) {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_string($value)) {
+            $value = str_replace([' ', ','], ['', '.'], $value);
+        }
+
+        return is_numeric($value) ? (float) $value : null;
+    };
+
+    $oldInitialRaw = old('cantitate_initiala');
+    $oldRemainingRaw = old('nr_bucati');
+
+    $initialInputSource = $oldInitialRaw;
+
+    if ($initialInputSource === null || $initialInputSource === '') {
+        $initialInputSource = $editing
+            ? ($piesa->cantitate_initiala ?? $piesa->nr_bucati ?? '')
+            : '';
+    }
+
+    $initialInputNumeric = $normalizeDecimal($initialInputSource);
+    $initialFieldValue = $initialInputNumeric === null
+        ? ($initialInputSource ?? '')
+        : number_format($initialInputNumeric, 2, '.', '');
+
+    $remainingInputSource = $oldRemainingRaw;
+
+    if ($remainingInputSource === null || $remainingInputSource === '') {
+        $remainingInputSource = $editing ? ($piesa->nr_bucati ?? '') : '';
+    }
+
+    $remainingInputNumeric = $normalizeDecimal($remainingInputSource);
+    $remainingFieldValue = $remainingInputNumeric === null
+        ? ($remainingInputSource ?? '')
+        : number_format($remainingInputNumeric, 2, '.', '');
+
+    $initialFromDb = $editing ? $normalizeDecimal($piesa->cantitate_initiala ?? $piesa->nr_bucati ?? null) : null;
+    $remainingFromDb = $editing ? $normalizeDecimal($piesa->nr_bucati ?? null) : null;
+
+    $oldInitialNumeric = $normalizeDecimal($oldInitialRaw);
+    $oldRemainingNumeric = $normalizeDecimal($oldRemainingRaw);
+
+    $consumedBaseline = null;
+
+    if ($oldInitialNumeric !== null && $oldRemainingNumeric !== null) {
+        $consumedBaseline = max($oldInitialNumeric - $oldRemainingNumeric, 0);
+    } elseif ($initialFromDb !== null && $remainingFromDb !== null) {
+        $consumedBaseline = max($initialFromDb - $remainingFromDb, 0);
+    }
+
+    $consumedBaselineValue = $consumedBaseline === null
+        ? ''
+        : number_format($consumedBaseline, 2, '.', '');
+    $initialBenchmarkValue = $initialFromDb === null
+        ? ''
+        : number_format($initialFromDb, 2, '.', '');
+    $remainingBenchmarkValue = $remainingFromDb === null
+        ? ''
+        : number_format($remainingFromDb, 2, '.', '');
 @endphp
 
 <div class="row g-3">
@@ -22,20 +85,24 @@
     <div class="col-lg-4">
         <label for="cantitate_initiala" class="form-label small text-muted mb-1">Cantitate inițială</label>
         <input type="number" step="0.01" min="0" name="cantitate_initiala" id="cantitate_initiala"
-            class="form-control rounded-3" value="{{ old('cantitate_initiala', $editing ? $piesa->cantitate_initiala : '') }}">
+            class="form-control rounded-3" value="{{ $initialFieldValue }}" data-piece-quantity="initial"
+            data-piece-used="{{ $consumedBaselineValue }}" data-piece-initial-benchmark="{{ $initialBenchmarkValue }}"
+            data-piece-remaining-benchmark="{{ $remainingBenchmarkValue }}">
         <small class="text-muted">Dacă lipsește, valoarea va fi completată din stocul curent.</small>
+        <input type="hidden" name="nr_bucati" id="nr_bucati" value="{{ $remainingFieldValue }}"
+            data-piece-quantity="remaining">
+        <input type="hidden" data-piece-quantity="consumed" value="{{ $consumedBaselineValue }}">
         @error('cantitate_initiala')
             <div class="text-danger small mt-1">{{ $message }}</div>
         @enderror
-    </div>
-    <div class="col-lg-4">
-        <label for="nr_bucati" class="form-label small text-muted mb-1">Stoc curent</label>
-        <input type="number" step="0.01" min="0" name="nr_bucati" id="nr_bucati"
-            class="form-control rounded-3" value="{{ old('nr_bucati', $editing ? $piesa->nr_bucati : '') }}">
         @error('nr_bucati')
             <div class="text-danger small mt-1">{{ $message }}</div>
         @enderror
     </div>
+    @php
+        $rawVatRate = old('tva_cota', $editing ? $piesa->tva_cota : null);
+        $selectedVatRate = is_numeric($rawVatRate) ? (float) $rawVatRate : null;
+    @endphp
     <div class="col-lg-4">
         <label for="factura_id" class="form-label small text-muted mb-1">Factură furnizor (opțional)</label>
         <input type="number" min="1" name="factura_id" id="factura_id" class="form-control rounded-3"
@@ -46,27 +113,169 @@
         @enderror
     </div>
     <div class="col-lg-4">
-        <label for="pret" class="form-label small text-muted mb-1">Preț net</label>
+        <label for="pret" class="form-label small text-muted mb-1">Preț NET/buc</label>
         <input type="number" step="0.01" min="0" name="pret" id="pret" class="form-control rounded-3"
-            value="{{ old('pret', $editing ? $piesa->pret : '') }}">
+            value="{{ old('pret', $editing ? $piesa->pret : '') }}" data-piece-price="net">
         @error('pret')
             <div class="text-danger small mt-1">{{ $message }}</div>
         @enderror
     </div>
     <div class="col-lg-4">
-        <label for="tva_cota" class="form-label small text-muted mb-1">Cotă TVA (%)</label>
-        <input type="number" step="0.01" min="0" max="100" name="tva_cota" id="tva_cota"
-            class="form-control rounded-3" value="{{ old('tva_cota', $editing ? $piesa->tva_cota : '') }}">
+        <label for="tva_cota" class="form-label small text-muted mb-1">Cotă TVA</label>
+        <select name="tva_cota" id="tva_cota" class="form-select rounded-3" data-piece-price="vat">
+            <option value="" @selected(!is_numeric($rawVatRate))>Cotă TVA</option>
+            <option value="11" @selected($selectedVatRate === 11.0)>11%</option>
+            <option value="21" @selected($selectedVatRate === 21.0)>21%</option>
+        </select>
         @error('tva_cota')
             <div class="text-danger small mt-1">{{ $message }}</div>
         @enderror
     </div>
     <div class="col-lg-4">
-        <label for="pret_brut" class="form-label small text-muted mb-1">Preț brut</label>
+        <label for="pret_brut" class="form-label small text-muted mb-1">Preț BRUT/buc</label>
         <input type="number" step="0.01" min="0" name="pret_brut" id="pret_brut"
-            class="form-control rounded-3" value="{{ old('pret_brut', $editing ? $piesa->pret_brut : '') }}">
+            class="form-control rounded-3 bg-light" value="{{ old('pret_brut', $editing ? $piesa->pret_brut : '') }}"
+            readonly tabindex="-1" data-piece-price="gross">
         @error('pret_brut')
             <div class="text-danger small mt-1">{{ $message }}</div>
         @enderror
     </div>
 </div>
+
+@once
+    @push('page-scripts')
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                const netInput = document.querySelector('[data-piece-price="net"]');
+                const vatInput = document.querySelector('[data-piece-price="vat"]');
+                const grossInput = document.querySelector('[data-piece-price="gross"]');
+                const initialQtyInput = document.querySelector('[data-piece-quantity="initial"]');
+                const remainingQtyInput = document.querySelector('[data-piece-quantity="remaining"]');
+
+                const roundTwo = (value) => Math.round(value * 100) / 100;
+
+                const formatNumber = (value) => {
+                    if (!Number.isFinite(value)) {
+                        return '';
+                    }
+
+                    return value.toFixed(2);
+                };
+
+                const parseNullableFloat = (raw) => {
+                    if (raw === null || raw === undefined) {
+                        return null;
+                    }
+
+                    if (typeof raw === 'number') {
+                        return Number.isFinite(raw) ? raw : null;
+                    }
+
+                    if (typeof raw !== 'string') {
+                        return null;
+                    }
+
+                    const normalized = raw.trim().replace(/\s+/g, '').replace(/,/g, '.');
+
+                    if (normalized === '') {
+                        return null;
+                    }
+
+                    const parsed = Number.parseFloat(normalized);
+
+                    return Number.isFinite(parsed) ? parsed : null;
+                };
+
+                if (netInput && vatInput && grossInput) {
+                    const recalculateGross = () => {
+                        const netRaw = netInput.value;
+                        const vatRaw = vatInput.value;
+
+                        if (netRaw.trim() === '' || vatRaw.trim() === '') {
+                            grossInput.value = '';
+                            return;
+                        }
+
+                        const netValue = Number.parseFloat(netRaw);
+                        const vatValue = Number.parseFloat(vatRaw);
+
+                        if (!Number.isFinite(netValue) || !Number.isFinite(vatValue)) {
+                            grossInput.value = '';
+                            return;
+                        }
+
+                        const grossValue = roundTwo(netValue * (1 + vatValue / 100));
+                        grossInput.value = formatNumber(grossValue);
+                    };
+
+                    const bindRecalculation = (element) => {
+                        ['input', 'change'].forEach((eventName) => {
+                            element.addEventListener(eventName, recalculateGross);
+                        });
+                    };
+
+                    bindRecalculation(netInput);
+                    bindRecalculation(vatInput);
+
+                    recalculateGross();
+                }
+
+                if (initialQtyInput && remainingQtyInput) {
+                    const consumedPieces = (() => {
+                        const consumedHolder = document.querySelector('[data-piece-quantity="consumed"]');
+                        const consumedFromHolder = consumedHolder ? parseNullableFloat(consumedHolder.value) : null;
+
+                        if (consumedFromHolder !== null) {
+                            return consumedFromHolder;
+                        }
+
+                        const consumedFromDataset = parseNullableFloat(initialQtyInput.dataset.pieceUsed ?? '');
+
+                        if (consumedFromDataset !== null) {
+                            return consumedFromDataset;
+                        }
+
+                        const initialBenchmark = parseNullableFloat(initialQtyInput.dataset.pieceInitialBenchmark ?? '');
+                        const remainingBenchmark = parseNullableFloat(initialQtyInput.dataset.pieceRemainingBenchmark ?? '');
+
+                        if (initialBenchmark !== null && remainingBenchmark !== null) {
+                            return Math.max(roundTwo(initialBenchmark - remainingBenchmark), 0);
+                        }
+
+                        const initialAtLoad = parseNullableFloat(initialQtyInput.value);
+                        const remainingAtLoad = parseNullableFloat(remainingQtyInput.value);
+
+                        if (initialAtLoad !== null && remainingAtLoad !== null) {
+                            return Math.max(roundTwo(initialAtLoad - remainingAtLoad), 0);
+                        }
+
+                        return null;
+                    })();
+
+                    const recalculateRemaining = () => {
+                        const initialValue = parseNullableFloat(initialQtyInput.value);
+
+                        if (initialValue === null) {
+                            remainingQtyInput.value = '';
+                            return;
+                        }
+
+                        if (consumedPieces === null) {
+                            remainingQtyInput.value = formatNumber(initialValue);
+                            return;
+                        }
+
+                        const remainingValue = Math.max(roundTwo(initialValue - consumedPieces), 0);
+                        remainingQtyInput.value = formatNumber(remainingValue);
+                    };
+
+                    ['input', 'change'].forEach((eventName) => {
+                        initialQtyInput.addEventListener(eventName, recalculateRemaining);
+                    });
+
+                    recalculateRemaining();
+                }
+            });
+        </script>
+    @endpush
+@endonce


### PR DESCRIPTION
## Summary
- expose hidden remaining stock and consumption metadata for service pieces so edits respect previous usage
- auto-recalculate remaining quantity from the initial amount while keeping the gross price sync helpers intact
- surface validation feedback for remaining stock alongside the initial quantity input

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6132fe20c8326818ce356607a3296