### PR TITLE
Use permission-aware navigation and add mechanic menu test

### DIFF
--- a/tests/Feature/UserNavigationTest.php
+++ b/tests/Feature/UserNavigationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UserNavigationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mechanic_navigation_updates_with_new_permissions(): void
+    {
+        $mechanicRole = $this->ensureRoleWithDefaults(
+            'mecanic',
+            'Mecanic',
+            'Acces limitat la gestiunea pieselor și service-ul mașinilor.'
+        );
+
+        $mechanic = $this->createUserWithRole($mechanicRole);
+
+        $response = $this->actingAs($mechanic)->get(route('gestiune-piese.index'));
+
+        $response->assertOk();
+        $response->assertSee('href="' . route('gestiune-piese.index') . '"', false);
+        $response->assertSee('href="' . route('service-masini.index') . '"', false);
+        $response->assertDontSee('href="/comenzi"', false);
+        $response->assertDontSee('href="/file-manager-personalizat"', false);
+
+        $comenziPermission = Permission::where('module', 'comenzi')->firstOrFail();
+
+        $mechanic->syncPermissions([$comenziPermission->id]);
+
+        $updatedResponse = $this->actingAs($mechanic->fresh())->get(route('gestiune-piese.index'));
+
+        $updatedResponse->assertOk();
+        $updatedResponse->assertSee('href="/comenzi"', false);
+        $updatedResponse->assertDontSee('href="/file-manager-personalizat"', false);
+    }
+
+    private function ensureRoleWithDefaults(string $slug, string $name, string $description): Role
+    {
+        $role = Role::firstOrCreate(
+            ['slug' => $slug],
+            [
+                'name' => $name,
+                'description' => $description,
+            ]
+        );
+
+        $this->syncRoleDefaults($role);
+
+        return $role;
+    }
+
+    private function createUserWithRole(Role $role, array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+        $user->assignRole($role);
+
+        return $user->fresh();
+    }
+
+    private function syncRoleDefaults(Role $role): void
+    {
+        $defaults = config('permissions.role_defaults', []);
+        $modules = $defaults[$role->slug] ?? [];
+
+        if (in_array('*', $modules, true)) {
+            $role->syncPermissions(Permission::all());
+
+            return;
+        }
+
+        if (empty($modules)) {
+            $role->syncPermissions([]);
+
+            return;
+        }
+
+        $role->syncPermissions(Permission::whereIn('module', $modules)->get());
+    }
+}


### PR DESCRIPTION
## Summary
- replace the mechanic role split in the main layout with permission-aware navigation data and dropdown rendering
- conditionally expose each navigation link or dropdown entry based on the relevant module permissions and keep the brand link pointed at an allowed route
- add a feature test that verifies a mechanic gains menu links after receiving an extra permission while other restricted entries remain hidden

## Testing
- ⚠️ `composer install` *(fails: requires a GitHub token to download dependencies, so phpunit could not be executed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8801f2d288326b2c2e521d2ccd8ed