### PR TITLE
Update impersonation badge label

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -442,7 +442,7 @@
                                 <li class="nav-item d-flex align-items-center me-3 gap-2">
                                     <span class="badge bg-warning text-dark text-wrap">
                                         <i class="fa-solid fa-user-secret me-1"></i>
-                                        Impersonare: {{ auth()->user()->name }}
+                                        Impersonate
                                     </span>
                                 </li>
                             @endif


### PR DESCRIPTION
## Summary
- replace the authenticated navbar impersonation badge text to show only "Impersonate"
- ensure no other impersonation indicators append the impersonated user's name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8a25446488326bcd82a5d7cabfaf7