### PR TITLE
Expand user forms to full width

### DIFF
--- a/resources/views/useri/create.blade.php
+++ b/resources/views/useri/create.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-6">
+        <div class="col-12 col-lg-12">
             <div class="shadow-lg" style="border-radius: 40px 40px 40px 40px;">
                 <div class="border border-secondary p-2 culoare2" style="border-radius: 40px 40px 0px 0px;">
                     <span class="badge text-light fs-5">

--- a/resources/views/useri/edit.blade.php
+++ b/resources/views/useri/edit.blade.php
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
     <div class="row justify-content-center">
-        <div class="col-md-6">
+        <div class="col-12 col-lg-12">
             <div class="shadow-lg" style="border-radius: 40px 40px 40px 40px;">
                 <div class="border border-secondary p-2 culoare2" style="border-radius: 40px 40px 0px 0px;">
                     <span class="badge text-light fs-5">


### PR DESCRIPTION
## Summary
- update the user creation and edit card wrappers to use full-width grid classes so the layout spans the desktop grid

## Testing
- not run (composer install requires GitHub credentials in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f86c52597c8326b54df65f501875cb