### PR TITLE
Adjust dispatcher supplier invoice permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ You can perform a dry run first to inspect the planned moves without making chan
 php artisan facturi-furnizori:organize-calup-files --dry-run
 ```
 
+## Dispatcher permissions update (March 2025)
+
+- The dispatcher role (`dispecer`) no longer has access to the Supplier Invoices module (`facturi-furnizori`). Deploying this release runs a migration that detaches the permission from existing dispatcher assignments.
+- After deploying, rerun the roles seeder to ensure permission maps stay in sync:
+
+```bash
+php artisan db:seed --class=RolesTableSeeder --force
+```
+
 ## Tech toolkit rollout checklist
 
 Follow these steps the first time you deploy the new Tech → Migration Center tooling:

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -102,7 +102,6 @@ return [
             'mementouri',
             'documente',
             'facturi',
-            'facturi-furnizori',
             'rapoarte',
         ],
         'mecanic' => [

--- a/database/migrations/2025_03_20_040000_detach_facturi_furnizori_from_dispatcher.php
+++ b/database/migrations/2025_03_20_040000_detach_facturi_furnizori_from_dispatcher.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $roleId = DB::table('roles')
+            ->where('slug', 'dispecer')
+            ->value('id');
+
+        if (! $roleId) {
+            return;
+        }
+
+        $permissionId = DB::table('permissions')
+            ->where(function (Builder $query) {
+                $query->where('slug', 'access-facturi-furnizori')
+                    ->orWhere('module', 'facturi-furnizori');
+            })
+            ->value('id');
+
+        if (! $permissionId) {
+            return;
+        }
+
+        DB::table('permission_role')
+            ->where('role_id', $roleId)
+            ->where('permission_id', $permissionId)
+            ->delete();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $roleId = DB::table('roles')
+            ->where('slug', 'dispecer')
+            ->value('id');
+
+        $permissionId = DB::table('permissions')
+            ->where(function (Builder $query) {
+                $query->where('slug', 'access-facturi-furnizori')
+                    ->orWhere('module', 'facturi-furnizori');
+            })
+            ->value('id');
+
+        if (! $roleId || ! $permissionId) {
+            return;
+        }
+
+        $exists = DB::table('permission_role')
+            ->where('role_id', $roleId)
+            ->where('permission_id', $permissionId)
+            ->exists();
+
+        if ($exists) {
+            return;
+        }
+
+        DB::table('permission_role')->insert([
+            'role_id' => $roleId,
+            'permission_id' => $permissionId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+};


### PR DESCRIPTION
## Summary
- remove the supplier invoices permission from the dispatcher role defaults
- add a migration that detaches the dispatcher from the supplier invoices permission in existing data
- document the dispatcher access change and the need to rerun the roles seeder after deployment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f906e1498c8326ba1282aebe948e73