### PR TITLE
Add inline document editor expansion for masini mementouri

### DIFF
--- a/app/Http/Controllers/Masini/MasiniDocumentFisierController.php
+++ b/app/Http/Controllers/Masini/MasiniDocumentFisierController.php
@@ -53,4 +53,11 @@ class MasiniDocumentFisierController extends Controller
 
         return Storage::disk('public')->download($fisier->cale, $fisier->nume_original);
     }
+
+    public function preview(Masina $masina, MasinaDocument $document, MasinaDocumentFisier $fisier)
+    {
+        abort_unless($document->masina_id === $masina->id && $fisier->document_id === $document->id, 404);
+
+        return Storage::disk('public')->response($fisier->cale, $fisier->nume_original);
+    }
 }

--- a/app/Http/Controllers/Masini/MasiniMementoController.php
+++ b/app/Http/Controllers/Masini/MasiniMementoController.php
@@ -20,11 +20,12 @@ class MasiniMementoController extends Controller
 
         $masini->each(function (Masina $masina): void {
             $masina->syncDefaultDocuments();
-            $masina->loadMissing(['memento', 'documente']);
+            $masina->loadMissing(['memento', 'documente.fisiere']);
         });
 
         $gridDocumentTypes = MasinaDocument::gridDocumentTypes();
         $vignetteCountries = MasinaDocument::vignetteCountries();
+        $uploadDocumentLabels = MasinaDocument::uploadDocumentLabels();
 
         $masiniModalData = $masini
             ->mapWithKeys(function (Masina $masina) {
@@ -45,6 +46,7 @@ class MasiniMementoController extends Controller
             'masini',
             'gridDocumentTypes',
             'vignetteCountries',
+            'uploadDocumentLabels',
             'masiniModalData'
         ));
     }

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -1,5 +1,58 @@
 @extends('layouts.app')
 
