### PR TITLE
Align selected service car at top of list

### DIFF
--- a/resources/views/serviceMasini/index.blade.php
+++ b/resources/views/serviceMasini/index.blade.php
@@ -94,7 +94,8 @@
                             <span class="fw-semibold"><i class="fa-solid fa-car-side me-1"></i>Mașini</span>
                         </div>
                         <div class="card-body">
-                            <div class="list-group mb-4" style="max-height: 320px; overflow-y: auto;">
+                            <div id="service-cars-list" class="list-group mb-4"
+                                style="max-height: 320px; overflow-y: auto;">
                                 @forelse ($masini as $masina)
                                     @php
                                         $masinaQuery = $queryParams;
@@ -378,6 +379,16 @@
             });
 
             toggleEntryFields();
+
+            const carList = document.getElementById('service-cars-list');
+            const activeCar = carList?.querySelector('.list-group-item.active');
+
+            if (carList && activeCar) {
+                const containerTop = carList.getBoundingClientRect().top;
+                const activeTop = activeCar.getBoundingClientRect().top;
+
+                carList.scrollTop += activeTop - containerTop;
+            }
         });
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- add an identifier to the service car list container
- scroll the selected car into view when the page reloads so it appears at the top of the list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901beba81c88326bc52ff6eab999623