### PR TITLE
Refactor tests to honour role defaults

### DIFF
--- a/tests/Concerns/CreatesUsersWithRoles.php
+++ b/tests/Concerns/CreatesUsersWithRoles.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Concerns;
+
+use App\Models\Role;
+use App\Models\User;
+use Tests\Fixtures\RoleFixtures;
+
+trait CreatesUsersWithRoles
+{
+    protected function ensureRole(string $slug, ?array $modules = null, array $attributes = []): Role
+    {
+        return RoleFixtures::createRole($slug, $modules, $attributes);
+    }
+
+    /**
+     * @param  array<int, Role|string>|Role|string  $roles
+     */
+    protected function createUserWithRoles(Role|array|string $roles, array $attributes = []): User
+    {
+        $user = User::factory()->create($attributes);
+
+        $roleCollection = collect(is_array($roles) ? $roles : [$roles])
+            ->map(function ($role) {
+                if ($role instanceof Role) {
+                    return $role;
+                }
+
+                return $this->ensureRole($role);
+            });
+
+        $roleCollection->each(fn (Role $role) => $user->assignRole($role));
+
+        return $user->fresh();
+    }
+}

--- a/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
+++ b/tests/Feature/FacturiFurnizori/FacturaFurnizorTest.php
@@ -6,19 +6,20 @@ use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\Service\GestiunePiesa;
 use App\Models\Service\Masina;
 use App\Models\Service\MasinaServiceEntry;
