### PR TITLE
Allow dispatchers to import Stații Peco while keeping mass delete restricted

### DIFF
--- a/app/Http/Controllers/StatiePecoController.php
+++ b/app/Http/Controllers/StatiePecoController.php
@@ -17,6 +17,7 @@ class StatiePecoController extends Controller
     {
         $searchNumarStatie = $request->searchNumarStatie;
         $searchNume = $request->searchNume;
+        $user = $request->user();
 
         $statiiPeco = StatiePeco::
             when($searchNumarStatie, function ($query, $searchNumarStatie) {
@@ -33,8 +34,7 @@ class StatiePecoController extends Controller
         $totalCount = $statiiPeco->count();
 
         if ($request->action === "massDelete") {
-            // Check if the user has the required permissions for mass deletion
-            if (! $request->user()?->hasPermission('comenzi')) {
+            if (! $user || ! $user->hasPermission('statii-peco-manage')) {
                 abort(403, 'Unauthorized action.');
             }
 
@@ -67,6 +67,12 @@ class StatiePecoController extends Controller
 
     public function excelImport(Request $request)
     {
+        $user = $request->user();
+
+        if (! $user || ! ($user->hasPermission('statii-peco-manage') || $user->hasPermission('statii-peco'))) {
+            abort(403, 'Unauthorized action.');
+        }
+
         // Validate the uploaded file
         $request->validate([
             'fisier_excel' => 'required|mimes:xls,xlsx'

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -26,6 +26,14 @@ return [
             'name' => 'Gestionare Comenzi',
             'description' => 'Reunește fluxul de creare, planificare și urmărire a comenzilor și curselor.',
         ],
+        'statii-peco' => [
+            'name' => 'Stații Peco',
+            'description' => 'Permite consultarea catalogului de stații peco și încărcarea de fișiere Excel cu noi înregistrări.',
+        ],
+        'statii-peco-manage' => [
+            'name' => 'Stații Peco (Ștergeri în masă)',
+            'description' => 'Limitează operațiunile destructive (ex. ștergere în masă) la rolurile administrative.',
+        ],
         'mesagerie' => [
             'name' => 'Gestionare Mesagerie',
             'description' => 'Acoperă notificările interne, comunicările către șoferi și istoricul mesajelor.',
@@ -82,6 +90,7 @@ return [
             'documente',
             'facturi',
             'rapoarte',
+            'statii-peco',
         ],
         'mecanic' => [
             'service-masini',

--- a/database/migrations/2025_03_22_000000_update_statii_peco_permissions.php
+++ b/database/migrations/2025_03_22_000000_update_statii_peco_permissions.php
@@ -1,0 +1,155 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasTable('permissions')) {
+            return;
+        }
+
+        $now = now();
+        $moduleKeys = ['statii-peco', 'statii-peco-manage'];
+
+        $records = collect($moduleKeys)
+            ->map(function (string $moduleKey) use ($now) {
+                $config = config('permissions.modules.' . $moduleKey, []);
+
+                return [
+                    'module' => $moduleKey,
+                    'name' => (string) ($config['name'] ?? Str::title(str_replace('-', ' ', $moduleKey))),
+                    'slug' => (string) ($config['slug'] ?? 'access-' . Str::slug($moduleKey)),
+                    'description' => $config['description'] ?? null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            })
+            ->all();
+
+        DB::table('permissions')->upsert(
+            $records,
+            ['module'],
+            ['name', 'slug', 'description', 'updated_at']
+        );
+
+        $permissionIds = DB::table('permissions')
+            ->whereIn('module', $moduleKeys)
+            ->pluck('id', 'module');
+
+        if ($permissionIds->isEmpty()) {
+            return;
+        }
+
+        if (Schema::hasTable('permission_user')) {
+            DB::table('permission_user')
+                ->whereIn('permission_id', $permissionIds->values()->all())
+                ->delete();
+        }
+
+        if (! Schema::hasTable('permission_role')) {
+            return;
+        }
+
+        $roleIds = DB::table('roles')
+            ->whereIn('slug', ['super-admin', 'admin', 'dispecer'])
+            ->pluck('id', 'slug');
+
+        if ($roleIds->isEmpty()) {
+            return;
+        }
+
+        $comenziPermissionId = DB::table('permissions')
+            ->where('module', 'comenzi')
+            ->value('id');
+
+        if ($comenziPermissionId) {
+            DB::table('permission_role')
+                ->where('permission_id', (int) $comenziPermissionId)
+                ->whereIn('role_id', $roleIds->values()->all())
+                ->delete();
+        }
+
+        DB::table('permission_role')
+            ->whereIn('permission_id', $permissionIds->values()->all())
+            ->whereIn('role_id', $roleIds->values()->all())
+            ->delete();
+
+        $rows = [];
+
+        foreach ($roleIds as $roleSlug => $roleId) {
+            if ($permissionIds->has('statii-peco')) {
+                $rows[] = [
+                    'role_id' => (int) $roleId,
+                    'permission_id' => (int) $permissionIds['statii-peco'],
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+
+            if ($permissionIds->has('statii-peco-manage') && in_array($roleSlug, ['admin', 'super-admin'], true)) {
+                $rows[] = [
+                    'role_id' => (int) $roleId,
+                    'permission_id' => (int) $permissionIds['statii-peco-manage'],
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+            }
+        }
+
+        if (! empty($rows)) {
+            DB::table('permission_role')->insert($rows);
+        }
+
+        if (! $comenziPermissionId) {
+            return;
+        }
+
+        $comenziRows = [];
+
+        foreach ($roleIds as $roleId) {
+            $comenziRows[] = [
+                'role_id' => (int) $roleId,
+                'permission_id' => (int) $comenziPermissionId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }
+
+        DB::table('permission_role')->insert($comenziRows);
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('permissions')) {
+            return;
+        }
+
+        $permissionIds = DB::table('permissions')
+            ->whereIn('module', ['statii-peco', 'statii-peco-manage'])
+            ->pluck('id');
+
+        if ($permissionIds->isEmpty()) {
+            return;
+        }
+
+        if (Schema::hasTable('permission_user')) {
+            DB::table('permission_user')
+                ->whereIn('permission_id', $permissionIds->all())
+                ->delete();
+        }
+
+        if (Schema::hasTable('permission_role')) {
+            DB::table('permission_role')
+                ->whereIn('permission_id', $permissionIds->all())
+                ->delete();
+        }
+
+        DB::table('permissions')
+            ->whereIn('id', $permissionIds->all())
+            ->delete();
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -226,7 +226,7 @@
             ],
             ['type' => 'divider'],
             [
-                'permission' => 'comenzi',
+                'permission' => 'statii-peco',
                 'href' => '/statii-peco',
                 'icon' => 'fa-solid fa-gas-pump',
                 'label' => 'Stații peco',

--- a/resources/views/statiiPeco/index.blade.php
+++ b/resources/views/statiiPeco/index.blade.php
@@ -1,6 +1,11 @@
 @extends ('layouts.app')
 
 @section('content')
+@php
+    $currentUser = auth()->user();
+    $canImportStations = $currentUser?->hasPermission('statii-peco') || $currentUser?->hasPermission('statii-peco-manage');
+    $canMassDeleteStations = $currentUser?->hasPermission('statii-peco-manage');
+@endphp
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
         <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
             <div class="col-lg-3">
@@ -34,16 +39,18 @@
                 </form>
             </div>
             <div class="col-lg-3 text-end">
-                <a href="#"
-                    class="mb-1 btn btn-sm btn-success text-white border border-dark rounded-3"
-                    data-bs-toggle="modal"
-                    data-bs-target="#adaugaStatiiPeco"
-                    title="Adaugă stații peco"
-                    >
-                    <i class="fas fa-plus-square text-white me-1"></i>Adaugă stații peco
-                </a>
+                @if ($canImportStations)
+                    <a href="#"
+                        class="mb-1 btn btn-sm btn-success text-white border border-dark rounded-3"
+                        data-bs-toggle="modal"
+                        data-bs-target="#adaugaStatiiPeco"
+                        title="Adaugă stații peco"
+                        >
+                        <i class="fas fa-plus-square text-white me-1"></i>Adaugă stații peco
+                    </a>
+                @endif
 
-                @can('is-admin')
+                @if ($canMassDeleteStations)
                     <br>
                     <a href="#"
                         class="btn btn-sm btn-danger text-white border border-dark rounded-3"
@@ -52,7 +59,7 @@
                         title="Șterge stații peco"
                         >
                         <i class="far fa-trash-alt text-white me-1"></i>Șterge stațiile căutate</a>
-                @endcan
+                @endif
             </div>
         </div>
 
@@ -100,6 +107,7 @@
     </div>
 
     {{-- Modal to add statii peco --}}
+    @if ($canImportStations)
     <div id="disableButton1">
         <div class="modal fade text-dark" id="adaugaStatiiPeco" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
             <div class="modal-dialog" role="document">
@@ -146,9 +154,10 @@
             </div>
         </div>
     </div>
+    @endif
 
     {{-- Modal to mass delete statii peco --}}
-    @can('is-admin')
+    @if ($canMassDeleteStations)
     <div id="disableButton2">
     <div class="modal fade text-dark" id="stergeStatiiPeco" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
         <div class="modal-dialog" role="document">
@@ -187,5 +196,5 @@
         </div>
     </div>
     </div>
-    @endcan
+    @endif
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -312,7 +312,7 @@ Route::middleware(['auth'])->group(function () {
                 ->name('plati-calupuri.descarca-fisier');
         });
 
-    Route::middleware('permission:comenzi')->group(function () {
+    Route::middleware('permission:statii-peco')->group(function () {
         Route::get('/statii-peco', [StatiePecoController::class, 'index']);
         Route::post('/statii-peco/excel-import', [StatiePecoController::class, 'excelImport']);
     });

--- a/tests/Feature/Permissions/PermissionMiddlewareTest.php
+++ b/tests/Feature/Permissions/PermissionMiddlewareTest.php
@@ -52,7 +52,8 @@ class PermissionMiddlewareTest extends TestCase
             'vehicle service' => ['GET', '/service-masini', 'service-masini'],
             'user management' => ['GET', '/utilizatori', 'users'],
             'tech impersonation' => ['GET', '/tech/impersonation', 'tech-tools'],
-            'fuel stations' => ['GET', '/statii-peco', 'comenzi'],
+            'fuel stations' => ['GET', '/statii-peco', 'statii-peco'],
+            'fuel stations import' => ['POST', '/statii-peco/excel-import', 'statii-peco'],
         ];
     }
 }

--- a/tests/Feature/StatiiPecoPermissionsTest.php
+++ b/tests/Feature/StatiiPecoPermissionsTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\StatiePeco;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use Tests\Concerns\CreatesUsersWithRoles;
+use Tests\TestCase;
+
+class StatiiPecoPermissionsTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsersWithRoles;
+
+    public function test_dispatcher_can_import_fuel_stations(): void
+    {
+        $dispatcher = $this->createUserWithRoles('dispecer');
+
+        $this->assertTrue($dispatcher->hasPermission('statii-peco'));
+        $this->assertFalse($dispatcher->hasPermission('statii-peco-manage'));
+
+        $file = $this->createStationsWorkbook([
+            ['9001', 'Stație Test', 'Strada Principală 1', '012345', 'Cluj-Napoca', '46.7700,23.5800'],
+        ]);
+
+        $response = $this->actingAs($dispatcher)->post('/statii-peco/excel-import', [
+            'fisier_excel' => $file,
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $this->assertDatabaseHas('statii_peco', [
+            'numar_statie' => '9001',
+            'nume' => 'Stație Test',
+        ]);
+    }
+
+    public function test_dispatcher_cannot_mass_delete_fuel_stations(): void
+    {
+        $dispatcher = $this->createUserWithRoles('dispecer');
+
+        $this->assertTrue($dispatcher->hasPermission('statii-peco'));
+        $this->assertFalse($dispatcher->hasPermission('statii-peco-manage'));
+
+        StatiePeco::create([
+            'numar_statie' => '7001',
+            'nume' => 'Stație Protejată',
+            'strada' => 'Strada Libertății 10',
+            'cod_postal' => '400100',
+            'localitate' => 'Cluj-Napoca',
+            'coordonate' => '46.7712,23.6236',
+        ]);
+
+        $response = $this->actingAs($dispatcher)->get('/statii-peco?action=massDelete');
+
+        $response->assertForbidden();
+        $this->assertDatabaseHas('statii_peco', ['numar_statie' => '7001']);
+    }
+
+    public function test_admin_can_mass_delete_fuel_stations(): void
+    {
+        $admin = $this->createUserWithRoles('admin');
+
+        StatiePeco::create([
+            'numar_statie' => '8001',
+            'nume' => 'Stație Ștersă',
+            'strada' => 'Strada Republicii 5',
+            'cod_postal' => '500200',
+            'localitate' => 'Brașov',
+            'coordonate' => '45.6427,25.5887',
+        ]);
+
+        $response = $this->actingAs($admin)->get('/statii-peco?action=massDelete');
+
+        $response->assertRedirect();
+        $response->assertSessionHas('status');
+        $this->assertDatabaseMissing('statii_peco', ['numar_statie' => '8001']);
+    }
+
+    private function createStationsWorkbook(array $rows): UploadedFile
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->fromArray([
+            ['numar_statie', 'nume', 'strada', 'cod_postal', 'localitate', 'coordonate'],
+            ...$rows,
+        ]);
+
+        $temporaryPath = tempnam(sys_get_temp_dir(), 'statii_peco');
+        $filePath = $temporaryPath . '.xlsx';
+        @unlink($temporaryPath);
+
+        $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');
+        $writer->save($filePath);
+
+        return new UploadedFile(
+            $filePath,
+            'statii-peco.xlsx',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            null,
+            true
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- clarify the Stații Peco module descriptions and keep the manage key reserved for admins in both the config defaults and migration
- relax the route, controller, and Blade checks so dispatchers with the read key can still import stations while mass delete continues to require the manage permission
- refresh automated coverage to assert dispatchers lack the manage key and can import, and update the middleware matrix expectation

## Testing
- `php -l config/permissions.php`
- `php -l app/Http/Controllers/StatiePecoController.php`
- `php -l database/migrations/2025_03_22_000000_update_statii_peco_permissions.php`
- `php -l tests/Feature/Permissions/PermissionMiddlewareTest.php`
- `php -l tests/Feature/StatiiPecoPermissionsTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68f9d64a29908326b6509a9a5e32d35f