### PR TITLE
Adjust service car list scrolling

### DIFF
--- a/resources/views/serviceMasini/index.blade.php
+++ b/resources/views/serviceMasini/index.blade.php
@@ -94,7 +94,8 @@
                             <span class="fw-semibold"><i class="fa-solid fa-car-side me-1"></i>Mașini</span>
                         </div>
                         <div class="card-body">
-                            <div class="list-group mb-4" style="max-height: 320px; overflow-y: auto;">
+                            <div id="service-cars-list" class="list-group mb-4"
+                                style="max-height: 320px; overflow-y: auto;">
                                 @forelse ($masini as $masina)
                                     @php
                                         $masinaQuery = $queryParams;
@@ -378,6 +379,17 @@
             });
 
             toggleEntryFields();
+
+            const carList = document.getElementById('service-cars-list');
+            const activeCar = carList?.querySelector('.list-group-item.active');
+
+            if (carList && activeCar) {
+                const containerRect = carList.getBoundingClientRect();
+                const activeRect = activeCar.getBoundingClientRect();
+                const offsetTop = activeRect.top - containerRect.top + carList.scrollTop;
+
+                carList.scrollTo({ top: Math.max(0, offsetTop) });
+            }
         });
     </script>
 @endpush


### PR DESCRIPTION
## Summary
- refine the scroll offset calculation for the service car list
- ensure the active car is scrolled to the top of the list container after reloads

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901beba81c88326bc52ff6eab999623