### PR TITLE
feat: allow assigning multiple roles and permissions to users

### DIFF
--- a/resources/views/useri/create.blade.php
+++ b/resources/views/useri/create.blade.php
@@ -21,6 +21,7 @@
                             @include ('useri.form', [
                                 'user' => $user,
                                 'roles' => $roles,
+                                'permissions' => $permissions,
                                 'buttonText' => 'Adaugă utilizator'
                             ])
                     </form>

--- a/resources/views/useri/edit.blade.php
+++ b/resources/views/useri/edit.blade.php
@@ -21,6 +21,7 @@
 
                                 @include ('useri.form', [
                                     'roles' => $roles,
+                                    'permissions' => $permissions,
                                     'buttonText' => 'Modifică utilizator'
                                 ])
 

--- a/resources/views/useri/index.blade.php
+++ b/resources/views/useri/index.blade.php
@@ -47,7 +47,8 @@
                         <tr class="" style="padding:2rem">
                             <th class="culoare2 text-white">#</th>
                             <th class="culoare2 text-white">Nume</th>
-                            <th class="culoare2 text-white">Rol</th>
+                            <th class="culoare2 text-white">Roluri</th>
+                            <th class="culoare2 text-white">Permisiuni</th>
                             <th class="culoare2 text-white">Telefon</th>
                             <th class="culoare2 text-white">Email</th>
                             <th class="culoare2 text-white">Stare Cont</th>
@@ -64,7 +65,33 @@
                                     {{ $user->name }}
                                 </td>
                                 <td class="">
-                                    {{ $user->display_role_name }}
+                                    <div class="d-flex flex-wrap gap-1">
+                                        @forelse ($user->roles as $role)
+                                            @php
+                                                $roleLabel = $role->name ?? \App\Models\User::LEGACY_ROLE_LABELS[$role->id] ?? ($role->slug ? ucwords(str_replace(['-', '_'], ' ', $role->slug)) : '');
+                                            @endphp
+                                            <span class="badge bg-primary">{{ $roleLabel }}</span>
+                                        @empty
+                                            <span class="text-muted">-</span>
+                                        @endforelse
+                                    </div>
+                                </td>
+                                <td class="">
+                                    <div class="d-flex flex-wrap gap-1">
+                                        @php
+                                            $uniquePermissions = $user->permissions?->unique('id');
+                                        @endphp
+                                        @if ($uniquePermissions && $uniquePermissions->isNotEmpty())
+                                            @foreach ($uniquePermissions as $permission)
+                                                @php
+                                                    $permissionLabel = $permission->name ?? ucwords(str_replace(['-', '_'], ' ', (string) $permission->module));
+                                                @endphp
+                                                <span class="badge bg-secondary">{{ $permissionLabel }}</span>
+                                            @endforeach
+                                        @else
+                                            <span class="text-muted">-</span>
+                                        @endif
+                                    </div>
                                 </td>
                                 <td class="">
                                     {{ $user->telefon }}

--- a/resources/views/useri/show.blade.php
+++ b/resources/views/useri/show.blade.php
@@ -30,10 +30,41 @@
                             </tr>
                             <tr>
                                 <td class="pe-4">
-                                    Rol
+                                    Roluri
                                 </td>
                                 <td>
-                                    {{ $user->display_role_name }}
+                                    <div class="d-flex flex-wrap gap-2">
+                                        @forelse ($user->roles as $role)
+                                            @php
+                                                $roleLabel = $role->name ?? \App\Models\User::LEGACY_ROLE_LABELS[$role->id] ?? ($role->slug ? ucwords(str_replace(['-', '_'], ' ', $role->slug)) : '');
+                                            @endphp
+                                            <span class="badge bg-primary">{{ $roleLabel }}</span>
+                                        @empty
+                                            <span class="text-muted">-</span>
+                                        @endforelse
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="pe-4">
+                                    Permisiuni directe
+                                </td>
+                                <td>
+                                    <div class="d-flex flex-wrap gap-2">
+                                        @php
+                                            $uniquePermissions = $user->permissions?->unique('id');
+                                        @endphp
+                                        @if ($uniquePermissions && $uniquePermissions->isNotEmpty())
+                                            @foreach ($uniquePermissions as $permission)
+                                                @php
+                                                    $permissionLabel = $permission->name ?? ucwords(str_replace(['-', '_'], ' ', (string) $permission->module));
+                                                @endphp
+                                                <span class="badge bg-secondary">{{ $permissionLabel }}</span>
+                                            @endforeach
+                                        @else
+                                            <span class="text-muted">-</span>
+                                        @endif
+                                    </div>
                                 </td>
                             </tr>
                             <tr>


### PR DESCRIPTION
## Summary
- update the user controller to validate role and permission arrays, synchronize the new relationships, and preload related data for listings
- replace the role dropdown with grouped role checkboxes and permission toggles while surfacing selections in the index and detail views
- expand the feature test suite to exercise the new payload shape and verify multi-role and permission syncing

## Testing
- composer install --no-interaction *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f1e555ec83268c7e3774abaf7d55