### PR TITLE
Refine user role handling and ordering

### DIFF
--- a/app/Http/Controllers/Tech/ImpersonationController.php
+++ b/app/Http/Controllers/Tech/ImpersonationController.php
@@ -24,7 +24,7 @@ class ImpersonationController extends Controller
                 });
             })
             ->orderBy('activ', 'desc')
-            ->orderBy('role')
+            ->orderByPrimaryRole()
             ->orderBy('name')
             ->simplePaginate(100)
             ->appends(['search' => $search]);

--- a/resources/views/keyPerformanceIndicators/show.blade.php
+++ b/resources/views/keyPerformanceIndicators/show.blade.php
@@ -33,14 +33,7 @@
                                     Rol
                                 </td>
                                 <td>
-                                    @switch($user->role)
-                                        @case(1)
-                                            Admin
-                                            @break
-                                        @case(2)
-                                            Operator
-                                            @break
-                                    @endswitch
+                                    {{ $user->display_role_name ?? '—' }}
                                 </td>
                             </tr>
                             <tr>

--- a/tests/Feature/ImpersonationTest.php
+++ b/tests/Feature/ImpersonationTest.php
@@ -55,6 +55,63 @@ class ImpersonationTest extends TestCase
         $this->assertNull(session('impersonated_by_name'));
     }
 
+    public function test_impersonation_index_orders_by_primary_role_then_name(): void
+    {
+        $superAdminRole = Role::firstOrCreate(
+            ['slug' => 'super-admin'],
+            [
+                'name' => 'Super Admin',
+                'description' => 'Full access to the technical toolbox.',
+            ]
+        );
+
+        $adminRole = Role::firstOrCreate(
+            ['slug' => 'admin'],
+            [
+                'name' => 'Administrator',
+                'description' => 'Administrator access.',
+            ]
+        );
+
+        $mechanicRole = Role::firstOrCreate(
+            ['slug' => 'mecanic'],
+            [
+                'name' => 'Mecanic',
+                'description' => 'Acces limitat la gestiune piese și service mașini.',
+            ]
+        );
+
+        $operatorRole = Role::firstOrCreate(
+            ['slug' => 'operator'],
+            [
+                'name' => 'Operator',
+                'description' => 'Operator access.',
+            ]
+        );
+
+        $superAdmin = User::factory()->create(['name' => 'Root User', 'activ' => 1]);
+        $superAdmin->assignRole($superAdminRole);
+
+        $adminUser = User::factory()->create(['name' => 'Zed Admin', 'activ' => 1]);
+        $adminUser->assignRole($adminRole);
+
+        $mechanicUser = User::factory()->create(['name' => 'Alpha Mechanic', 'activ' => 1]);
+        $mechanicUser->assignRole($mechanicRole);
+
+        $operatorUser = User::factory()->create(['name' => 'Beta Operator', 'activ' => 1]);
+        $operatorUser->assignRole($operatorRole);
+
+        $response = $this->actingAs($superAdmin)->get(route('tech.impersonation.index'));
+
+        $response->assertOk();
+        $response->assertSeeInOrder([
+            'Zed Admin',
+            'Alpha Mechanic',
+            'Beta Operator',
+            'Root User',
+        ]);
+    }
+
     private function createSuperAdmin(): User
     {
         $role = Role::firstOrCreate(


### PR DESCRIPTION
## Summary
- add a reusable scope and accessors on the `User` model so listing logic can sort by the primary pivot role without leaking the legacy `role` column
- update the user management and impersonation controllers to rely on the pivot-driven ordering/syncing while keeping password handling intact
- refresh KPI templates to pull role options from the database and display the primary role helper, and extend feature coverage for creation/update and impersonation ordering

## Testing
- `php artisan test --testsuite=Feature --filter=UserRolesTest` *(fails: composer install requires GitHub credentials in this environment)*
- `php artisan test --testsuite=Feature --filter=ImpersonationTest` *(not run: same dependency installation blocker as above)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a37480dc83269806a9ae2d0a8c7b