### PR TITLE
Harden file manager admin permissions

### DIFF
--- a/app/Http/Controllers/FileManagerPersonalizatController.php
+++ b/app/Http/Controllers/FileManagerPersonalizatController.php
@@ -60,6 +60,8 @@ class FileManagerPersonalizatController extends Controller
 
     public function directorCreaza(Request $request)
     {
+        $this->authorize('documente-admin');
+
         $request->validate([
             'cale'         => '',
             'numeDirector' => 'required',
@@ -81,9 +83,7 @@ class FileManagerPersonalizatController extends Controller
 
     public function directorSterge(Request $request, $cale = null)
     {
-        if (! $request->user()?->hasPermission('documente')) {
-            return back()->with('error', 'Nu aveți dreptul să ștergeti directoare! Contactați administratorul aplicației.');
-        }
+        $this->authorize('documente-admin');
 
         try {
             Storage::disk('filemanager')->deleteDirectory($cale);
@@ -97,6 +97,8 @@ class FileManagerPersonalizatController extends Controller
 
     public function fisiereAdauga(Request $request)
     {
+        $this->authorize('documente-admin');
+
         $request->validate([
             'fisiere.*' => 'required|max:300000'
         ]);
@@ -142,9 +144,7 @@ class FileManagerPersonalizatController extends Controller
 
     public function fisierSterge(Request $request, $cale = null)
     {
-        if (! $request->user()?->hasPermission('documente')) {
-            return back()->with('error', 'Nu aveți dreptul să ștergeti fișiere! Contactați administratorul aplicației.');
-        }
+        $this->authorize('documente-admin');
 
         try {
             Storage::disk('filemanager')->delete($cale);
@@ -158,9 +158,7 @@ class FileManagerPersonalizatController extends Controller
 
     public function modificaCaleNume(Request $request)
     {
-        if (! $request->user()?->hasPermission('documente')) {
-            return back()->with('error', 'Nu aveți dreptul de modificare! Contactați administratorul aplicației.');
-        }
+        $this->authorize('documente-admin');
 
         $request->validate([
             'cale'           => '',
@@ -195,6 +193,8 @@ class FileManagerPersonalizatController extends Controller
      */
     public function copyFile(Request $request)
     {
+        $this->authorize('documente-admin');
+
         $request->validate([
             'source'      => 'required',
             'destination' => 'nullable',
@@ -224,6 +224,8 @@ class FileManagerPersonalizatController extends Controller
      */
     public function moveFile(Request $request)
     {
+        $this->authorize('documente-admin');
+
         $request->validate([
             'source'      => 'required',
             'destination' => 'nullable',
@@ -253,6 +255,8 @@ class FileManagerPersonalizatController extends Controller
      */
     public function copyDirectory(Request $request)
     {
+        $this->authorize('documente-admin');
+
         $request->validate([
             'source'      => 'required',
             'destination' => 'nullable',
@@ -283,6 +287,8 @@ class FileManagerPersonalizatController extends Controller
      */
     public function moveDirectory(Request $request)
     {
+        $this->authorize('documente-admin');
+
         $request->validate([
             'source'      => 'required',
             'destination' => 'nullable',

--- a/resources/views/fileManagerPersonalizat/index.blade.php
+++ b/resources/views/fileManagerPersonalizat/index.blade.php
@@ -26,26 +26,28 @@
                 </div>
             </form>
         </div>
-        <div class="col-lg-3 text-end">
-            <div class="mb-2">
-                <a class="btn btn-sm btn-success text-white border border-dark rounded-3"
-                   href="#"
-                   data-bs-toggle="modal"
-                   data-bs-target="#creazaDirector"
-                   title="Crează Director">
-                    <i class="fas fa-folder-plus"></i> Crează director
-                </a>
+        @can('documente-admin')
+            <div class="col-lg-3 text-end">
+                <div class="mb-2">
+                    <a class="btn btn-sm btn-success text-white border border-dark rounded-3"
+                       href="#"
+                       data-bs-toggle="modal"
+                       data-bs-target="#creazaDirector"
+                       title="Crează Director">
+                        <i class="fas fa-folder-plus"></i> Crează director
+                    </a>
+                </div>
+                <div>
+                    <a class="btn btn-sm btn-success text-white border border-dark rounded-3"
+                       href="#"
+                       data-bs-toggle="modal"
+                       data-bs-target="#adaugaFisiere"
+                       title="Adaugă fișiere">
+                        <i class="fas fa-file-upload"></i> Adaugă fișiere
+                    </a>
+                </div>
             </div>
-            <div>
-                <a class="btn btn-sm btn-success text-white border border-dark rounded-3"
-                   href="#"
-                   data-bs-toggle="modal"
-                   data-bs-target="#adaugaFisiere"
-                   title="Adaugă fișiere">
-                    <i class="fas fa-file-upload"></i> Adaugă fișiere
-                </a>
-            </div>
-        </div>
+        @endcan
     </div>
 
     <div class="card-body px-0 py-3">
@@ -130,7 +132,7 @@
                                         /
                                     @endforeach
                                 </th>
-                                @can('documente')
+                                @can('documente-admin')
                                     <th class="text-end">Acțiuni</th>
                                 @endcan
                             </tr>
@@ -147,8 +149,8 @@
                                             <i class="fas fa-folder text-warning"></i> {{ $dirName }}
                                         </a>
                                     </td>
-                                    <td>
-                                        @can('documente')
+                                    @can('documente-admin')
+                                        <td>
                                             <div class="d-flex justify-content-end">
                                                 <!-- Modify button  -->
                                                 <div class="me-1">
@@ -183,8 +185,8 @@
                                                     </a>
                                                 </div>
                                             </div>
-                                        @endcan
-                                    </td>
+                                        </td>
+                                    @endcan
                                 </tr>
                             @endforeach
                             @foreach ($fisiere as $fisier)
@@ -198,8 +200,8 @@
                                             <i class="fas fa-file"></i> {{ $fileName }}
                                         </a>
                                     </td>
-                                    <td>
-                                        @can('documente')
+                                    @can('documente-admin')
+                                        <td>
                                             <div class="d-flex justify-content-end">
                                                 <!-- Modify button -->
                                                 <div class="me-1">
@@ -234,8 +236,8 @@
                                                     </a>
                                                 </div>
                                             </div>
-                                        @endcan
-                                    </td>
+                                        </td>
+                                    @endcan
                                 </tr>
                             @endforeach
                         </tbody>
@@ -246,6 +248,7 @@
     </div>
 </div>
 
+@can('documente-admin')
 {{-- ======================= Modale ======================= --}}
 
 {{-- Crează Director Modal --}}
@@ -635,5 +638,7 @@
         </div>
     </div>
 @endforeach
+
+@endcan
 
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -110,17 +110,20 @@ Route::middleware(['auth'])->group(function () {
 
     Route::middleware('permission:documente')->group(function () {
         Route::get('/file-manager-personalizat/{cale?}', [FileManagerPersonalizatController::class, 'afisareDirectoareSiFisiere'])->where('cale', '.*');
-        Route::post('/file-manager-personalizat-director/creaza', [FileManagerPersonalizatController::class, 'directorCreaza']);
-        // Route::post('/file-manager-personalizat-director/modifica-cale-nume', [FileManagerPersonalizatController::class, 'directorModificaCaleNume']);
-        Route::delete('/file-manager-personalizat-director/sterge/{cale?}', [FileManagerPersonalizatController::class, 'directorSterge'])->where('cale', '.*');
-        Route::post('/file-manager-personalizat-fisiere/adauga', [FileManagerPersonalizatController::class, 'fisiereAdauga']);
         Route::get('/file-manager-personalizat-fisier/deschide/{cale?}', [FileManagerPersonalizatController::class, 'fisierDeschide'])->where('cale', '.*');
-        Route::delete('/file-manager-personalizat-fisier/sterge/{cale?}', [FileManagerPersonalizatController::class, 'fisierSterge'])->where('cale', '.*');
-        Route::post('/file-manager-personalizat-resursa/modifica-cale-nume', [FileManagerPersonalizatController::class, 'ModificaCaleNume']);
-        Route::post('/file-manager-personalizat-fisier/copy', [FileManagerPersonalizatController::class, 'copyFile']);
-        Route::post('/file-manager-personalizat-fisier/move', [FileManagerPersonalizatController::class, 'moveFile']);
-        Route::post('/file-manager-personalizat-director/copy', [FileManagerPersonalizatController::class, 'copyDirectory']);
-        Route::post('/file-manager-personalizat-director/move', [FileManagerPersonalizatController::class, 'moveDirectory']);
+
+        Route::middleware('permission:documente-admin')->group(function () {
+            Route::post('/file-manager-personalizat-director/creaza', [FileManagerPersonalizatController::class, 'directorCreaza']);
+            // Route::post('/file-manager-personalizat-director/modifica-cale-nume', [FileManagerPersonalizatController::class, 'directorModificaCaleNume']);
+            Route::delete('/file-manager-personalizat-director/sterge/{cale?}', [FileManagerPersonalizatController::class, 'directorSterge'])->where('cale', '.*');
+            Route::post('/file-manager-personalizat-fisiere/adauga', [FileManagerPersonalizatController::class, 'fisiereAdauga']);
+            Route::delete('/file-manager-personalizat-fisier/sterge/{cale?}', [FileManagerPersonalizatController::class, 'fisierSterge'])->where('cale', '.*');
+            Route::post('/file-manager-personalizat-resursa/modifica-cale-nume', [FileManagerPersonalizatController::class, 'ModificaCaleNume']);
+            Route::post('/file-manager-personalizat-fisier/copy', [FileManagerPersonalizatController::class, 'copyFile']);
+            Route::post('/file-manager-personalizat-fisier/move', [FileManagerPersonalizatController::class, 'moveFile']);
+            Route::post('/file-manager-personalizat-director/copy', [FileManagerPersonalizatController::class, 'copyDirectory']);
+            Route::post('/file-manager-personalizat-director/move', [FileManagerPersonalizatController::class, 'moveDirectory']);
+        });
 
         // For transporters to upload their documents
         Route::get('/comanda-documente-transportator/{cheie_unica}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'afisareDocumenteIncarcateDejaSiFormular']);

--- a/tests/Feature/FileManagerPersonalizatTest.php
+++ b/tests/Feature/FileManagerPersonalizatTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class FileManagerPersonalizatTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('filemanager');
+    }
+
+    public function test_dispatcher_cannot_mutate_file_manager(): void
+    {
+        $dispatcher = $this->createUserWithRole('dispecer');
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-director/creaza', [
+                'cale' => '',
+                'numeDirector' => 'Restricted',
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-fisiere/adauga', [
+                'cale' => '',
+                'fisiere' => [UploadedFile::fake()->create('blocked.txt', 1)],
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-resursa/modifica-cale-nume', [
+                'cale' => '',
+                'numeVechi' => 'old',
+                'numeNou' => 'new',
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-fisier/copy', [
+                'source' => 'Reports/report.txt',
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-fisier/move', [
+                'source' => 'Reports/report.txt',
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-director/copy', [
+                'source' => 'Reports',
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->post('/file-manager-personalizat-director/move', [
+                'source' => 'Reports',
+            ])
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->delete('/file-manager-personalizat-director/sterge/Reports')
+            ->assertForbidden();
+
+        $this->actingAs($dispatcher)
+            ->delete('/file-manager-personalizat-fisier/sterge/Reports/report.txt')
+            ->assertForbidden();
+    }
+
+    public function test_admin_can_manage_file_manager_resources(): void
+    {
+        $admin = $this->createUserWithRole('admin');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat')
+            ->post('/file-manager-personalizat-director/creaza', [
+                'cale' => '',
+                'numeDirector' => 'Reports',
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertDirectoryExists('Reports');
+
+        $upload = UploadedFile::fake()->create('summary.txt', 1);
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat/Reports')
+            ->post('/file-manager-personalizat-fisiere/adauga', [
+                'cale' => 'Reports',
+                'fisiere' => [$upload],
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertExists('Reports/summary.txt');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat/Reports')
+            ->post('/file-manager-personalizat-resursa/modifica-cale-nume', [
+                'cale' => 'Reports',
+                'extensieFisier' => 'txt',
+                'numeVechi' => 'summary',
+                'numeNou' => 'report',
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertExists('Reports/report.txt');
+        Storage::disk('filemanager')->assertMissing('Reports/summary.txt');
+
+        Storage::disk('filemanager')->makeDirectory('Archive');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat/Reports')
+            ->post('/file-manager-personalizat-fisier/copy', [
+                'source' => 'Reports/report.txt',
+                'destination' => 'Archive',
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertExists('Archive/report.txt');
+
+        Storage::disk('filemanager')->makeDirectory('Archive2');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat/Reports')
+            ->post('/file-manager-personalizat-fisier/move', [
+                'source' => 'Reports/report.txt',
+                'destination' => 'Archive2',
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertMissing('Reports/report.txt');
+        Storage::disk('filemanager')->assertExists('Archive2/report.txt');
+
+        Storage::disk('filemanager')->put('Archive2/nested.txt', 'content');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat')
+            ->post('/file-manager-personalizat-director/copy', [
+                'source' => 'Archive2',
+                'destination' => 'Archive',
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertExists('Archive/Archive2/report.txt');
+        Storage::disk('filemanager')->assertExists('Archive/Archive2/nested.txt');
+
+        Storage::disk('filemanager')->makeDirectory('Archive3');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat')
+            ->post('/file-manager-personalizat-director/move', [
+                'source' => 'Archive2',
+                'destination' => 'Archive3',
+            ])
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertDirectoryMissing('Archive2');
+        Storage::disk('filemanager')->assertExists('Archive3/Archive2/report.txt');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat')
+            ->delete('/file-manager-personalizat-fisier/sterge/Archive/Archive2/report.txt')
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertMissing('Archive/Archive2/report.txt');
+
+        $this->actingAs($admin)
+            ->from('/file-manager-personalizat')
+            ->delete('/file-manager-personalizat-director/sterge/Archive3/Archive2')
+            ->assertRedirect();
+
+        Storage::disk('filemanager')->assertDirectoryMissing('Archive3/Archive2');
+    }
+
+    private function createUserWithRole(string $slug): User
+    {
+        $role = Role::firstOrCreate(
+            ['slug' => $slug],
+            [
+                'name' => Str::headline($slug),
+                'description' => Str::headline($slug) . ' role.',
+            ]
+        );
+
+        $role->syncPermissions(config('permissions.role_defaults.' . $slug, []));
+
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- restrict all file manager mutation routes to the `documente-admin` permission and enforce the authorization in the controller
- hide file manager UI actions and modals unless the current user can `documente-admin`
- add a feature test covering dispatcher 403 responses and administrator success paths

## Testing
- php artisan test --filter=FileManagerPersonalizatTest *(fails: dependencies could not be installed because composer cannot reach GitHub over the network)*

------
https://chatgpt.com/codex/tasks/task_e_68f906bd00448326a8a5925db2929ad2