### PR TITLE
Drop legacy users role column

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ php artisan facturi-furnizori:organize-calup-files --dry-run
 Follow these steps the first time you deploy the new Tech → Migration Center tooling:
 
 1. **Pull the code** on the server (e.g., `git pull origin work`).
-2. **Run the migrations**: `php artisan migrate --force`. This creates the `roles` and `role_user` tables and backfills the existing `users.role` assignments. The guarded legacy schema import (`2024_01_01_000000_import_legacy_schema.php`) exits immediately when a `users` table already exists, so it will not try to recreate your production schema.
+2. **Run the migrations**: `php artisan migrate --force`. This creates the `roles` and `role_user` tables, backfills the existing `users.role` assignments, and now ships with the cleanup that drops the legacy `users.role` column. The guarded legacy schema import (`2024_01_01_000000_import_legacy_schema.php`) exits immediately when a `users` table already exists, so it will not try to recreate your production schema.
 3. **Seed the Tech roles**: `php artisan db:seed --class=RolesTableSeeder --force`. This grants the Super Admin role to user ID 1 so future role checks rely on the pivot table instead of the legacy column.
 4. **Verify access**: user ID 1 always keeps access to the Tech menu, even before the seeder runs, so you can open the Migration Center to preview pending changes with the new interface.
-5. **Plan the legacy cleanup**: once you are satisfied that all users have the correct records in `role_user`, you may create a follow-up migration to drop the old `users.role` column. Keeping it for now avoids breaking older code paths while you transition.
+5. **Confirm the legacy cleanup**: once you are satisfied that all users have the correct records in `role_user`, rerun `php artisan migrate --force` if needed so the included drop migration removes the old `users.role` column. Keeping your code pivot-aware avoids regressions now that the column is gone.
 
 > Tip: from the Migration Center, you can trigger `php artisan migrate --pretend` to review the SQL that will run before committing migrations.
 

--- a/database/migrations/2025_03_20_010500_drop_role_column_from_users_table.php
+++ b/database/migrations/2025_03_20_010500_drop_role_column_from_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', fn (Blueprint $table) => $table->dropColumn('role'));
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->tinyInteger('role')
+                ->nullable()
+                ->comment('1-admin | 2-dispecer')
+                ->after('id');
+        });
+    }
+};

--- a/database/schema/mysql-schema.sql
+++ b/database/schema/mysql-schema.sql
@@ -1157,7 +1157,6 @@ DROP TABLE IF EXISTS `users`;
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `users` (
   `id` bigint unsigned NOT NULL AUTO_INCREMENT,
-  `role` tinyint(1) DEFAULT NULL COMMENT '1-admin | 2-dispecer',
   `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   `telefon` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,


### PR DESCRIPTION
## Summary
- add a cleanup migration that removes the legacy `users.role` column while providing a reversible down path
- refresh the MySQL schema snapshot to match the dropped column
- update the rollout checklist to note that the cleanup migration now ships with the project

## Testing
- php artisan migrate *(fails: Laravel framework classes unavailable in the execution environment)*
- php artisan test *(fails: Laravel framework classes unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f74578baf88326a2cb601de79b9650