### PR TITLE
Fix auto-scroll for selected service car

### DIFF
--- a/resources/views/service/masini/index.blade.php
+++ b/resources/views/service/masini/index.blade.php
@@ -222,7 +222,7 @@
                             <span class="fw-semibold"><i class="fa-solid fa-car-side me-1"></i>Mașini</span>
                         </div>
                         <div class="card-body">
-                            <div class="list-group mb-4" style="max-height: 450px; overflow-y: auto;">
+                            <div id="service-cars-list" class="list-group mb-4" style="max-height: 450px; overflow-y: auto;">
                                 @forelse ($masini as $masina)
                                     @php
                                         $masinaQuery = $queryParams;
@@ -937,6 +937,16 @@
 @push('page-scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
+            const carList = document.getElementById('service-cars-list');
+
+            if (carList) {
+                const activeCar = carList.querySelector('.list-group-item.active');
+
+                if (activeCar) {
+                    carList.scrollTop = Math.max(0, activeCar.offsetTop);
+                }
+            }
+
             const pieceComboboxRaw = @json($pieceComboboxDataset);
             const normalizedPieces = Array.isArray(pieceComboboxRaw)
                 ? pieceComboboxRaw.map(function (piece) {


### PR DESCRIPTION
## Summary
- add an id to the service cars list container
- initialize the page to scroll the list to the active car when present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901c6c7024c8326a40133f067f4e685