### PR TITLE
Refresh role descriptions and update legacy data

### DIFF
--- a/database/migrations/2024_01_01_010000_create_roles_tables.php
+++ b/database/migrations/2024_01_01_010000_create_roles_tables.php
@@ -35,12 +35,12 @@ return new class extends Migration {
                 1 => [
                     'name' => 'Administrator',
                     'slug' => 'admin',
-                    'description' => 'Legacy administrator role mapped from users.role = 1.',
+                    'description' => 'Acces complet la configurarea aplicației și administrarea utilizatorilor.',
                 ],
                 2 => [
                     'name' => 'Dispecer',
                     'slug' => 'dispecer',
-                    'description' => 'Legacy dispatcher role mapped from users.role = 2.',
+                    'description' => 'Coordonează comenzile și distribuie cursele către șoferi.',
                 ],
             ];
 

--- a/database/migrations/2024_08_15_000001_update_role_descriptions.php
+++ b/database/migrations/2024_08_15_000001_update_role_descriptions.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $updates = [
+            'admin' => [
+                'from' => 'Legacy administrator role mapped from users.role = 1.',
+                'to' => 'Acces complet la configurarea aplicației și administrarea utilizatorilor.',
+            ],
+            'dispecer' => [
+                'from' => 'Legacy dispatcher role mapped from users.role = 2.',
+                'to' => 'Coordonează comenzile și distribuie cursele către șoferi.',
+            ],
+            'mecanic' => [
+                'from' => 'Acces limitat la gestiunea pieselor și service-ul mașinilor.',
+                'to' => 'Gestionează intervențiile tehnice și starea vehiculelor.',
+            ],
+        ];
+
+        foreach ($updates as $slug => $payload) {
+            DB::table('roles')
+                ->where('slug', $slug)
+                ->where('description', $payload['from'])
+                ->update(['description' => $payload['to']]);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $updates = [
+            'admin' => [
+                'from' => 'Acces complet la configurarea aplicației și administrarea utilizatorilor.',
+                'to' => 'Legacy administrator role mapped from users.role = 1.',
+            ],
+            'dispecer' => [
+                'from' => 'Coordonează comenzile și distribuie cursele către șoferi.',
+                'to' => 'Legacy dispatcher role mapped from users.role = 2.',
+            ],
+            'mecanic' => [
+                'from' => 'Gestionează intervențiile tehnice și starea vehiculelor.',
+                'to' => 'Acces limitat la gestiunea pieselor și service-ul mașinilor.',
+            ],
+        ];
+
+        foreach ($updates as $slug => $payload) {
+            DB::table('roles')
+                ->where('slug', $slug)
+                ->where('description', $payload['from'])
+                ->update(['description' => $payload['to']]);
+        }
+    }
+};

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -26,7 +26,7 @@ class RolesTableSeeder extends Seeder
             ['slug' => 'admin'],
             [
                 'name' => 'Administrator',
-                'description' => 'Legacy administrator role mapped from users.role = 1.',
+                'description' => 'Acces complet la configurarea aplicației și administrarea utilizatorilor.',
             ]
         );
 
@@ -34,7 +34,7 @@ class RolesTableSeeder extends Seeder
             ['slug' => 'dispecer'],
             [
                 'name' => 'Dispecer',
-                'description' => 'Legacy dispatcher role mapped from users.role = 2.',
+                'description' => 'Coordonează comenzile și distribuie cursele către șoferi.',
             ]
         );
 
@@ -42,7 +42,7 @@ class RolesTableSeeder extends Seeder
             ['slug' => 'mecanic'],
             [
                 'name' => 'Mecanic',
-                'description' => 'Acces limitat la gestiunea pieselor și service-ul mașinilor.',
+                'description' => 'Gestionează intervențiile tehnice și starea vehiculelor.',
             ]
         );
 


### PR DESCRIPTION
## Summary
- refresh administrator, dispecer, and mecanic descriptions in the roles seeder and base migration
- ensure new installs seed consistent descriptions for the legacy role records
- add a follow-up migration to update existing role descriptions in production databases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f8a29b16148326b8b014ef6e4e2c9a