### PR TITLE
Restrict transportator payment terms by document format

### DIFF
--- a/app/Http/Requests/ComandaRequest.php
+++ b/app/Http/Requests/ComandaRequest.php
@@ -229,6 +229,24 @@ class ComandaRequest extends FormRequest
                     );
                 }
             }
+
+            $selectedFormat = isset($data['transportator_format_documente']) ? (int) $data['transportator_format_documente'] : null;
+            $selectedPaymentTerm = isset($data['transportator_termen_plata_id']) ? (int) $data['transportator_termen_plata_id'] : null;
+
+            $invalidCombinations = [
+                1 => 4,
+                2 => 3,
+            ];
+
+            foreach ($invalidCombinations as $format => $paymentTerm) {
+                if ($selectedFormat === $format && $selectedPaymentTerm === $paymentTerm) {
+                    $validator->errors()->add(
+                        'transportator_termen_plata_id',
+                        'Termenul de plată selectat nu este disponibil pentru formatul documentelor ales.'
+                    );
+                    break;
+                }
+            }
         });
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1139,3 +1139,37 @@ document.addEventListener('DOMContentLoaded', () => {
     // Optional: stop timer when navigating away
     window.addEventListener('beforeunload', () => { if (timerId) clearTimeout(timerId); });
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+    const formatSelect = document.getElementById('transportator_format_documente');
+    const termSelect = document.getElementById('transportator_termen_plata_id');
+
+    if (!formatSelect || !termSelect) {
+        return;
+    }
+
+    const forbiddenPairs = {
+        '1': ['4'],
+        '2': ['3'],
+    };
+
+    const updatePaymentTermOptions = () => {
+        const selectedFormat = formatSelect.value;
+        const disallowedTerms = forbiddenPairs[selectedFormat] ?? [];
+
+        Array.from(termSelect.options).forEach((option) => {
+            const shouldDisable = disallowedTerms.includes(option.value);
+
+            option.disabled = shouldDisable;
+
+            if (shouldDisable && termSelect.value === option.value) {
+                termSelect.value = '';
+                termSelect.dispatchEvent(new Event('change', { bubbles: true }));
+            }
+        });
+    };
+
+    formatSelect.addEventListener('change', updatePaymentTermOptions);
+
+    updatePaymentTermOptions();
+});

--- a/resources/views/comenzi/form.blade.php
+++ b/resources/views/comenzi/form.blade.php
@@ -209,7 +209,7 @@
             </div>
             <div class="col-lg-3 mb-4">
                 <label for="transportator_termen_plata_id" class="mb-0 ps-3">Termen de plată</label>
-                <select name="transportator_termen_plata_id" class="form-select bg-white rounded-3 {{ $errors->has('transportator_termen_plata_id') ? 'is-invalid' : '' }}">
+                <select id="transportator_termen_plata_id" name="transportator_termen_plata_id" class="form-select bg-white rounded-3 {{ $errors->has('transportator_termen_plata_id') ? 'is-invalid' : '' }}">
                     <option selected></option>
                     @foreach ($termeneDePlata as $termenDePlata)
                         <option value="{{ $termenDePlata->id }}" {{ ($termenDePlata->id === intval(old('transportator_termen_plata_id', $comanda->transportator_termen_plata_id ?? ''))) ? 'selected' : '' }}>{{ $termenDePlata->nume }}</option>
@@ -227,7 +227,7 @@
             </div>
             <div class="col-lg-2 mb-4">
                 <label for="transportator_format_documente" class="mb-0 ps-3">Format documente<span class="text-danger">*</span></label>
-                <select name="transportator_format_documente" class="form-select bg-white rounded-3 {{ $errors->has('transportator_format_documente') ? 'is-invalid' : '' }}">
+                <select id="transportator_format_documente" name="transportator_format_documente" class="form-select bg-white rounded-3 {{ $errors->has('transportator_format_documente') ? 'is-invalid' : '' }}">
                     <option selected></option>
                         <option value="1" {{ intval(old('transportator_format_documente', $comanda->transportator_format_documente === 1 )) ? 'selected' : '' }}>Per post</option>
                         <option value="2" {{ intval(old('transportator_format_documente', $comanda->transportator_format_documente === 2 )) ? 'selected' : '' }}>Digital</option>


### PR DESCRIPTION
## Summary
- add DOM ids to the transportator format and payment term selects on the order form so they can be coordinated
- disable invalid transportator payment terms on the edit form whenever the document format changes and clear conflicting selections
- validate on the backend that the forbidden format/term combinations are rejected with a clear message

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fa3035bacc83269b7e0f61b425c0dd