### PR TITLE
Update user permissions matrix to show per-role columns

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,0 +1,63 @@
+.permissions-matrix-table .module-name {
+    min-width: 12rem;
+}
+
+.permissions-matrix-table .module-description {
+    min-width: 14rem;
+}
+
+.permissions-matrix-table .matrix-role-col {
+    text-align: center;
+    white-space: nowrap;
+    min-width: 7rem;
+    font-weight: 500;
+}
+
+.permissions-matrix-table .matrix-role-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    font-size: 0.95rem;
+}
+
+.permissions-matrix-table .matrix-role-indicator i {
+    font-size: 0.9rem;
+}
+
+@media (max-width: 991.98px) {
+    .permissions-matrix-table .module-name {
+        min-width: 10rem;
+    }
+
+    .permissions-matrix-table .module-description {
+        min-width: 12rem;
+    }
+
+    .permissions-matrix-table .matrix-role-col {
+        min-width: 6.5rem;
+        font-size: 0.9rem;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .permissions-matrix-table .module-name {
+        min-width: 9rem;
+        font-size: 0.9rem;
+    }
+
+    .permissions-matrix-table .module-description {
+        min-width: 11rem;
+        font-size: 0.85rem;
+    }
+
+    .permissions-matrix-table .matrix-role-col {
+        min-width: 5.5rem;
+        font-size: 0.85rem;
+    }
+
+    .permissions-matrix-table td,
+    .permissions-matrix-table th {
+        padding: 0.75rem 0.5rem;
+    }
+}

--- a/resources/views/useri/form.blade.php
+++ b/resources/views/useri/form.blade.php
@@ -92,6 +92,7 @@
                 @include('useri.partials.permissionsMatrix', [
                     'moduleRoleMatrix' => $moduleRoleMatrix,
                     'moduleDefinitions' => $permissionDefinitions,
+                    'visibleRoles' => $availableRoles,
                 ])
             </div>
         @endif

--- a/resources/views/useri/help/permissionsMatrix.blade.php
+++ b/resources/views/useri/help/permissionsMatrix.blade.php
@@ -20,14 +20,14 @@
                         <ul class="mb-4">
                             <li><strong>Coloana „Modul”</strong> indică funcționalitatea din aplicație (ex.: Comenzi, Documente, Service).</li>
                             <li><strong>Descrierea</strong> sintetizează ce acoperă modulul respectiv pentru a-ți reaminti rapid scopul lui.</li>
-                            <li><strong>Rolurile cu acces implicit</strong> afișează insigne pentru fiecare rol care acordă automat modulul atunci când este atribuit unui utilizator.</li>
+                            <li><strong>Fiecare rol vizibil are propria coloană</strong>; bifele verzi indică modulele acordate implicit de acel rol, iar simbolul „—” arată că modulul nu este inclus.</li>
                         </ul>
 
                         <h2 class="h6 text-uppercase text-muted">Recomandări pentru onboarding</h2>
                         <ul class="mb-4">
                             <li>Înainte de a bifa rolurile, consultă legenda pentru a verifica dacă permisiunile implicite acoperă responsabilitățile noului coleg.</li>
                             <li>Dacă un rol nu oferă toate modulele necesare, combină-l cu alte roluri relevante – permisiunile directe nu mai sunt configurabile individual.</li>
-                            <li>Păstrează supravegherea asupra rolurilor speciale (ex. Super Admin) – acestea apar în legendă pentru transparență, dar rămân rezervate echipei de administratori principali.</li>
+                            <li>Păstrează supravegherea asupra rolurilor speciale (ex. Super Admin) – acestea apar în legendă doar pentru administratorii cu acces la ele și rămân rezervate echipei principale.</li>
                         </ul>
 
                         <h2 class="h6 text-uppercase text-muted">Actualizarea permisiunilor existente</h2>

--- a/resources/views/useri/partials/permissionsMatrix.blade.php
+++ b/resources/views/useri/partials/permissionsMatrix.blade.php
@@ -1,6 +1,87 @@
 @php
     $moduleDefinitions = collect($moduleDefinitions ?? config('permissions.modules', []));
-    $moduleRoleMatrix = collect($moduleRoleMatrix ?? []);
+    $moduleRoleMatrix = collect($moduleRoleMatrix ?? [])->map(function ($moduleRoles) {
+        if ($moduleRoles instanceof \Illuminate\Support\Collection) {
+            return $moduleRoles;
+        }
+
+        return collect($moduleRoles);
+    });
+
+    $normalizeRole = function ($role) {
+        if ($role instanceof \App\Models\Role) {
+            $slug = $role->slug ?? null;
+            $name = $role->name ?? null;
+
+            if (! $name && $slug) {
+                $name = ucwords(str_replace(['-', '_'], ' ', $slug));
+            }
+
+            return array_filter([
+                'id' => $role->id ?? null,
+                'slug' => $slug,
+                'name' => $name,
+                'description' => $role->description ?? null,
+            ]);
+        }
+
+        if (is_array($role)) {
+            $slug = $role['slug'] ?? null;
+            $name = $role['name'] ?? null;
+
+            if (! $name && $slug) {
+                $name = ucwords(str_replace(['-', '_'], ' ', $slug));
+            }
+
+            return array_filter([
+                'id' => $role['id'] ?? null,
+                'slug' => $slug,
+                'name' => $name,
+                'description' => $role['description'] ?? null,
+            ]);
+        }
+
+        if (is_object($role) && isset($role->slug)) {
+            $slug = $role->slug;
+            $name = $role->name ?? null;
+
+            if (! $name && $slug) {
+                $name = ucwords(str_replace(['-', '_'], ' ', $slug));
+            }
+
+            return array_filter([
+                'id' => $role->id ?? null,
+                'slug' => $slug,
+                'name' => $name,
+                'description' => $role->description ?? null,
+            ]);
+        }
+
+        if (is_string($role)) {
+            return [
+                'slug' => $role,
+                'name' => ucwords(str_replace(['-', '_'], ' ', $role)),
+            ];
+        }
+
+        return null;
+    };
+
+    $visibleRoles = collect($visibleRoles ?? $availableRoles ?? [])
+        ->map($normalizeRole)
+        ->filter(fn ($role) => is_array($role) && ! empty($role['slug']))
+        ->unique('slug')
+        ->values();
+
+    if ($visibleRoles->isEmpty()) {
+        $visibleRoles = $moduleRoleMatrix
+            ->flatMap(function ($moduleRoles) use ($normalizeRole) {
+                return $moduleRoles->map($normalizeRole);
+            })
+            ->filter(fn ($role) => is_array($role) && ! empty($role['slug']))
+            ->unique('slug')
+            ->values();
+    }
 @endphp
 
 @if ($moduleDefinitions->isNotEmpty() && $moduleRoleMatrix->isNotEmpty())
@@ -14,12 +95,19 @@
             </div>
         </div>
         <div class="table-responsive">
-            <table class="table table-sm align-middle mb-0">
+            <table class="table table-sm align-middle mb-0 permissions-matrix-table">
                 <thead>
                     <tr class="table-light">
-                        <th scope="col" style="min-width: 200px;">Modul</th>
-                        <th scope="col">Descriere</th>
-                        <th scope="col" style="min-width: 220px;">Roluri cu acces implicit</th>
+                        <th scope="col" class="module-name">Modul</th>
+                        <th scope="col" class="module-description">Descriere</th>
+                        @foreach ($visibleRoles as $roleDetails)
+                            @php
+                                $roleLabel = $roleDetails['name'] ?? ucwords(str_replace(['-', '_'], ' ', $roleDetails['slug'] ?? ''));
+                            @endphp
+                            <th scope="col" class="text-center matrix-role-col" title="{{ $roleDetails['description'] ?? $roleLabel }}">
+                                {{ $roleLabel }}
+                            </th>
+                        @endforeach
                     </tr>
                 </thead>
                 <tbody>
@@ -29,25 +117,37 @@
                             if (! ($roleEntries instanceof \Illuminate\Support\Collection)) {
                                 $roleEntries = collect($roleEntries);
                             }
+
+                            $rolesBySlug = $roleEntries->mapWithKeys(function ($role) use ($normalizeRole) {
+                                $normalized = $normalizeRole($role);
+
+                                if (! is_array($normalized) || empty($normalized['slug'])) {
+                                    return [];
+                                }
+
+                                return [$normalized['slug'] => $normalized];
+                            });
                         @endphp
                         <tr>
-                            <td class="fw-semibold">{{ $moduleDetails['name'] ?? ucwords(str_replace(['-', '_'], ' ', $moduleKey)) }}</td>
-                            <td class="text-muted small">{{ $moduleDetails['description'] ?? '—' }}</td>
-                            <td>
-                                @if ($roleEntries->isNotEmpty())
-                                    <div class="d-flex flex-wrap gap-1">
-                                        @foreach ($roleEntries as $role)
-                                            @php
-                                                $roleName = is_array($role) ? ($role['name'] ?? null) : ($role->name ?? null);
-                                                $roleName = $roleName ?: ucwords(str_replace(['-', '_'], ' ', is_array($role) ? ($role['slug'] ?? '') : ($role->slug ?? '')));
-                                            @endphp
-                                            <span class="badge bg-light text-dark border">{{ $roleName }}</span>
-                                        @endforeach
-                                    </div>
-                                @else
-                                    <span class="text-muted">—</span>
-                                @endif
-                            </td>
+                            <td class="fw-semibold module-name">{{ $moduleDetails['name'] ?? ucwords(str_replace(['-', '_'], ' ', $moduleKey)) }}</td>
+                            <td class="text-muted small module-description">{{ $moduleDetails['description'] ?? '—' }}</td>
+                            @foreach ($visibleRoles as $roleDetails)
+                                @php
+                                    $roleSlug = $roleDetails['slug'] ?? null;
+                                    $hasImplicitAccess = $roleSlug ? $rolesBySlug->has($roleSlug) : false;
+                                    $roleLabel = $roleDetails['name'] ?? ucwords(str_replace(['-', '_'], ' ', $roleSlug ?? ''));
+                                @endphp
+                                <td class="matrix-role-col">
+                                    @if ($hasImplicitAccess)
+                                        <span class="matrix-role-indicator text-success" title="Rolul {{ $roleLabel }} acordă acces implicit">
+                                            <i class="fa-solid fa-check"></i>
+                                            <span class="visually-hidden">Acces implicit pentru rolul {{ $roleLabel }}</span>
+                                        </span>
+                                    @else
+                                        <span class="text-muted">—</span>
+                                    @endif
+                                </td>
+                            @endforeach
                         </tr>
                     @endforeach
                 </tbody>


### PR DESCRIPTION
## Summary
- filter the module role defaults by the roles available to the editor so super-admin is hidden when not selectable
- redesign the permissions matrix partial to render one column per visible role with checkmarks and update the help text accordingly
- add responsive styles to keep the expanded matrix readable on smaller screens

## Testing
- php -l app/Http/Controllers/UserController.php

------
https://chatgpt.com/codex/tasks/task_e_68f9cc360b948326ba6863cd6c985f5a