### PR TITLE
Add dedicated Word document permissions and roles

### DIFF
--- a/app/Http/Controllers/DocumentWordController.php
+++ b/app/Http/Controllers/DocumentWordController.php
@@ -27,7 +27,7 @@ class DocumentWordController extends Controller
             when($searchNume, function ($query, $searchNume) {
                 return $query->where('nume', 'like', '%' . $searchNume . '%');
             })
-            ->when(! $request->user()?->hasPermission('documente-manage'), function ($query) {
+            ->when(! $request->user()?->hasPermission('documente-word-manage'), function ($query) {
                 // Users without the admin document permission can see only "operator" documents
                 return $query->where('nivel_acces', 2);
             })
@@ -145,6 +145,8 @@ class DocumentWordController extends Controller
 
     public function unlock(Request $request, DocumentWord $documentWord)
     {
+        $this->authorize('unlock', $documentWord);
+
         // Unlock the record
         $documentWord->update([
             'locked_by' => null,

--- a/app/Policies/DocumentWordPolicy.php
+++ b/app/Policies/DocumentWordPolicy.php
@@ -38,7 +38,7 @@ class DocumentWordPolicy
     public function update(User $user, DocumentWord $documentWord): Response
     {
         // Check if the document has admin-only rights and the user isn't an admin
-        if ($documentWord->nivel_acces === 1 && ! $user->hasPermission('documente-manage')) {
+        if ($documentWord->nivel_acces === 1 && ! $user->hasPermission('documente-word-manage')) {
             return Response::deny('Nu ai drepturi să modifici acest document.');
         }
 

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -42,6 +42,14 @@ return [
             'name' => 'Documente (Acțiuni)',
             'description' => 'Controlează acțiunile din coloana „Acțiuni” (încărcare, redenumire, ștergere) din managerul de fișiere.',
         ],
+        'documente-word' => [
+            'name' => 'Documente Word (vizualizare)',
+            'description' => 'Permite accesul la biblioteca de documente Word interne.',
+        ],
+        'documente-word-manage' => [
+            'name' => 'Documente Word (Acțiuni)',
+            'description' => 'Autorizează modificarea, adăugarea și ștergerea documentelor Word.',
+        ],
         'facturi' => [
             'name' => 'Gestionare Facturi',
             'description' => 'Include emiterea, urmărirea încasărilor și raportarea scadențarelor clienților.',
@@ -86,6 +94,13 @@ return [
         'mecanic' => [
             'service-masini',
             'gestiune-piese',
+        ],
+        'documente-word-operator' => [
+            'documente-word',
+        ],
+        'documente-word-administrator' => [
+            'documente-word',
+            'documente-word-manage',
         ],
     ],
 ];

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -46,6 +46,22 @@ class RolesTableSeeder extends Seeder
             ]
         );
 
+        $documenteWordOperator = Role::firstOrCreate(
+            ['slug' => 'documente-word-operator'],
+            [
+                'name' => 'Operator Documente Word',
+                'description' => 'Poate consulta biblioteca de documente Word.',
+            ]
+        );
+
+        $documenteWordAdministrator = Role::firstOrCreate(
+            ['slug' => 'documente-word-administrator'],
+            [
+                'name' => 'Administrator Documente Word',
+                'description' => 'Gestionează conținutul bibliotecii de documente Word.',
+            ]
+        );
+
         $permissions = Permission::all();
         $permissionMap = $permissions->keyBy('module');
         $roleDefaults = collect(config('permissions.role_defaults', []));
@@ -73,6 +89,8 @@ class RolesTableSeeder extends Seeder
         $syncPermissions($admin);
         $syncPermissions($dispecer);
         $syncPermissions($mecanic);
+        $syncPermissions($documenteWordOperator);
+        $syncPermissions($documenteWordAdministrator);
 
         $user = User::find(1);
 

--- a/resources/views/documenteWord/index.blade.php
+++ b/resources/views/documenteWord/index.blade.php
@@ -26,9 +26,11 @@
             </form>
         </div>
         <div class="col-lg-3 text-end">
-            <a class="btn btn-sm btn-success text-white border border-dark rounded-3 col-md-8" href="{{ url()->current() }}/adauga" role="button">
-                <i class="fas fa-plus-square text-white me-1"></i>Adaugă Document Word
-            </a>
+            @can('documente-word-manage')
+                <a class="btn btn-sm btn-success text-white border border-dark rounded-3 col-md-8" href="{{ url()->current() }}/adauga" role="button">
+                    <i class="fas fa-plus-square text-white me-1"></i>Adaugă Document Word
+                </a>
+            @endcan
         </div>
     </div>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -233,7 +233,7 @@
             ],
             ['type' => 'divider'],
             [
-                'permission' => 'documente',
+                'permission' => 'documente-word',
                 'href' => '/documente-word',
                 'icon' => 'fa-solid fa-file-word',
                 'label' => 'Documente word',

--- a/routes/web.php
+++ b/routes/web.php
@@ -138,8 +138,20 @@ Route::middleware(['auth'])->group(function () {
         Route::resource('/fisiere/{categorieFisier}', FisierController::class)->parameters(['{categorieFisier}' => 'fisier']);
         Route::get('/fisiere/{categorieFisier}/{fisier}/descarca', [FisierController::class, 'descarca']);
 
+    });
+
+    Route::middleware('permission:documente-word')->group(function () {
+        Route::resource('/documente-word', DocumentWordController::class)
+            ->only(['index', 'show'])
+            ->parameters(['documente-word' => 'documentWord']);
+    });
+
+    Route::middleware('permission:documente-word-manage')->group(function () {
         Route::get('/documente-word/{documentWord}/unlock', [DocumentWordController::class, 'unlock'])->name('documentWord.unlock');
-        Route::resource('/documente-word', DocumentWordController::class)->parameters(['documente-word' => 'documentWord']);
+
+        Route::resource('/documente-word', DocumentWordController::class)
+            ->except(['index', 'show'])
+            ->parameters(['documente-word' => 'documentWord']);
     });
 
     Route::middleware('permission:firme')->group(function () {

--- a/tests/Feature/Permissions/PermissionMiddlewareTest.php
+++ b/tests/Feature/Permissions/PermissionMiddlewareTest.php
@@ -39,6 +39,7 @@ class PermissionMiddlewareTest extends TestCase
         return [
             'dashboard' => ['GET', '/acasa', 'dashboard'],
             'document manager' => ['GET', '/file-manager-personalizat', 'documente'],
+            'document word library' => ['GET', '/documente-word', 'documente-word'],
             'companies' => ['GET', '/firme/transportatori', 'firme'],
             'trucks' => ['GET', '/camioane', 'camioane'],
             'operation sites' => ['GET', '/locuri-operare', 'locuri-operare'],

--- a/tests/Feature/UserRolesTest.php
+++ b/tests/Feature/UserRolesTest.php
@@ -337,14 +337,14 @@ class UserRolesTest extends TestCase
     {
         [, , $mechanicRole] = $this->createCoreRoles();
 
-        $documentViewerRole = $this->ensureRole('documente-operator', ['documente'], [
-            'name' => 'Operator Documente',
-            'description' => 'Poate vizualiza documentele disponibile.',
+        $documentWordViewerRole = $this->ensureRole('documente-word-operator', ['documente-word'], [
+            'name' => 'Operator Documente Word',
+            'description' => 'Poate vizualiza documentele Word disponibile.',
         ]);
 
-        $documentManagerRole = $this->ensureRole('documente-administrator', ['documente', 'documente-manage'], [
-            'name' => 'Administrator Documente',
-            'description' => 'Poate gestiona documentele disponibile.',
+        $documentWordManagerRole = $this->ensureRole('documente-word-administrator', ['documente-word', 'documente-word-manage'], [
+            'name' => 'Administrator Documente Word',
+            'description' => 'Poate gestiona documentele Word disponibile.',
         ]);
 
         $mechanic = $this->createUserWithRoles($mechanicRole);
@@ -363,7 +363,7 @@ class UserRolesTest extends TestCase
 
         $this->actingAs($mechanic)->get('/documente-word')->assertForbidden();
 
-        $mechanic->assignRole($documentViewerRole);
+        $mechanic->assignRole($documentWordViewerRole);
 
         $indexResponse = $this->actingAs($mechanic->fresh())->get('/documente-word');
         $indexResponse->assertOk();
@@ -373,7 +373,7 @@ class UserRolesTest extends TestCase
         $editResponse = $this->actingAs($mechanic->fresh())->get($adminDocument->path() . '/modifica');
         $editResponse->assertForbidden();
 
-        $mechanic->assignRole($documentManagerRole);
+        $mechanic->assignRole($documentWordManagerRole);
 
         $indexResponse = $this->actingAs($mechanic->fresh())->get('/documente-word');
         $indexResponse->assertOk();


### PR DESCRIPTION
## Summary
- define dedicated `documente-word` permissions and default roles in the permission config and role seeder
- move the Word document routes/UI behind the new middleware and require the manage permission for authoring actions
- update policy, controller logic, navigation, and tests to target the new permission keys

## Testing
- composer install --no-interaction --no-progress *(fails: CONNECT tunnel 403 when downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d58244fc8326aacc1e8a854b4548