+@push('page-styles')
+    <style>
+        .expanded-row-wrapper {
+            background-color: #f8fafc;
+            border-radius: 1.25rem;
+            border: 1px solid rgba(0, 0, 0, 0.075);
+            padding: 1.5rem;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+            overflow: hidden;
+            max-height: 0;
+            opacity: 0;
+            transition: max-height 0.3s ease, opacity 0.25s ease;
+        }
+
+        .expanded-row-wrapper.is-visible {
+            max-height: 1200px;
+            opacity: 1;
+        }
+
+        .expanded-row-document {
+            border: 1px solid rgba(15, 23, 42, 0.12);
+            border-radius: 1rem;
+            background-color: #ffffff;
+            display: flex;
+            flex-direction: column;
+            height: 100%;
+        }
+
+        .expanded-row-document__header {
+            padding: 0.85rem 1.1rem;
+            border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .expanded-row-document__body {
+            padding: 1rem 1.1rem 1.25rem;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .expanded-row-document__files {
+            border-top: 1px dashed rgba(15, 23, 42, 0.12);
+            padding-top: 0.75rem;
+            margin-top: 0.25rem;
+        }
+    </style>
+@endpush
+
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
@@ -18,6 +71,10 @@
     <div class="card-body px-0 py-3">
         @include('errors')
 
+        @php
+            $columnCount = 5 + count($gridDocumentTypes) + count($vignetteCountries);
+            $today = now()->format('Y-m-d');
+        @endphp
         <div class="table-responsive rounded">
             <table class="table table-striped table-hover align-middle mb-0">
                 <thead class="text-white rounded culoare2">
@@ -75,7 +132,9 @@
                             </td>
                             <td class="text-end">
                                 <div class="d-inline-flex gap-2 justify-content-end">
-                                    <a href="{{ route('masini-mementouri.show', $masina) }}" class="badge bg-primary text-decoration-none">Editează</a>
+                                    <button type="button" class="badge bg-primary border-0" data-toggle-row data-masina-id="{{ $masina->id }}" aria-expanded="false">
+                                        Editează
+                                    </button>
                                     <form method="POST" action="{{ route('masini-mementouri.destroy', $masina) }}" onsubmit="return confirm('Sigur dorești să ștergi această mașină?');">
                                         @csrf
                                         @method('DELETE')
@@ -84,9 +143,119 @@
                                 </div>
                             </td>
                         </tr>
+                        <tr class="expanded-row" data-expanded-row="{{ $masina->id }}" style="display: none;">
+                            <td colspan="{{ $columnCount }}" class="border-top-0">
+                                <div class="expanded-row-wrapper" data-expanded-row-content>
+                                    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center mb-3">
+                                        <div class="flex-grow-1">
+                                            <label class="form-label mb-1" for="expanded_reference_date_{{ $masina->id }}">Dată de referință</label>
+                                            <input type="date" id="expanded_reference_date_{{ $masina->id }}" class="form-control form-control-sm rounded-3"
+                                                   value="{{ $today }}" data-master-date data-masina-id="{{ $masina->id }}">
+                                            <div class="form-text">Folosește această dată pentru a completa rapid câmpurile goale.</div>
+                                        </div>
+                                        <div class="text-lg-end">
+                                            <a href="{{ route('masini-mementouri.show', $masina) }}" class="btn btn-outline-secondary border border-dark rounded-3">
+                                                <i class="fa-solid fa-up-right-from-square me-1"></i>Vezi pagina completă
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <div class="row g-3">
+                                        @foreach ($masina->documente as $document)
+                                            @php
+                                                $documentKey = $document->document_type . ($document->tara ? ':' . $document->tara : '');
+                                                $documentLabel = $uploadDocumentLabels[$documentKey] ?? ($gridDocumentTypes[$document->document_type] ?? $document->document_type);
+                                                $documentDateValue = optional($document->data_expirare)->format('Y-m-d');
+                                            @endphp
+                                            <div class="col-xl-4 col-lg-6">
+                                                <div class="expanded-row-document">
+                                                    <div class="expanded-row-document__header">
+                                                        <span class="fw-semibold">{{ $documentLabel }}</span>
+                                                        <span class="badge text-bg-light text-dark border">{{ optional($document->data_expirare)->isoFormat('DD.MM.YYYY') ?? 'Fără dată' }}</span>
+                                                    </div>
+                                                    <div class="expanded-row-document__body">
+                                                        <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}" class="row g-2 align-items-end">
+                                                            @csrf
+                                                            @method('PATCH')
+                                                            <div class="col-12">
+                                                                <label class="form-label" for="document_expiration_{{ $document->id }}">Dată expirare</label>
+                                                                <input type="date" class="form-control form-control-sm" id="document_expiration_{{ $document->id }}" name="data_expirare"
+                                                                       value="{{ $documentDateValue ?? $today }}" data-sync-target="{{ $masina->id }}">
+                                                            </div>
+                                                            <div class="col-12">
+                                                                <label class="form-label" for="document_email_{{ $document->id }}">Email alertă</label>
+                                                                <input type="email" class="form-control form-control-sm" id="document_email_{{ $document->id }}" name="email_notificare"
+                                                                       value="{{ $document->email_notificare }}">
+                                                            </div>
+                                                            <div class="col-12 text-end">
+                                                                <button type="submit" class="btn btn-sm btn-outline-primary border border-dark rounded-3">
+                                                                    <i class="fa-solid fa-floppy-disk me-1"></i>Salvează
+                                                                </button>
+                                                            </div>
+                                                        </form>
+
+                                                        <form method="POST" action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}" enctype="multipart/form-data" class="row g-2 align-items-end">
+                                                            @csrf
+                                                            <div class="col-12">
+                                                                <label class="form-label" for="document_file_{{ $document->id }}">Adaugă document (PDF)</label>
+                                                                <input type="file" class="form-control form-control-sm" id="document_file_{{ $document->id }}" name="fisier" accept="application/pdf" required>
+                                                            </div>
+                                                            <div class="col-12 text-end">
+                                                                <button type="submit" class="btn btn-sm btn-success text-white border border-dark rounded-3">
+                                                                    <i class="fa-solid fa-upload me-1"></i>Încarcă
+                                                                </button>
+                                                            </div>
+                                                        </form>
+
+                                                        <div class="expanded-row-document__files">
+                                                            <p class="fw-semibold small mb-2">Fișiere existente</p>
+                                                            <ul class="list-unstyled mb-0">
+                                                                @forelse ($document->fisiere as $fisier)
+                                                                    @php
+                                                                        $previewable = ($fisier->mime_type === 'application/pdf') || (is_string($fisier->mime_type) && \Illuminate\Support\Str::startsWith($fisier->mime_type, 'image/'));
+                                                                    @endphp
+                                                                    <li class="d-flex flex-column gap-2 mb-3">
+                                                                        <div class="d-flex justify-content-between align-items-center gap-2">
+                                                                            <div class="me-auto">
+                                                                                <i class="fa-solid fa-file-pdf text-danger me-2"></i>
+                                                                                <span class="fw-semibold">{{ $fisier->nume_original }}</span>
+                                                                                <small class="text-muted ms-2">{{ number_format(($fisier->dimensiune ?? 0) / 1024, 1) }} KB</small>
+                                                                            </div>
+                                                                            <div class="btn-group btn-group-sm" role="group">
+                                                                                @if ($previewable)
+                                                                                    <a href="{{ route('masini-mementouri.documente.fisiere.preview', [$masina, $document, $fisier]) }}" class="btn btn-outline-secondary border" target="_blank" rel="noopener">
+                                                                                        <i class="fa-solid fa-eye"></i>
+                                                                                    </a>
+                                                                                @endif
+                                                                                <a href="{{ route('masini-mementouri.documente.fisiere.download', [$masina, $document, $fisier]) }}" class="btn btn-outline-secondary border">
+                                                                                    <i class="fa-solid fa-download"></i>
+                                                                                </a>
+                                                                            </div>
+                                                                        </div>
+                                                                        <form method="POST" action="{{ route('masini-mementouri.documente.fisiere.destroy', [$masina, $document, $fisier]) }}" onsubmit="return confirm('Ștergi fișierul?');" class="text-end">
+                                                                            @csrf
+                                                                            @method('DELETE')
+                                                                            <button type="submit" class="btn btn-sm btn-outline-danger border border-dark rounded-3">
+                                                                                <i class="fa-solid fa-trash me-1"></i>Șterge
+                                                                            </button>
+                                                                        </form>
+                                                                    </li>
+                                                                @empty
+                                                                    <li class="text-muted">Nu există fișiere încărcate.</li>
+                                                                @endforelse
+                                                            </ul>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                </div>
+                            </td>
+                        </tr>
                     @empty
                         <tr>
