### PR TITLE
Validate gestiune piese stock against existing usage

### DIFF
--- a/app/Http/Requests/Service/GestiunePiesaRequest.php
+++ b/app/Http/Requests/Service/GestiunePiesaRequest.php
@@ -2,11 +2,15 @@
 
 namespace App\Http\Requests\Service;
 
+use App\Models\Service\GestiunePiesa;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Validator;
 
 class GestiunePiesaRequest extends FormRequest
 {
+    private float $usedQuantity = 0.0;
+
     public function authorize(): bool
     {
         return $this->user() !== null;
@@ -63,10 +67,40 @@ class GestiunePiesaRequest extends FormRequest
     {
         $validator->after(function (Validator $validator): void {
             $initial = $this->input('cantitate_initiala');
-            $remaining = $this->input('nr_bucati');
 
-            if ($initial !== null && $remaining !== null && (float) $remaining > (float) $initial) {
-                $validator->errors()->add('nr_bucati', 'Stocul disponibil nu poate depăși cantitatea inițială.');
+            $piece = $this->route('gestiune_piesa');
+
+            if ($piece && ! $piece instanceof GestiunePiesa) {
+                $piece = GestiunePiesa::query()->find($piece);
+            }
+
+            if ($piece instanceof GestiunePiesa) {
+                $this->usedQuantity = (float) DB::table('service_masina_service_entries')
+                    ->where('gestiune_piesa_id', $piece->getKey())
+                    ->where('tip', 'piesa')
+                    ->whereNotNull('cantitate')
+                    ->sum('cantitate');
+            } else {
+                $this->usedQuantity = 0.0;
+            }
+
+            $used = round($this->usedQuantity, 2);
+
+            if ($piece instanceof GestiunePiesa && $initial === null) {
+                $initial = $piece->cantitate_initiala;
+            }
+
+            if ($initial !== null) {
+                $initial = round((float) $initial, 2);
+
+                if ($used > $initial) {
+                    $validator->errors()->add('cantitate_initiala', sprintf(
+                        'Cantitatea inițială nu poate fi mai mică decât totalul montat pe mașini (%.2f).',
+                        $used
+                    ));
+                }
+            } elseif ($used > 0) {
+                $validator->errors()->add('cantitate_initiala', 'Cantitatea inițială trebuie să fie cel puțin egală cu totalul montat pe mașini.');
             }
         });
     }
@@ -76,14 +110,33 @@ class GestiunePiesaRequest extends FormRequest
         $data = parent::validated($key, $default);
 
         $initial = $data['cantitate_initiala'] ?? null;
-        $remaining = $data['nr_bucati'] ?? null;
 
-        if ($initial === null && $remaining !== null) {
-            $data['cantitate_initiala'] = $remaining;
-        } elseif ($initial !== null && $remaining === null) {
-            $data['nr_bucati'] = $initial;
+        $piece = $this->route('gestiune_piesa');
+
+        if ($piece && ! $piece instanceof GestiunePiesa) {
+            $piece = GestiunePiesa::query()->find($piece);
+        }
+
+        if ($initial === null && $piece instanceof GestiunePiesa && $piece->cantitate_initiala !== null) {
+            $initial = (float) $piece->cantitate_initiala;
+            $data['cantitate_initiala'] = $initial;
+        }
+
+        $used = round($this->usedQuantity, 2);
+
+        if ($initial !== null) {
+            $initial = round((float) $initial, 2);
+            $data['cantitate_initiala'] = $initial;
+            $data['nr_bucati'] = round(max($initial - $used, 0), 2);
+        } else {
+            $data['nr_bucati'] = null;
         }
 
         return $data;
+    }
+
+    public function usedQuantity(): float
+    {
+        return round($this->usedQuantity, 2);
     }
 }


### PR DESCRIPTION
## Summary
- prevent saving a piece with an initial quantity lower than the total already mounted on cars
- automatically derive the remaining stock from the validated initial quantity minus the used quantity
- extend gestiune piesa feature tests to cover stock calculations and validation failures

## Testing
- php artisan test --testsuite=Feature --filter=GestiunePieseTest *(fails: vendor autoload missing; composer install blocked by network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68f61de20b6c832681e8cef67dd50d67