### PR TITLE
Add edit page for Masini mementouri documents

### DIFF
--- a/app/Http/Controllers/Masini/MasiniMementoController.php
+++ b/app/Http/Controllers/Masini/MasiniMementoController.php
@@ -80,6 +80,19 @@ class MasiniMementoController extends Controller
         ]);
     }
 
+    public function edit(Masina $masini_mementouri): View
+    {
+        $masini_mementouri->syncDefaultDocuments();
+        $masini_mementouri->loadMissing(['documente.fisiere']);
+
+        $uploadDocumentLabels = MasinaDocument::uploadDocumentLabels();
+
+        return view('masini-mementouri.edit', [
+            'masina' => $masini_mementouri,
+            'uploadDocumentLabels' => $uploadDocumentLabels,
+        ]);
+    }
+
     public function update(Request $request, Masina $masini_mementouri): RedirectResponse
     {
         $validated = $request->validate([

--- a/resources/views/masini-mementouri/edit.blade.php
+++ b/resources/views/masini-mementouri/edit.blade.php
@@ -1,0 +1,85 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-6">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-car me-1"></i>{{ $masina->numar_inmatriculare }}
+            </span>
+        </div>
+        <div class="col-lg-6 text-end">
+            <a href="{{ route('masini-mementouri.index') }}" class="btn btn-sm btn-secondary border border-dark rounded-3">
+                <i class="fa-solid fa-arrow-left me-1"></i>Înapoi la listă
+            </a>
+        </div>
+    </div>
+
+    <div class="card-body px-0 py-3">
+        @include('errors')
+
+        <div class="mx-3">
+            <div class="row g-3">
+                @forelse ($masina->documente as $document)
+                    @php
+                        $labelKey = $document->document_type . ($document->tara ? ':' . $document->tara : '');
+                        $label = $uploadDocumentLabels[$labelKey] ?? \Illuminate\Support\Str::of($document->document_type)->headline();
+                    @endphp
+                    <div class="col-lg-6">
+                        <div class="card h-100 border border-secondary-subtle rounded-4">
+                            <div class="card-header d-flex justify-content-between align-items-center rounded-4">
+                                <span class="fw-semibold">{{ $label }}</span>
+                                <span class="badge bg-light text-dark border">{{ optional($document->data_expirare)->isoFormat('DD.MM.YYYY') }}</span>
+                            </div>
+                            <div class="card-body">
+                                <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}" class="row g-3 mb-3">
+                                    @csrf
+                                    @method('PATCH')
+                                    <div class="col-md-6">
+                                        <label class="form-label" for="data_expirare_{{ $document->id }}">Dată expirare</label>
+                                        <input type="date" class="form-control rounded-3" id="data_expirare_{{ $document->id }}" name="data_expirare"
+                                               value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
+                                    </div>
+                                    <div class="col-md-6">
+                                        <label class="form-label" for="email_notificare_{{ $document->id }}">Email alertă</label>
+                                        <input type="email" class="form-control rounded-3" id="email_notificare_{{ $document->id }}" name="email_notificare"
+                                               value="{{ old('email_notificare', $document->email_notificare) }}">
+                                    </div>
+                                    <div class="col-12 text-end">
+                                        <button type="submit" class="btn btn-primary border border-dark rounded-3">
+                                            <i class="fa-solid fa-floppy-disk me-1"></i>Salvează documentul
+                                        </button>
+                                    </div>
+                                </form>
+
+                                <form method="POST" action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}" enctype="multipart/form-data" class="row g-2 align-items-end">
+                                    @csrf
+                                    <div class="col-md-8">
+                                        <label class="form-label" for="fisier_{{ $document->id }}">Încarcă fișier (PDF)</label>
+                                        <input type="file" class="form-control rounded-3" id="fisier_{{ $document->id }}" name="fisier" accept="application/pdf" required>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <button type="submit" class="btn btn-success text-white border border-dark w-100 rounded-3">
+                                            <i class="fa-solid fa-upload me-1"></i>Încarcă
+                                        </button>
+                                    </div>
+                                </form>
+
+                                <hr>
+
+                                @include('masini-mementouri.partials.document-files-list', ['masina' => $masina, 'document' => $document])
+                            </div>
+                        </div>
+                    </div>
+                @empty
+                    <div class="col-12">
+                        <div class="alert alert-info rounded-4 border border-info-subtle">
+                            Nu există documente definite pentru această mașină.
+                        </div>
+                    </div>
+                @endforelse
+            </div>
+        </div>
+    </div>
+</div>
+@endsection


### PR DESCRIPTION
## Summary
- add an edit action on the MasiniMementoController to prepare document data for the new page
- create an edit Blade view that exposes expiry date editing and file management with navigation back to the listing

## Testing
- `php artisan test --filter=MasiniMementouriTest` *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_6901cffcf8588326892031647b246463