### PR TITLE
Enhance inline document management

### DIFF
--- a/resources/views/masini-mementouri/partials/document-cell.blade.php
+++ b/resources/views/masini-mementouri/partials/document-cell.blade.php
@@ -5,10 +5,15 @@
     $displayDate = optional($document->data_expirare)->format('d.m.Y');
 @endphp
 
-<div class="{{ $baseClass }} {{ $colorClass }}" data-color-holder data-base-class="{{ $baseClass }}">
+<div class="{{ $baseClass }} {{ $colorClass }}"
+     data-color-holder
+     data-base-class="{{ $baseClass }}"
+     data-document-wrapper
+     data-document-id="{{ $document->id }}"
+     data-empty-label="—">
     <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}"
           class="document-date-form"
-          data-document-update data-empty-label="—">
+          data-document-update data-auto-submit="true">
         @csrf
         @method('PATCH')
 
@@ -24,5 +29,7 @@
         <button type="button" class="btn btn-link p-0 document-date-edit" data-edit-trigger aria-label="Editează data">
             <i class="fa-solid fa-pen"></i>
         </button>
+
+        <div class="document-feedback small mt-1" data-feedback-target hidden></div>
     </form>
 </div>

--- a/resources/views/masini-mementouri/partials/document-files-list.blade.php
+++ b/resources/views/masini-mementouri/partials/document-files-list.blade.php
@@ -1,0 +1,38 @@
+<ul class="list-unstyled mb-0" data-document-files-list>
+    @forelse ($document->fisiere as $fisier)
+        @php
+            $iconClass = $fisier->iconClass();
+            $previewRoute = route('masini-mementouri.documente.fisiere.preview', [$masina, $document, $fisier]);
+            $downloadRoute = route('masini-mementouri.documente.fisiere.download', [$masina, $document, $fisier]);
+            $deleteRoute = route('masini-mementouri.documente.fisiere.destroy', [$masina, $document, $fisier]);
+        @endphp
+        <li class="d-flex flex-column gap-2 mb-3" data-document-file data-file-id="{{ $fisier->id }}">
+            <div class="d-flex justify-content-between align-items-center gap-2">
+                <div class="me-auto">
+                    <i class="fa-solid {{ $iconClass }} me-2"></i>
+                    <span class="fw-semibold">{{ $fisier->nume_original }}</span>
+                    <small class="text-muted ms-2">{{ number_format(($fisier->dimensiune ?? 0) / 1024, 1) }} KB</small>
+                </div>
+                <div class="btn-group btn-group-sm" role="group">
+                    @if ($fisier->isPreviewable())
+                        <a href="{{ $previewRoute }}" class="btn btn-outline-primary border" target="_blank" rel="noopener" title="Deschide în filă nouă">
+                            <i class="fa-solid fa-eye"></i>
+                        </a>
+                    @endif
+                    <a href="{{ $downloadRoute }}" class="btn btn-outline-secondary border" download="{{ $fisier->downloadName() }}" title="Descarcă fișierul">
+                        <i class="fa-solid fa-download"></i>
+                    </a>
+                </div>
+            </div>
+            <form method="POST" action="{{ $deleteRoute }}" class="text-end" data-document-delete>
+                @csrf
+                @method('DELETE')
+                <button type="submit" class="btn btn-sm btn-outline-danger border border-dark rounded-3">
+                    <i class="fa-solid fa-trash me-1"></i>Șterge
+                </button>
+            </form>
+        </li>
+    @empty
+        <li class="text-muted" data-document-files-empty>Nu există fișiere încărcate.</li>
+    @endforelse
+</ul>


### PR DESCRIPTION
## Summary
- connect the inline document date controls and file management actions to the JSON endpoints and show inline feedback with loading guards
- extract a reusable partial for rendering document file lists so the backend can return refreshed markup after uploads or deletions
- expand the Masini mementouri feature tests to cover JSON upload and delete flows

## Testing
- ⚠️ `./vendor/bin/phpunit --filter MasiniMementouriTest` *(fails: vendor/bin is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6901c5b12b108326bed4c788f6c212d2