### PR TITLE
Clean up permission pivots to rely on role defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ php artisan facturi-furnizori:organize-calup-files --dry-run
 php artisan db:seed --class=RolesTableSeeder --force
 ```
 
+## Permission pivot cleanup (March 2025)
+
+Follow this order in production to realign cached permissions with the updated role defaults:
+
+1. **Run the migrations** so the new cleanup executes: `php artisan migrate --force`.
+2. **Reseed the roles** to pull the revised role → permission map into the database: `php artisan db:seed --class=RolesTableSeeder --force`.
+3. **Reset caches** so Laravel reads the refreshed config and permission metadata: `php artisan optimize:clear`.
+4. **Warm the caches** that matter for permissions before releasing to users (optional but recommended): `php artisan config:cache` followed by `php artisan route:cache`.
+
+After these steps the `permission_user` pivot remains empty by design, and each user's effective access comes from the roles assigned in `role_user`.
+
 ## Tech toolkit rollout checklist
 
 Follow these steps the first time you deploy the new Tech → Migration Center tooling:

--- a/database/migrations/2025_03_21_000000_reset_permission_user_and_sync_roles.php
+++ b/database/migrations/2025_03_21_000000_reset_permission_user_and_sync_roles.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('permissions') || ! Schema::hasTable('roles') || ! Schema::hasTable('permission_role')) {
+            return;
+        }
+
+        if (Schema::hasTable('permission_user')) {
+            DB::table('permission_user')->delete();
+        }
+
+        $permissions = DB::table('permissions')->select('id', 'module')->get();
+        $roles = DB::table('roles')->select('id', 'slug')->get();
+
+        if ($permissions->isEmpty() || $roles->isEmpty()) {
+            return;
+        }
+
+        $permissionMap = $permissions->keyBy('module');
+        $roleDefaults = collect(config('permissions.role_defaults', []));
+        $allPermissionIds = $permissions->pluck('id')->map(fn ($id) => (int) $id)->all();
+
+        foreach ($roles as $role) {
+            $modules = $roleDefaults->get($role->slug, []);
+
+            if ($modules === '*' || (is_array($modules) && in_array('*', $modules, true))) {
+                $permissionIds = $allPermissionIds;
+            } else {
+                $permissionIds = collect((array) $modules)
+                    ->map(function ($module) use ($permissionMap) {
+                        $permission = $permissionMap->get((string) $module);
+
+                        return $permission ? (int) $permission->id : null;
+                    })
+                    ->filter()
+                    ->unique()
+                    ->values()
+                    ->all();
+            }
+
+            DB::table('permission_role')->where('role_id', (int) $role->id)->delete();
+
+            if (empty($permissionIds)) {
+                continue;
+            }
+
+            $now = now();
+            $rows = array_map(function ($permissionId) use ($role, $now) {
+                return [
+                    'role_id' => (int) $role->id,
+                    'permission_id' => (int) $permissionId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }, $permissionIds);
+
+            DB::table('permission_role')->insert($rows);
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('permission_user')) {
+            DB::table('permission_user')->delete();
+        }
+    }
+};

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -79,7 +79,6 @@ class RolesTableSeeder extends Seeder
         if ($user) {
             $user->assignRole($superAdmin);
             $user->assignRole($admin);
-            $user->syncPermissions($permissions);
         }
     }
 }


### PR DESCRIPTION
## Summary
- stop the roles seeder from syncing direct permissions onto user records while still assigning the admin roles to user #1
- leave the March 20 backfill migration focused on permission_role rows instead of duplicating permissions into permission_user
- add a follow-up migration that clears permission_user and resynchronizes permission_role rows from the current config
- document the production rollout steps so migrations, seeders, and caches are executed in the correct order

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f91c3a5e108326884984205a10a702