### PR TITLE
Remove legacy roles permission module

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -8,11 +8,7 @@ return [
         ],
         'users' => [
             'name' => 'Gestionare Utilizatori',
-            'description' => 'Include listarea, invitarea și administrarea conturilor și a permisiunilor individuale.',
-        ],
-        'roles' => [
-            'name' => 'Gestionare Roluri',
-            'description' => 'Acoperă configurarea rolurilor, asocierile lor și revizuirea accesului implicit.',
+            'description' => 'Include listarea, invitarea și administrarea conturilor, rolurilor și a permisiunilor individuale.',
         ],
         'firme' => [
             'name' => 'Gestionare Companii',

--- a/database/migrations/2025_03_21_010000_remove_roles_permission.php
+++ b/database/migrations/2025_03_21_010000_remove_roles_permission.php
@@ -1,0 +1,81 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasTable('permissions')) {
+            return;
+        }
+
+        $permissionId = DB::table('permissions')
+            ->where('module', 'roles')
+            ->value('id');
+
+        if (! $permissionId) {
+            return;
+        }
+
+        if (Schema::hasTable('permission_role')) {
+            DB::table('permission_role')
+                ->where('permission_id', (int) $permissionId)
+                ->delete();
+        }
+
+        DB::table('permissions')->where('id', (int) $permissionId)->delete();
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('permissions')) {
+            return;
+        }
+
+        $permission = DB::table('permissions')
+            ->where('module', 'roles')
+            ->first();
+
+        if ($permission) {
+            return;
+        }
+
+        $now = now();
+
+        $permissionId = DB::table('permissions')->insertGetId([
+            'name' => 'Gestionare Roluri',
+            'slug' => 'access-roles',
+            'module' => 'roles',
+            'description' => 'Acoperă configurarea rolurilor, asocierile lor și revizuirea accesului implicit.',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        if (! Schema::hasTable('permission_role')) {
+            return;
+        }
+
+        $roles = DB::table('roles')
+            ->whereIn('slug', ['super-admin', 'admin'])
+            ->pluck('id');
+
+        if ($roles->isEmpty()) {
+            return;
+        }
+
+        $rows = $roles
+            ->map(function ($roleId) use ($permissionId, $now) {
+                return [
+                    'role_id' => (int) $roleId,
+                    'permission_id' => (int) $permissionId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            })
+            ->all();
+
+        DB::table('permission_role')->insert($rows);
+    }
+};


### PR DESCRIPTION
## Summary
- merge the former role management description into the users permission module
- add a migration that deletes the legacy roles permission and detaches any assigned pivot rows

## Testing
- php artisan config:cache *(fails: missing vendor/autoload.php)*
- php artisan permission:cache-reset *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68f9cda5ebe883268765e8da1662adeb