### PR TITLE
Refine impersonation access and UX

### DIFF
--- a/app/Http/Controllers/Tech/ImpersonationController.php
+++ b/app/Http/Controllers/Tech/ImpersonationController.php
@@ -17,6 +17,7 @@ class ImpersonationController extends Controller
 
         $users = User::query()
             ->with('roles')
+            ->where('activ', 1)
             ->when($search !== '', function ($query) use ($search) {
                 $query->where(function ($subQuery) use ($search) {
                     $subQuery->where('name', 'like', '%' . $search . '%')

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -33,5 +33,15 @@ class AuthServiceProvider extends ServiceProvider
             // Tech menu (migration tooling, etc.) stays available during rollouts.
             return $user->id === 1 || $user->hasRole('super-admin');
         });
+
+        Gate::define('access-tech-impersonation', function ($user) {
+            // Allow specific trusted accounts to reach the impersonation tool even if they
+            // are not full Super Admins.
+            if (in_array((int) $user->id, [1, 2], true)) {
+                return true;
+            }
+
+            return $user->hasRole('super-admin');
+        });
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,6 +23,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
+            'activ' => 1,
         ];
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -296,31 +296,35 @@
                                 @endif
                             </ul>
                         </li>
-                        @can('access-tech')
+                        @canany(['access-tech', 'access-tech-impersonation'])
                             <li class="nav-item me-3 dropdown">
                                 <a class="nav-link active dropdown-toggle" href="about:blank" id="navbarTech" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                     <i class="fa-solid fa-microchip me-1"></i>
                                     Tech
                                 </a>
                                 <ul class="dropdown-menu" aria-labelledby="navbarTech">
-                                    <li>
-                                        <a class="dropdown-item" href="{{ route('tech.impersonation.index') }}">
-                                            <i class="fa-solid fa-user-secret me-1"></i>Impersonare utilizatori
-                                        </a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item" href="{{ route('tech.migrations.index') }}">
-                                            <i class="fa-solid fa-database me-1"></i>Migration Center
-                                        </a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item" href="{{ route('tech.seeders.index') }}">
-                                            <i class="fa-solid fa-seedling me-1"></i>Seeder Center
-                                        </a>
-                                    </li>
+                                    @can('access-tech-impersonation')
+                                        <li>
+                                            <a class="dropdown-item" href="{{ route('tech.impersonation.index') }}">
+                                                <i class="fa-solid fa-user-secret me-1"></i>Impersonare utilizatori
+                                            </a>
+                                        </li>
+                                    @endcan
+                                    @can('access-tech')
+                                        <li>
+                                            <a class="dropdown-item" href="{{ route('tech.migrations.index') }}">
+                                                <i class="fa-solid fa-database me-1"></i>Migration Center
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a class="dropdown-item" href="{{ route('tech.seeders.index') }}">
+                                                <i class="fa-solid fa-seedling me-1"></i>Seeder Center
+                                            </a>
+                                        </li>
+                                    @endcan
                                 </ul>
                             </li>
-                        @endcan
+                        @endcanany
                         </ul>
                     @endif
 
@@ -346,13 +350,6 @@
                                         <i class="fa-solid fa-user-secret me-1"></i>
                                         Impersonare: {{ auth()->user()->name }}
                                     </span>
-                                    <form method="post" action="{{ route('impersonation.stop') }}" class="d-inline">
-                                        @csrf
-                                        <button type="submit" class="btn btn-outline-light btn-sm"
-                                            title="Revenire la {{ $impersonatorName ?? 'contul inițial' }}">
-                                            <i class="fa-solid fa-person-walking-arrow-loop-left me-1"></i>Stop impersonating
-                                        </button>
-                                    </form>
                                 </li>
                             @endif
                             <li class="nav-item dropdown">
@@ -361,6 +358,19 @@
                                 </a>
 
                                 <ul class="dropdown-menu" aria-labelledby="navbarAuthentication">
+                                    @if ($impersonationActive)
+                                        <li>
+                                            <form method="post" action="{{ route('impersonation.stop') }}" class="d-inline">
+                                                @csrf
+                                                <button type="submit" class="dropdown-item d-flex align-items-center gap-2"
+                                                    title="Revenire la {{ $impersonatorName ?? 'contul inițial' }}">
+                                                    <i class="fa-solid fa-person-walking-arrow-loop-left"></i>
+                                                    <span>Oprește impersonarea</span>
+                                                </button>
+                                            </form>
+                                        </li>
+                                        <li><hr class="dropdown-divider"></li>
+                                    @endif
                                     <li>
                                         <a class="dropdown-item" href="{{ route('logout') }}"
                                         onclick="event.preventDefault();

--- a/resources/views/tech/impersonation/index.blade.php
+++ b/resources/views/tech/impersonation/index.blade.php
@@ -50,7 +50,7 @@
                 <div class="alert alert-warning mx-3" role="alert">
                     <i class="fa-solid fa-triangle-exclamation me-1"></i>
                     Ești autentificat temporar ca <strong>{{ auth()->user()->name }}</strong>.
-                    Folosește butonul „Stop impersonating” din meniu pentru a reveni la contul tău.
+                    Folosește opțiunea „Oprește impersonarea” din meniul „Logout” pentru a reveni la contul tău.
                 </div>
             @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,15 +86,19 @@ Route::group(['middleware' => ['auth', 'restrict-mechanic-access']], function ()
 
     Route::prefix('tech')
         ->name('tech.')
-        ->middleware('role:super-admin')
         ->group(function () {
-            Route::get('impersonation', [ImpersonationController::class, 'index'])->name('impersonation.index');
-            Route::post('impersonation', [ImpersonationController::class, 'store'])->name('impersonation.start');
-            Route::get('migrations', [MigrationCenterController::class, 'index'])->name('migrations.index');
-            Route::post('migrations/preview', [MigrationCenterController::class, 'preview'])->name('migrations.preview');
-            Route::post('migrations/run', [MigrationCenterController::class, 'run'])->name('migrations.run');
-            Route::get('seeders', [SeederCenterController::class, 'index'])->name('seeders.index');
-            Route::post('seeders/run', [SeederCenterController::class, 'run'])->name('seeders.run');
+            Route::middleware('can:access-tech-impersonation')->group(function () {
+                Route::get('impersonation', [ImpersonationController::class, 'index'])->name('impersonation.index');
+                Route::post('impersonation', [ImpersonationController::class, 'store'])->name('impersonation.start');
+            });
+
+            Route::middleware('role:super-admin')->group(function () {
+                Route::get('migrations', [MigrationCenterController::class, 'index'])->name('migrations.index');
+                Route::post('migrations/preview', [MigrationCenterController::class, 'preview'])->name('migrations.preview');
+                Route::post('migrations/run', [MigrationCenterController::class, 'run'])->name('migrations.run');
+                Route::get('seeders', [SeederCenterController::class, 'index'])->name('seeders.index');
+                Route::post('seeders/run', [SeederCenterController::class, 'run'])->name('seeders.run');
+            });
         });
 
     Route::post('impersonation/stop', [ImpersonationController::class, 'destroy'])


### PR DESCRIPTION
## Summary
- restrict the impersonation listing to active accounts and cover the behavior with tests
- move the stop impersonation action into the logout menu with a Romanian label
- allow user ID 2 to reach the impersonation tool while keeping other tech utilities limited to super admins

## Testing
- `php artisan test --filter=ImpersonationTest` *(blocked: composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f74fcd437c8326adbb3e39298403b5