### PR TITLE
Localize permission labels to Romanian

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -3,67 +3,67 @@
 return [
     'modules' => [
         'dashboard' => [
-            'name' => 'Access Dashboard',
+            'name' => 'Acces Panou Principal',
             'description' => 'Vizualizează pagina principală și indicatorii generali.',
         ],
         'users' => [
-            'name' => 'Manage Users',
+            'name' => 'Gestionare Utilizatori',
             'description' => 'Acces la listarea și administrarea utilizatorilor.',
         ],
         'roles' => [
-            'name' => 'Manage Roles',
+            'name' => 'Gestionare Roluri',
             'description' => 'Configurează rolurile și accesul acestora.',
         ],
         'firme' => [
-            'name' => 'Manage Companies',
+            'name' => 'Gestionare Companii',
             'description' => 'Gestionează clienții, transportatorii și partenerii.',
         ],
         'camioane' => [
-            'name' => 'Manage Trucks',
+            'name' => 'Gestionare Camioane',
             'description' => 'Administrează flota de camioane și documentele aferente.',
         ],
         'locuri-operare' => [
-            'name' => 'Manage Operation Sites',
+            'name' => 'Gestionare Locații de Operare',
             'description' => 'Gestionează locațiile de operare și detaliile acestora.',
         ],
         'comenzi' => [
-            'name' => 'Manage Orders',
+            'name' => 'Gestionare Comenzi',
             'description' => 'Creează, actualizează și monitorizează comenzile.',
         ],
         'mesagerie' => [
-            'name' => 'Manage Messaging',
+            'name' => 'Gestionare Mesagerie',
             'description' => 'Acces la notificările și mesajele trimise.',
         ],
         'mementouri' => [
-            'name' => 'Manage Reminders',
+            'name' => 'Gestionare Mementouri',
             'description' => 'Administrează mementourile și alertele.',
         ],
         'documente' => [
-            'name' => 'Manage Documents',
+            'name' => 'Gestionare Documente',
             'description' => 'Acces la managerul de fișiere și documente interne.',
         ],
         'facturi' => [
-            'name' => 'Manage Invoices',
+            'name' => 'Gestionare Facturi',
             'description' => 'Gestionează facturile și scadențarele.',
         ],
         'facturi-furnizori' => [
-            'name' => 'Manage Supplier Invoices',
+            'name' => 'Gestionare Facturi Furnizori',
             'description' => 'Administrează facturile furnizorilor și plățile.',
         ],
         'service-masini' => [
-            'name' => 'Manage Vehicle Service',
+            'name' => 'Gestionare Service Auto',
             'description' => 'Gestionează operațiunile din service-ul mașinilor.',
         ],
         'gestiune-piese' => [
-            'name' => 'Manage Parts Inventory',
+            'name' => 'Gestionare Stoc Piese',
             'description' => 'Gestionează stocul de piese și ajustările acestuia.',
         ],
         'rapoarte' => [
-            'name' => 'View Reports',
+            'name' => 'Vizualizare Rapoarte',
             'description' => 'Acces la rapoartele și analizele aplicației.',
         ],
         'tech-tools' => [
-            'name' => 'Access Tech Tools',
+            'name' => 'Acces Instrumente Tehnice',
             'description' => 'Acces la instrumentele tehnice dedicate echipei interne.',
         ],
     ],

--- a/database/migrations/2025_03_20_030000_update_permission_labels_to_romanian.php
+++ b/database/migrations/2025_03_20_030000_update_permission_labels_to_romanian.php
@@ -1,0 +1,109 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        $modules = config('permissions.modules', []);
+
+        if (empty($modules)) {
+            return;
+        }
+
+        $now = now();
+
+        foreach ($modules as $moduleKey => $details) {
+            DB::table('permissions')
+                ->where('module', (string) $moduleKey)
+                ->update([
+                    'name' => $details['name'] ?? null,
+                    'description' => $details['description'] ?? null,
+                    'updated_at' => $now,
+                ]);
+        }
+    }
+
+    public function down(): void
+    {
+        $originals = [
+            'dashboard' => [
+                'name' => 'Access Dashboard',
+                'description' => 'Vizualizează pagina principală și indicatorii generali.',
+            ],
+            'users' => [
+                'name' => 'Manage Users',
+                'description' => 'Acces la listarea și administrarea utilizatorilor.',
+            ],
+            'roles' => [
+                'name' => 'Manage Roles',
+                'description' => 'Configurează rolurile și accesul acestora.',
+            ],
+            'firme' => [
+                'name' => 'Manage Companies',
+                'description' => 'Gestionează clienții, transportatorii și partenerii.',
+            ],
+            'camioane' => [
+                'name' => 'Manage Trucks',
+                'description' => 'Administrează flota de camioane și documentele aferente.',
+            ],
+            'locuri-operare' => [
+                'name' => 'Manage Operation Sites',
+                'description' => 'Gestionează locațiile de operare și detaliile acestora.',
+            ],
+            'comenzi' => [
+                'name' => 'Manage Orders',
+                'description' => 'Creează, actualizează și monitorizează comenzile.',
+            ],
+            'mesagerie' => [
+                'name' => 'Manage Messaging',
+                'description' => 'Acces la notificările și mesajele trimise.',
+            ],
+            'mementouri' => [
+                'name' => 'Manage Reminders',
+                'description' => 'Administrează mementourile și alertele.',
+            ],
+            'documente' => [
+                'name' => 'Manage Documents',
+                'description' => 'Acces la managerul de fișiere și documente interne.',
+            ],
+            'facturi' => [
+                'name' => 'Manage Invoices',
+                'description' => 'Gestionează facturile și scadențarele.',
+            ],
+            'facturi-furnizori' => [
+                'name' => 'Manage Supplier Invoices',
+                'description' => 'Administrează facturile furnizorilor și plățile.',
+            ],
+            'service-masini' => [
+                'name' => 'Manage Vehicle Service',
+                'description' => 'Gestionează operațiunile din service-ul mașinilor.',
+            ],
+            'gestiune-piese' => [
+                'name' => 'Manage Parts Inventory',
+                'description' => 'Gestionează stocul de piese și ajustările acestuia.',
+            ],
+            'rapoarte' => [
+                'name' => 'View Reports',
+                'description' => 'Acces la rapoartele și analizele aplicației.',
+            ],
+            'tech-tools' => [
+                'name' => 'Access Tech Tools',
+                'description' => 'Acces la instrumentele tehnice dedicate echipei interne.',
+            ],
+        ];
+
+        $now = now();
+
+        foreach ($originals as $moduleKey => $details) {
+            DB::table('permissions')
+                ->where('module', (string) $moduleKey)
+                ->update([
+                    'name' => $details['name'],
+                    'description' => $details['description'],
+                    'updated_at' => $now,
+                ]);
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- update permission configuration labels to Romanian text for UI display
- add a data migration to sync existing permission records with the new Romanian labels

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f86c4ad9bc832696c1612f0e20a195