### PR TITLE
Add totals summary by currency to calup invoice table

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -112,6 +112,10 @@ class PlataCalupController extends Controller
             ->sortBy(fn (FacturaFurnizor $factura) => $factura->data_scadenta?->timestamp ?? PHP_INT_MAX)
             ->values();
 
+        $totaluriFacturiCalup = $facturiCalup
+            ->groupBy(fn (FacturaFurnizor $factura) => $factura->moneda)
+            ->map(fn ($facturi) => $facturi->sum('suma'));
+
         $facturiDisponibile = FacturaFurnizor::query()
             ->whereDoesntHave('calupuri')
             ->orderByRaw('data_scadenta IS NULL')
@@ -122,6 +126,7 @@ class PlataCalupController extends Controller
         return view('facturiFurnizori.calupuri.show', [
             'calup' => $plataCalup,
             'facturiCalup' => $facturiCalup,
+            'totaluriFacturiCalup' => $totaluriFacturiCalup,
             'facturiDisponibile' => $facturiDisponibile,
         ]);
     }

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -138,6 +138,17 @@
                                     </tr>
                                 @endforeach
                             </tbody>
+                            @if ($totaluriFacturiCalup->isNotEmpty())
+                                <tfoot>
+                                    @foreach ($totaluriFacturiCalup as $moneda => $total)
+                                        <tr class="fw-semibold">
+                                            <td colspan="3" class="text-end">Total {{ $moneda }}</td>
+                                            <td class="text-end">{{ number_format($total, 2) }} {{ $moneda }}</td>
+                                            <td></td>
+                                        </tr>
+                                    @endforeach
+                                </tfoot>
+                            @endif
                         </table>
                     </div>
                 @endif


### PR DESCRIPTION
## Summary
- compute grouped totals by currency for calup invoices in the controller
- render the aggregated totals in the invoice table footer when invoices are attached

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900666d1e788326af0003810b07244f