### PR TITLE
Allow impersonated users to stop impersonation

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -69,5 +69,6 @@ class Kernel extends HttpKernel
         // Andrei
         'role' => \App\Http\Middleware\Role::class,
         'permission' => \App\Http\Middleware\EnsurePermission::class,
+        'can-stop-impersonation' => \App\Http\Middleware\EnsureCanStopImpersonation::class,
     ];
 }

--- a/app/Http/Middleware/EnsureCanStopImpersonation.php
+++ b/app/Http/Middleware/EnsureCanStopImpersonation.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureCanStopImpersonation
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->session()->has('impersonated_by')) {
+            return $next($request);
+        }
+
+        $user = $request->user();
+
+        if ($user && $user->hasPermission('tech-tools')) {
+            return $next($request);
+        }
+
+        abort(403);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -105,7 +105,7 @@ Route::middleware(['auth'])->group(function () {
         });
 
     Route::post('impersonation/stop', [ImpersonationController::class, 'destroy'])
-        ->middleware('permission:tech-tools')
+        ->middleware('can-stop-impersonation')
         ->name('impersonation.stop');
 
     Route::middleware('permission:documente')->group(function () {

--- a/tests/Feature/ImpersonationTest.php
+++ b/tests/Feature/ImpersonationTest.php
@@ -64,6 +64,32 @@ class ImpersonationTest extends TestCase
         $this->assertNull(session('impersonated_by_name'));
     }
 
+    public function test_impersonated_mechanic_receives_redirect_when_stopping_impersonation(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+        $mechanicRole = Role::firstOrCreate(
+            ['slug' => 'mecanic'],
+            [
+                'name' => 'Mecanic',
+                'description' => 'Acces limitat la gestiune piese și service mașini.',
+            ]
+        );
+
+        $mechanicUser = User::factory()->create();
+        $mechanicUser->assignRole($mechanicRole);
+
+        $this->actingAs($superAdmin)->post(route('tech.impersonation.start'), [
+            'user_id' => $mechanicUser->id,
+        ]);
+
+        $this->assertAuthenticatedAs($mechanicUser);
+
+        $response = $this->post(route('impersonation.stop'));
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/');
+    }
+
     public function test_impersonating_mechanic_redirects_to_service_module(): void
     {
         $superAdmin = $this->createSuperAdmin();


### PR DESCRIPTION
## Summary
- add middleware that authorizes impersonation stop requests for impersonated users or tech-tools operators
- register the middleware alias and use it on the impersonation stop route
- cover the scenario with a dedicated feature test asserting a redirect instead of a 403

## Testing
- phpunit --filter=ImpersonationTest *(fails: vendor/bin/phpunit not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f86c36cad88326972521207812655d