### PR TITLE
Remove redundant primary nav links for existing sections

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -91,18 +91,6 @@
 
         $primaryNavLinks = array_values(array_filter([
             [
-                'permission' => 'gestiune-piese',
-                'href' => route('gestiune-piese.index'),
-                'icon' => 'fa-solid fa-boxes-stacked',
-                'label' => 'Gestiune piese',
-            ],
-            [
-                'permission' => 'service-masini',
-                'href' => route('service-masini.index'),
-                'icon' => 'fa-solid fa-screwdriver-wrench',
-                'label' => 'Service mașini',
-            ],
-            [
                 'permission' => 'documente',
                 'href' => '/file-manager-personalizat',
                 'icon' => 'fa-solid fa-folder',


### PR DESCRIPTION
## Summary
- remove the gestiune-piese and service-masini entries from the primary navigation links so they only appear under the Utile dropdown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8a2979c188326a545c65401c18286