### PR TITLE
Revamp memento date display with inline edit trigger

### DIFF
--- a/app/Http/Controllers/Masini/MasiniDocumentController.php
+++ b/app/Http/Controllers/Masini/MasiniDocumentController.php
@@ -52,6 +52,7 @@ class MasiniDocumentController extends Controller
                 'color_class' => $document->colorClass(),
                 'days_until_expiry' => $document->daysUntilExpiry(),
                 'formatted_date' => $document->data_expirare?->format('Y-m-d'),
+                'readable_date' => $document->data_expirare?->format('d.m.Y'),
                 'message' => __('Modificarea a fost salvată.'),
             ]);
         }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -61,3 +61,26 @@
         padding: 0.75rem 0.5rem;
     }
 }
+
+.document-date-form {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    color: inherit;
+    text-decoration: none;
+}
+
+.document-date-text {
+    white-space: nowrap;
+}
+
+.document-date-edit {
+    color: inherit;
+}
+
+.document-date-edit:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+}

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -249,9 +249,24 @@
         const forms = document.querySelectorAll('[data-document-update]');
 
         forms.forEach((form) => {
-            const input = form.querySelector('input[type="date"]');
-            if (!input) {
+            const input = form.querySelector('[data-date-input]');
+            const display = form.querySelector('[data-date-text]');
+            const trigger = form.querySelector('[data-edit-trigger]');
+            const emptyLabel = form.dataset.emptyLabel || '—';
+
+            if (!input || !display) {
                 return;
+            }
+
+            if (trigger) {
+                trigger.addEventListener('click', () => {
+                    if (typeof input.showPicker === 'function') {
+                        input.showPicker();
+                    } else {
+                        input.focus();
+                        input.click();
+                    }
+                });
             }
 
             input.addEventListener('change', () => {
@@ -277,38 +292,15 @@
                             input.value = data.formatted_date ?? '';
                         }
 
+                        if (typeof data.readable_date !== 'undefined') {
+                            display.textContent = data.readable_date ?? emptyLabel;
+                        } else {
+                            display.textContent = input.value ? input.value : emptyLabel;
+                        }
+
                         const holder = form.closest('[data-color-holder]');
                         if (holder) {
                             holder.className = holder.dataset.baseClass + (data.color_class ? ' ' + data.color_class : '');
-                        }
-
-                        const daysLabel = form.querySelector('[data-days-label]');
-                        if (daysLabel) {
-                            if (data.days_until_expiry === null || typeof data.days_until_expiry === 'undefined') {
-                                daysLabel.innerHTML = '&nbsp;';
-                            } else if (data.days_until_expiry < 0) {
-                                const days = Math.abs(data.days_until_expiry);
-                                daysLabel.textContent = `Expirat de ${days} ${days === 1 ? 'zi' : 'zile'}`;
-                            } else {
-                                daysLabel.textContent = `Expiră în ${data.days_until_expiry} ${data.days_until_expiry === 1 ? 'zi' : 'zile'}`;
-                            }
-                        }
-
-                        const feedback = form.querySelector('[data-save-feedback]');
-                        if (feedback) {
-                            if (feedback.dataset.timeoutId) {
-                                clearTimeout(Number(feedback.dataset.timeoutId));
-                            }
-
-                            feedback.textContent = data.message || 'Modificarea a fost salvată.';
-                            feedback.classList.remove('d-none');
-
-                            const timeoutId = window.setTimeout(() => {
-                                feedback.classList.add('d-none');
-                                feedback.dataset.timeoutId = '';
-                            }, 3000);
-
-                            feedback.dataset.timeoutId = String(timeoutId);
                         }
                     })
                     .catch(() => {

--- a/resources/views/masini-mementouri/partials/document-cell.blade.php
+++ b/resources/views/masini-mementouri/partials/document-cell.blade.php
@@ -1,31 +1,28 @@
 @php
     $baseClass = 'document-cell rounded-3 px-2 py-2 text-center';
     $colorClass = $document->colorClass();
-    $daysUntilExpiry = $document->daysUntilExpiry();
 
-    if ($daysUntilExpiry === null) {
-        $daysText = null;
-    } elseif ($daysUntilExpiry < 0) {
-        $abs = abs($daysUntilExpiry);
-        $daysText = 'Expirat de ' . $abs . ' ' . ($abs === 1 ? 'zi' : 'zile');
-    } else {
-        $daysText = 'Expiră în ' . $daysUntilExpiry . ' ' . ($daysUntilExpiry === 1 ? 'zi' : 'zile');
-    }
+    $displayDate = optional($document->data_expirare)->format('d.m.Y');
 @endphp
 
 <div class="{{ $baseClass }} {{ $colorClass }}" data-color-holder data-base-class="{{ $baseClass }}">
-    <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}" data-document-update>
+    <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}"
+          class="document-date-form"
+          data-document-update data-empty-label="—">
         @csrf
         @method('PATCH')
-        <input type="date" name="data_expirare" class="form-control form-control-sm rounded-3"
-               value="{{ optional($document->data_expirare)->format('Y-m-d') }}">
+
+        <span class="document-date-text" data-date-text>
+            {{ $displayDate ?? '—' }}
+        </span>
+
+        <input type="date" name="data_expirare"
+               class="document-date-input visually-hidden"
+               value="{{ optional($document->data_expirare)->format('Y-m-d') }}"
+               data-date-input>
+
+        <button type="button" class="btn btn-link p-0 document-date-edit" data-edit-trigger aria-label="Editează data">
+            <i class="fa-solid fa-pen"></i>
+        </button>
     </form>
-    <small class="d-block" data-days-label>
-        @if (!is_null($daysText))
-            {{ $daysText }}
-        @else
-            &nbsp;
-        @endif
-    </small>
-    <small class="d-block text-success d-none" data-save-feedback></small>
 </div>


### PR DESCRIPTION
## Summary
- display document expiry dates in the masinii mementouri grid as formatted strings with an inline edit button
- adjust the ajax handler to keep the formatted text in sync after updates and request a readable date from the backend
- add styling so the edit icon sits neatly beside the date without affecting the table layout

## Testing
- `./vendor/bin/phpunit` *(fails: vendor directory is not present in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6901c0358c448326a8c1c3f34744bcb3