### PR TITLE
Expand vehicle document test coverage

### DIFF
--- a/tests/Unit/Models/MasinaDocumentFisierTest.php
+++ b/tests/Unit/Models/MasinaDocumentFisierTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Masini\MasinaDocumentFisier;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class MasinaDocumentFisierTest extends TestCase
+{
+    public function test_download_name_falls_back_to_generic_when_missing(): void
+    {
+        $fisier = new MasinaDocumentFisier();
+
+        $this->assertSame('document', $fisier->downloadName());
+    }
+
+    #[DataProvider('downloadNameProvider')]
+    public function test_download_name_prefers_original_then_filename(?string $original, ?string $filename, string $expected): void
+    {
+        $fisier = new MasinaDocumentFisier([
+            'nume_original' => $original,
+            'nume_fisier' => $filename,
+            'cale' => 'masini-documente/1/' . ($filename ?? 'fallback.pdf'),
+        ]);
+
+        $this->assertSame($expected, $fisier->downloadName());
+    }
+
+    public static function downloadNameProvider(): array
+    {
+        return [
+            'has original name' => ['atestat.pdf', 'internal.pdf', 'atestat.pdf'],
+            'missing original uses file name' => [null, 'contract.pdf', 'contract.pdf'],
+            'trimmed value' => ['   ', 'contract.pdf', 'contract.pdf'],
+        ];
+    }
+
+    #[DataProvider('mimeTypeProvider')]
+    public function test_guess_mime_type_from_attributes(?string $savedMime, ?string $fileName, ?string $expected): void
+    {
+        $fisier = new MasinaDocumentFisier([
+            'mime_type' => $savedMime,
+            'nume_original' => $fileName,
+        ]);
+
+        $this->assertSame($expected, $fisier->guessMimeType());
+    }
+
+    public static function mimeTypeProvider(): array
+    {
+        return [
+            'uses stored mime type' => ['application/pdf', 'contract.pdf', 'application/pdf'],
+            'infers from extension' => [null, 'imagine.PNG', 'image/png'],
+            'unknown extension' => [null, 'document.bin', null],
+        ];
+    }
+
+    #[DataProvider('previewableProvider')]
+    public function test_is_previewable_handles_common_types(?string $mime, ?string $fileName, bool $expected): void
+    {
+        $fisier = new MasinaDocumentFisier([
+            'mime_type' => $mime,
+            'nume_original' => $fileName,
+        ]);
+
+        $this->assertSame($expected, $fisier->isPreviewable());
+    }
+
+    public static function previewableProvider(): array
+    {
+        return [
+            'pdf mime type' => ['application/pdf', 'atestat.pdf', true],
+            'image mime type' => ['image/jpeg', 'poza.jpg', true],
+            'text mime type' => ['text/plain', 'note.txt', true],
+            'extension fallback' => [null, 'fisier.csv', true],
+            'non previewable type' => ['application/vnd.ms-excel', 'date.xls', false],
+        ];
+    }
+
+    #[DataProvider('iconClassProvider')]
+    public function test_icon_class_matches_mime_type(string $mime, string $expected): void
+    {
+        $fisier = new MasinaDocumentFisier([
+            'mime_type' => $mime,
+        ]);
+
+        $this->assertSame($expected, $fisier->iconClass());
+    }
+
+    public static function iconClassProvider(): array
+    {
+        return [
+            'image' => ['image/png', 'fa-file-image text-primary'],
+            'pdf' => ['application/pdf', 'fa-file-pdf text-danger'],
+            'text' => ['text/plain', 'fa-file-lines text-info'],
+            'other' => ['application/octet-stream', 'fa-file-lines text-secondary'],
+        ];
+    }
+}

--- a/tests/Unit/Models/MasinaDocumentTest.php
+++ b/tests/Unit/Models/MasinaDocumentTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Masini\MasinaDocument;
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class MasinaDocumentTest extends TestCase
+{
+    #[DataProvider('colorClassProvider')]
+    public function test_color_class_returns_expected_value(?string $date, string $expected): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 5, 1));
+
+        $document = new MasinaDocument();
+        $document->data_expirare = $date ? Carbon::parse($date) : null;
+
+        $this->assertSame($expected, $document->colorClass());
+
+        Carbon::setTestNow();
+    }
+
+    public static function colorClassProvider(): array
+    {
+        return [
+            'missing date' => [null, 'bg-secondary-subtle'],
+            'expired date' => ['2024-04-30', 'bg-danger text-white'],
+            'expires in 1 day' => ['2024-05-02', 'bg-danger text-white'],
+            'expires in 15 days' => ['2024-05-16', 'bg-warning'],
+            'expires in 45 days' => ['2024-06-15', 'bg-success text-white'],
+            'long term' => ['2024-07-15', ''],
+        ];
+    }
+
+    public function test_days_until_expiry_returns_expected_difference(): void
+    {
+        Carbon::setTestNow(Carbon::create(2024, 5, 10));
+
+        $document = new MasinaDocument();
+        $document->data_expirare = Carbon::parse('2024-05-25');
+
+        $this->assertSame(15, $document->daysUntilExpiry());
+
+        Carbon::setTestNow();
+    }
+
+    #[DataProvider('labelProvider')]
+    public function test_label_generation(string $type, ?string $country, string $expected): void
+    {
+        $document = new MasinaDocument([
+            'document_type' => $type,
+            'tara' => $country,
+        ]);
+
+        $this->assertSame($expected, $document->label());
+    }
+
+    public static function labelProvider(): array
+    {
+        return [
+            'itp' => [MasinaDocument::TYPE_ITP, null, 'ITP'],
+            'vignette known country' => [MasinaDocument::TYPE_VIGNETA, 'hu', 'Vignetă HU'],
+            'vignette unknown country' => [MasinaDocument::TYPE_VIGNETA, 'de', 'Vignetă DE'],
+            'talon' => [MasinaDocument::TYPE_TALON, null, 'Talon'],
+            'fallback' => ['neidentificat', null, 'Neidentificat'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- extend vehicle memento feature tests to cover inline updates, validation failures, and document file management edge cases
- add regression coverage for cross-vehicle download/preview protection
- introduce unit tests for MasinaDocument color/label helpers and MasinaDocumentFisier preview, mime, and icon logic

## Testing
- not run (Composer install blocked by network restrictions)

------
https://chatgpt.com/codex/tasks/task_e_6901c82265048326a46557f978d3c23a