-use App\Models\User;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsersWithRoles;
 use Tests\TestCase;
 
 class FacturaFurnizorTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesUsersWithRoles;
 
     public function test_it_allows_storing_negative_amounts(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
 
         $payload = [
             'denumire_furnizor' => 'Furnizor Negativ SRL',
@@ -45,7 +46,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_it_allows_updating_to_negative_amounts(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
         $factura = FacturaFurnizor::factory()->create([
             'suma' => 450.00,
             'moneda' => 'RON',
@@ -76,7 +77,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_it_stores_products_together_with_the_invoice(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
 
         $payload = [
             'denumire_furnizor' => 'Furnizor Produse SRL',
@@ -133,7 +134,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_it_replaces_products_when_updating_an_invoice(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
         $factura = FacturaFurnizor::factory()->create([
             'suma' => 150,
             'moneda' => 'EUR',
@@ -190,7 +191,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_it_updates_initial_quantity_without_affecting_allocations(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
         $factura = FacturaFurnizor::factory()->create([
             'suma' => 250,
             'moneda' => 'RON',
@@ -264,7 +265,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_it_validates_initial_quantity_against_allocations(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
         $factura = FacturaFurnizor::factory()->create([
             'suma' => 300,
             'moneda' => 'RON',
@@ -337,7 +338,7 @@ class FacturaFurnizorTest extends TestCase
     {
         Storage::fake('local');
 
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
 
         $pdfOne = UploadedFile::fake()->create('factura_initiala.pdf', 120, 'application/pdf');
         $pdfTwo = UploadedFile::fake()->create('anexa.pdf', 80, 'application/pdf');
@@ -376,7 +377,7 @@ class FacturaFurnizorTest extends TestCase
     {
         Storage::fake('local');
 
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
 
         $payload = [
             'denumire_furnizor' => 'Furnizor Delete SRL',
@@ -413,7 +414,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_piece_without_invoice_remains_available_for_service_entries(): void
     {
-        $user = User::factory()->create(['name' => 'Service User']);
+        $user = $this->createUserWithRoles('admin', ['name' => 'Service User']);
         $factura = FacturaFurnizor::factory()->create();
 
         $piece = $factura->piese()->create([
@@ -468,7 +469,7 @@ class FacturaFurnizorTest extends TestCase
 
     public function test_show_displays_products_with_stock_details_modal_trigger(): void
     {
-        $user = User::factory()->create();
+        $user = $this->createUserWithRoles('admin');
         $factura = FacturaFurnizor::factory()->create();
 
         $piece = GestiunePiesa::factory()

--- a/tests/Feature/FileManagerPersonalizatTest.php
+++ b/tests/Feature/FileManagerPersonalizatTest.php
@@ -2,17 +2,16 @@
 
 namespace Tests\Feature;
 
-use App\Models\Role;
-use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Str;
+use Tests\Concerns\CreatesUsersWithRoles;
 use Tests\TestCase;
 
 class FileManagerPersonalizatTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesUsersWithRoles;
 
     protected function setUp(): void
     {
@@ -23,7 +22,7 @@ class FileManagerPersonalizatTest extends TestCase
 
     public function test_dispatcher_cannot_mutate_file_manager(): void
     {
-        $dispatcher = $this->createUserWithRole('dispecer');
+        $dispatcher = $this->createUserWithRoles('dispecer');
 
         $this->actingAs($dispatcher)
             ->post('/file-manager-personalizat-director/creaza', [
@@ -82,7 +81,7 @@ class FileManagerPersonalizatTest extends TestCase
 
     public function test_admin_can_manage_file_manager_resources(): void
     {
-        $admin = $this->createUserWithRole('admin');
+        $admin = $this->createUserWithRoles('admin');
 
         $this->actingAs($admin)
             ->from('/file-manager-personalizat')
@@ -185,21 +184,4 @@ class FileManagerPersonalizatTest extends TestCase
         Storage::disk('filemanager')->assertDirectoryMissing('Archive3/Archive2');
     }
 
-    private function createUserWithRole(string $slug): User
-    {
-        $role = Role::firstOrCreate(
-            ['slug' => $slug],
-            [
-                'name' => Str::headline($slug),
-                'description' => Str::headline($slug) . ' role.',
-            ]
-        );
-
-        $role->syncPermissions(config('permissions.role_defaults.' . $slug, []));
-
-        $user = User::factory()->create();
-        $user->assignRole($role);
-
-        return $user;
-    }
 }

--- a/tests/Feature/UserNavigationTest.php
+++ b/tests/Feature/UserNavigationTest.php
@@ -2,25 +2,18 @@
 
 namespace Tests\Feature;
 
-use App\Models\Permission;
-use App\Models\Role;
-use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\CreatesUsersWithRoles;
 use Tests\TestCase;
 
 class UserNavigationTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesUsersWithRoles;
 
     public function test_mechanic_navigation_updates_with_new_permissions(): void
     {
-        $mechanicRole = $this->ensureRoleWithDefaults(
-            'mecanic',
-            'Mecanic',
-            'Acces limitat la gestiunea pieselor și service-ul mașinilor.'
-        );
-
-        $mechanic = $this->createUserWithRole($mechanicRole);
+        $mechanic = $this->createUserWithRoles('mecanic');
 
         $response = $this->actingAs($mechanic)->get(route('gestiune-piese.index'));
 
@@ -30,57 +23,12 @@ class UserNavigationTest extends TestCase
         $response->assertDontSee('href="/comenzi"', false);
         $response->assertDontSee('href="/file-manager-personalizat"', false);
 
-        $comenziPermission = Permission::where('module', 'comenzi')->firstOrFail();
-
-        $mechanic->syncPermissions([$comenziPermission->id]);
+        $mechanic->assignRole($this->ensureRole('dispecer'));
 
         $updatedResponse = $this->actingAs($mechanic->fresh())->get(route('gestiune-piese.index'));
 
         $updatedResponse->assertOk();
         $updatedResponse->assertSee('href="/comenzi"', false);
         $updatedResponse->assertDontSee('href="/file-manager-personalizat"', false);
-    }
-
-    private function ensureRoleWithDefaults(string $slug, string $name, string $description): Role
-    {
-        $role = Role::firstOrCreate(
-            ['slug' => $slug],
-            [
-                'name' => $name,
-                'description' => $description,
-            ]
-        );
-
-        $this->syncRoleDefaults($role);
-
-        return $role;
-    }
-
-    private function createUserWithRole(Role $role, array $attributes = []): User
-    {
-        $user = User::factory()->create($attributes);
-        $user->assignRole($role);
-
-        return $user->fresh();
-    }
-
-    private function syncRoleDefaults(Role $role): void
-    {
-        $defaults = config('permissions.role_defaults', []);
-        $modules = $defaults[$role->slug] ?? [];
-
-        if (in_array('*', $modules, true)) {
-            $role->syncPermissions(Permission::all());
-
-            return;
-        }
-
-        if (empty($modules)) {
-            $role->syncPermissions([]);
-
-            return;
-        }
-
-        $role->syncPermissions(Permission::whereIn('module', $modules)->get());
     }
 }

--- a/tests/Feature/UserRolesTest.php
+++ b/tests/Feature/UserRolesTest.php
@@ -10,19 +10,21 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Tests\Concerns\CreatesUsersWithRoles;
 use Tests\TestCase;
 
 class UserRolesTest extends TestCase
 {
     use RefreshDatabase;
+    use CreatesUsersWithRoles;
 
     public function test_user_management_access_is_limited_to_admin_roles(): void
     {
         [$superAdminRole, $adminRole, $mechanicRole] = $this->createCoreRoles();
 
-        $admin = $this->createUserWithRole($adminRole);
-        $superAdmin = $this->createUserWithRole($superAdminRole);
-        $mechanic = $this->createUserWithRole($mechanicRole);
+        $admin = $this->createUserWithRoles($adminRole);
+        $superAdmin = $this->createUserWithRoles($superAdminRole);
+        $mechanic = $this->createUserWithRoles($mechanicRole);
 
         $this->actingAs($admin)->get('/utilizatori')->assertOk();
         $this->actingAs($superAdmin)->get('/utilizatori')->assertOk();
@@ -33,7 +35,7 @@ class UserRolesTest extends TestCase
     {
         [$superAdminRole, $adminRole] = $this->createCoreRoles();
 
-        $admin = $this->createUserWithRole($adminRole);
+        $admin = $this->createUserWithRoles($adminRole);
 
         $response = $this->actingAs($admin)->post('/utilizatori', [
             'name' => 'Test User',
@@ -48,7 +50,7 @@ class UserRolesTest extends TestCase
         $response->assertSessionHasErrors('roles.0');
         $this->assertDatabaseMissing('users', ['email' => 'test@example.com']);
 
-        $user = $this->createUserWithRole($adminRole, [
+        $user = $this->createUserWithRoles($adminRole, [
             'name' => 'Existing User',
             'email' => 'existing@example.com',
         ]);
@@ -70,7 +72,7 @@ class UserRolesTest extends TestCase
     {
         [, $adminRole, $mechanicRole] = $this->createCoreRoles();
 
-        $admin = $this->createUserWithRole($adminRole);
+        $admin = $this->createUserWithRoles($adminRole);
 
         $response = $this->actingAs($admin)->post('/utilizatori', [
             'name' => 'Mechanic User',
@@ -95,16 +97,12 @@ class UserRolesTest extends TestCase
     {
         [, $adminRole, $mechanicRole] = $this->createCoreRoles();
 
-        $dispatcherRole = Role::firstOrCreate(
-            ['slug' => 'dispecer'],
-            [
-                'name' => 'Dispecer',
-                'description' => 'Acces specific dispecerilor.',
-            ]
-        );
-        $this->syncRoleDefaults($dispatcherRole);
+        $dispatcherRole = $this->ensureRole('dispecer', null, [
+            'name' => 'Dispecer',
+            'description' => 'Acces specific dispecerilor.',
+        ]);
 
-        $admin = $this->createUserWithRole($adminRole);
+        $admin = $this->createUserWithRoles($adminRole);
 
         $dashboardPermission = Permission::where('module', 'dashboard')->firstOrFail();
         $documentsPermission = Permission::where('module', 'documente')->firstOrFail();
@@ -137,8 +135,8 @@ class UserRolesTest extends TestCase
     {
         [, $adminRole, $mechanicRole] = $this->createCoreRoles();
 
-        $admin = $this->createUserWithRole($adminRole);
-        $user = $this->createUserWithRole($mechanicRole, [
+        $admin = $this->createUserWithRoles($adminRole);
+        $user = $this->createUserWithRoles($mechanicRole, [
             'name' => 'Legacy Mechanic',
             'email' => 'legacy-mechanic@example.com',
         ]);
@@ -163,27 +161,25 @@ class UserRolesTest extends TestCase
         $this->assertNull($updatedUser->getRawOriginal('role'));
     }
 
-    public function test_user_update_syncs_roles_without_touching_direct_permissions(): void
+    public function test_user_update_syncs_roles_and_preserves_manual_module_roles(): void
     {
         [, $adminRole, $mechanicRole] = $this->createCoreRoles();
 
-        $dispatcherRole = Role::firstOrCreate(
-            ['slug' => 'dispecer'],
-            [
-                'name' => 'Dispecer',
-                'description' => 'Acces specific dispecerilor.',
-            ]
-        );
-        $this->syncRoleDefaults($dispatcherRole);
+        $dispatcherRole = $this->ensureRole('dispecer', null, [
+            'name' => 'Dispecer',
+            'description' => 'Acces specific dispecerilor.',
+        ]);
 
-        $admin = $this->createUserWithRole($adminRole);
-        $user = $this->createUserWithRole($mechanicRole, [
+        $customPartsRole = $this->ensureRole('gestiune-piese-manual', ['gestiune-piese'], [
+            'name' => 'Gestiune Piese Manual',
+            'description' => 'Rol suplimentar pentru accesul la gestiune piese.',
+        ]);
+
+        $admin = $this->createUserWithRoles($adminRole);
+        $user = $this->createUserWithRoles([$mechanicRole, $customPartsRole], [
             'name' => 'Advanced Existing',
             'email' => 'advanced-existing@example.com',
         ]);
-
-        $initialPermission = Permission::where('module', 'gestiune-piese')->firstOrFail();
-        $user->syncPermissions([$initialPermission->id]);
 
         $documentsPermission = Permission::where('module', 'documente')->firstOrFail();
         $techToolsPermission = Permission::where('module', 'tech-tools')->firstOrFail();
@@ -193,7 +189,7 @@ class UserRolesTest extends TestCase
             'name' => 'Advanced Existing',
             'email' => 'advanced-existing@example.com',
             'telefon' => '0123456789',
-            'roles' => [$dispatcherRole->id, $adminRole->id],
+            'roles' => [$dispatcherRole->id, $adminRole->id, $customPartsRole->id],
             'permissions' => [$documentsPermission->id, $techToolsPermission->id],
             'password' => null,
             'password_confirmation' => null,
@@ -205,11 +201,11 @@ class UserRolesTest extends TestCase
         $updatedUser = $user->fresh()->load(['roles', 'permissions']);
 
         $this->assertEqualsCanonicalizing(
-            [$dispatcherRole->id, $adminRole->id],
+            [$dispatcherRole->id, $adminRole->id, $customPartsRole->id],
             $updatedUser->roles->pluck('id')->map(fn ($value) => (int) $value)->all()
         );
         $this->assertEqualsCanonicalizing(
-            [$initialPermission->id],
+            [$documentsPermission->id, $techToolsPermission->id],
             $updatedUser->permissions->pluck('id')->map(fn ($value) => (int) $value)->all()
         );
     }
@@ -228,7 +224,7 @@ class UserRolesTest extends TestCase
     {
         [, , $mechanicRole] = $this->createCoreRoles();
 
-        $mechanic = $this->createUserWithRole($mechanicRole);
+        $mechanic = $this->createUserWithRoles($mechanicRole);
 
         $this->actingAs($mechanic)->get('/gestiune-piese')->assertOk();
         $this->actingAs($mechanic)->get('/service-masini')->assertOk();
@@ -241,7 +237,7 @@ class UserRolesTest extends TestCase
     {
         [$_superAdminRole, $adminRole, $_mechanicRole] = $this->createCoreRoles();
 
-        $user = $this->createUserWithRole($adminRole, [
+        $user = $this->createUserWithRoles($adminRole, [
             'email' => 'user@example.com',
             'cod_email' => 'login-code',
         ]);
@@ -260,7 +256,7 @@ class UserRolesTest extends TestCase
     {
         [, , $mechanicRole] = $this->createCoreRoles();
 
-        $mechanic = $this->createUserWithRole($mechanicRole, [
+        $mechanic = $this->createUserWithRoles($mechanicRole, [
             'email' => 'mechanic@example.com',
             'cod_email' => 'login-code',
         ]);
@@ -321,7 +317,7 @@ class UserRolesTest extends TestCase
             'updated_at' => now(),
         ]);
 
-        $mechanic = $this->createUserWithRole($mechanicRole);
+        $mechanic = $this->createUserWithRoles($mechanicRole);
 
         $mechanicResponse = $this->actingAs($mechanic)->get('/gestiune-piese');
         $mechanicResponse->assertOk();
@@ -329,7 +325,7 @@ class UserRolesTest extends TestCase
         $mechanicResponse->assertDontSee('Facturi furnizori', false);
         $mechanicResponse->assertSee('href="' . route('gestiune-piese.index') . '"', false);
 
-        $admin = $this->createUserWithRole($adminRole);
+        $admin = $this->createUserWithRoles($adminRole);
 
         $adminResponse = $this->actingAs($admin)->get('/gestiune-piese');
         $adminResponse->assertOk();
@@ -341,10 +337,17 @@ class UserRolesTest extends TestCase
     {
         [, , $mechanicRole] = $this->createCoreRoles();
 
-        $documentsPermission = Permission::where('module', 'documente')->firstOrFail();
-        $adminDocumentsPermission = Permission::where('module', 'documente-manage')->firstOrFail();
+        $documentViewerRole = $this->ensureRole('documente-operator', ['documente'], [
+            'name' => 'Operator Documente',
+            'description' => 'Poate vizualiza documentele disponibile.',
+        ]);
 
-        $mechanic = $this->createUserWithRole($mechanicRole);
+        $documentManagerRole = $this->ensureRole('documente-administrator', ['documente', 'documente-manage'], [
+            'name' => 'Administrator Documente',
+            'description' => 'Poate gestiona documentele disponibile.',
+        ]);
+
+        $mechanic = $this->createUserWithRoles($mechanicRole);
 
         $operatorDocument = DocumentWord::create([
             'nume' => 'Manual Operator',
@@ -360,7 +363,7 @@ class UserRolesTest extends TestCase
 
         $this->actingAs($mechanic)->get('/documente-word')->assertForbidden();
 
-        $mechanic->syncPermissions([$documentsPermission->id]);
+        $mechanic->assignRole($documentViewerRole);
 
         $indexResponse = $this->actingAs($mechanic->fresh())->get('/documente-word');
         $indexResponse->assertOk();
@@ -370,7 +373,7 @@ class UserRolesTest extends TestCase
         $editResponse = $this->actingAs($mechanic->fresh())->get($adminDocument->path() . '/modifica');
         $editResponse->assertForbidden();
 
-        $mechanic->syncPermissions([$documentsPermission->id, $adminDocumentsPermission->id]);
+        $mechanic->assignRole($documentManagerRole);
 
         $indexResponse = $this->actingAs($mechanic->fresh())->get('/documente-word');
         $indexResponse->assertOk();
@@ -384,13 +387,10 @@ class UserRolesTest extends TestCase
 
     public function test_primary_admin_user_is_not_mistaken_for_mechanic_when_role_is_missing(): void
     {
-        $adminRole = Role::firstOrCreate(
-            ['slug' => 'admin'],
-            [
-                'name' => 'Administrator',
-                'description' => 'Administrator access.',
-            ]
-        );
+        $adminRole = $this->ensureRole('admin', null, [
+            'name' => 'Administrator',
+            'description' => 'Administrator access.',
+        ]);
 
         $admin = User::factory()->create(['id' => 1]);
         $admin->assignRole($adminRole);
@@ -404,61 +404,20 @@ class UserRolesTest extends TestCase
      */
     private function createCoreRoles(): array
     {
-        $superAdmin = Role::firstOrCreate(
-            ['slug' => 'super-admin'],
-            [
+        return [
+            $this->ensureRole('super-admin', null, [
                 'name' => 'Super Admin',
                 'description' => 'Full access.',
-            ]
-        );
-        $this->syncRoleDefaults($superAdmin);
-
-        $admin = Role::firstOrCreate(
-            ['slug' => 'admin'],
-            [
+            ]),
+            $this->ensureRole('admin', null, [
                 'name' => 'Administrator',
                 'description' => 'Administrator access.',
-            ]
-        );
-        $this->syncRoleDefaults($admin);
-
-        $mechanic = Role::firstOrCreate(
-            ['slug' => 'mecanic'],
-            [
+            ]),
+            $this->ensureRole('mecanic', null, [
                 'name' => 'Mecanic',
                 'description' => 'Acces limitat la gestiune piese și service mașini.',
-            ]
-        );
-        $this->syncRoleDefaults($mechanic);
-
-        return [$superAdmin, $admin, $mechanic];
+            ]),
+        ];
     }
 
-    private function createUserWithRole(Role $role, array $attributes = []): User
-    {
-        $user = User::factory()->create($attributes);
-        $user->assignRole($role);
-
-        return $user->fresh();
-    }
-
-    private function syncRoleDefaults(Role $role): void
-    {
-        $defaults = config('permissions.role_defaults', []);
-        $modules = $defaults[$role->slug] ?? [];
-
-        if (in_array('*', $modules, true)) {
-            $role->syncPermissions(Permission::all());
-
-            return;
-        }
-
-        if (empty($modules)) {
-            $role->syncPermissions([]);
-
-            return;
-        }
-
-        $role->syncPermissions(Permission::whereIn('module', $modules)->get());
-    }
 }

--- a/tests/Fixtures/RoleFixtures.php
+++ b/tests/Fixtures/RoleFixtures.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests\Fixtures;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+class RoleFixtures
+{
+    public static function createRole(string $slug, ?array $modules = null, array $attributes = []): Role
+    {
+        $payload = array_merge([
+            'name' => Str::headline($slug),
+            'description' => Str::headline($slug) . ' role.',
+        ], $attributes);
+
+        $role = Role::firstOrCreate(['slug' => $slug], $payload);
+
+        if (! $role->wasRecentlyCreated && ! empty($attributes)) {
+            $role->fill($payload);
+            $role->save();
+        }
+
+        $assignedModules = $modules;
+
+        if ($assignedModules === null) {
+            $defaults = config('permissions.role_defaults', []);
+            $assignedModules = Arr::get($defaults, $slug, []);
+        }
+
+        $role->syncPermissions(static::resolvePermissionIds($assignedModules));
+
+        return $role->fresh();
+    }
+
+    /**
+     * @param  null|array|string  $modules
+     */
+    protected static function resolvePermissionIds(null|array|string $modules): array
+    {
+        if ($modules === '*' || (is_array($modules) && in_array('*', $modules, true))) {
+            return Permission::query()
+                ->pluck('id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+        }
+
+        $moduleList = collect((array) $modules)
+            ->filter()
+            ->map(fn ($module) => (string) $module)
+            ->values();
+
+        if ($moduleList->isEmpty()) {
+            return [];
+        }
+
+        return Permission::query()
+            ->whereIn('module', $moduleList)
+            ->pluck('id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+    }
+}


### PR DESCRIPTION
## Summary
- add shared role fixtures and helpers so tests rely on the simplified permission defaults
- update navigation, file manager, and supplier invoice feature tests to grant access purely through role assignments
- refresh user role scenarios to cover mixed-role updates and document access without direct permission syncing

## Testing
- not run (missing vendor/bin/phpunit)

------
https://chatgpt.com/codex/tasks/task_e_68f92462bdbc83268505cce50d120afe