-                            <td colspan="{{ 5 + count($gridDocumentTypes) + count($vignetteCountries) }}" class="text-center py-4">Nu există mașini înregistrate momentan.</td>
+                            <td colspan="{{ $columnCount }}" class="text-center py-4">Nu există mașini înregistrate momentan.</td>
                         </tr>
                     @endforelse
                 </tbody>
@@ -148,6 +317,98 @@
         const bootstrapModal = modalElement && typeof bootstrap !== 'undefined'
             ? new bootstrap.Modal(modalElement)
             : null;
+
+        const expandedState = {
+            id: null,
+            button: null,
+        };
+
+        const hideExpandedRow = (row) => {
+            if (!row) {
+                return;
+            }
+
+            const content = row.querySelector('[data-expanded-row-content]');
+            if (content) {
+                content.classList.remove('is-visible');
+                const handleTransitionEnd = () => {
+                    row.style.display = 'none';
+                    content.removeEventListener('transitionend', handleTransitionEnd);
+                };
+                content.addEventListener('transitionend', handleTransitionEnd);
+            } else {
+                row.style.display = 'none';
+            }
+        };
+
+        const showExpandedRow = (row) => {
+            if (!row) {
+                return;
+            }
+
+            const content = row.querySelector('[data-expanded-row-content]');
+            row.style.display = 'table-row';
+
+            requestAnimationFrame(() => {
+                if (content) {
+                    content.classList.add('is-visible');
+                }
+            });
+        };
+
+        document.querySelectorAll('[data-toggle-row]').forEach((button) => {
+            button.addEventListener('click', () => {
+                const id = button.dataset.masinaId;
+                const row = document.querySelector(`[data-expanded-row="${id}"]`);
+
+                if (!row) {
+                    return;
+                }
+
+                const isCurrent = expandedState.id === id;
+
+                if (expandedState.button) {
+                    expandedState.button.setAttribute('aria-expanded', 'false');
+                }
+
+                if (expandedState.id && expandedState.id !== id) {
+                    const previousRow = document.querySelector(`[data-expanded-row="${expandedState.id}"]`);
+                    hideExpandedRow(previousRow);
+                }
+
+                if (isCurrent) {
+                    hideExpandedRow(row);
+                    expandedState.id = null;
+                    expandedState.button = null;
+                    button.setAttribute('aria-expanded', 'false');
+                } else {
+                    showExpandedRow(row);
+                    expandedState.id = id;
+                    expandedState.button = button;
+                    button.setAttribute('aria-expanded', 'true');
+                }
+            });
+        });
+
+        document.querySelectorAll('[data-master-date]').forEach((input) => {
+            const masinaId = input.dataset.masinaId;
+            input.addEventListener('change', () => {
+                document.querySelectorAll(`[data-sync-target="${masinaId}"]`).forEach((target) => {
+                    if (target.dataset.syncEmpty === 'true') {
+                        target.value = input.value;
+                        target.dispatchEvent(new Event('input', { bubbles: true }));
+                    }
+                });
+            });
+        });
+
+        document.querySelectorAll('[data-sync-target]').forEach((input) => {
+            input.dataset.syncEmpty = input.value ? 'false' : 'true';
+
+            input.addEventListener('input', () => {
+                input.dataset.syncEmpty = input.value ? 'false' : 'true';
+            });
+        });
 
         if (modalElement && bootstrapModal) {
             const form = modalElement.querySelector('form');

--- a/routes/web.php
+++ b/routes/web.php
@@ -231,6 +231,8 @@ Route::middleware(['auth'])->group(function () {
                 ->name('masini-mementouri.documente.fisiere.destroy');
             Route::get('masini-mementouri/{masini_mementouri}/documente/{document}/fisiere/{fisier}', [MasiniDocumentFisierController::class, 'download'])
                 ->name('masini-mementouri.documente.fisiere.download');
+            Route::get('masini-mementouri/{masini_mementouri}/documente/{document}/fisiere/{fisier}/preview', [MasiniDocumentFisierController::class, 'preview'])
+                ->name('masini-mementouri.documente.fisiere.preview');
         });
     });
 


### PR DESCRIPTION
## Summary
- load machine documents with associated files for the index view and expose document labels to the template
- add an inline expandable editor row with styling, upload/delete controls, and quick date helpers beneath each machine entry
- provide a preview response for stored documents and route it for use by the inline document list

## Testing
- `php artisan test` *(fails: vendor dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6901c269ec7c832698153eeb2ac5f361