### PR TITLE
Add streamed previews and downloads for stored documents

### DIFF
--- a/app/Http/Controllers/ComandaFisierInternController.php
+++ b/app/Http/Controllers/ComandaFisierInternController.php
@@ -9,11 +9,11 @@ use App\Models\ComandaFisier;
 use App\Models\ComandaFisierIstoric;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Mail;
-use File;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Response;
 use Closure;
 use App\Models\ComandaFisierEmail;
+use App\Support\BrowserViewableFile;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ComandaFisierInternController extends Controller
 {
@@ -82,20 +82,83 @@ class ComandaFisierInternController extends Controller
 
     public function fisierDeschide(Comanda $comanda, $numeFisier)
     {
-        //This method will look for the file and get it from drive
         foreach ($comanda->fisiereInterne as $fisier) {
             if ($fisier->nume === $numeFisier) {
-                try {
-                    $file = Storage::get($fisier->cale . '/' . $fisier->nume);
-                    $type = Storage::mimeType($fisier->cale . '/' . $fisier->nume);
-                    $response = Response::make($file, 200);
-                    $response->header("Content-Type", $type);
-                    return $response;
-                } catch (FileNotFoundException $exception) {
+                $path = $fisier->cale . '/' . $fisier->nume;
+
+                if (! Storage::exists($path)) {
                     abort(404);
                 }
+
+                $mimeType = Storage::mimeType($path) ?? 'application/octet-stream';
+
+                if (! BrowserViewableFile::isViewable($fisier->nume, $mimeType)) {
+                    return $this->fisierDownload($comanda, $numeFisier);
+                }
+
+                return $this->streamStorageFile($path, $fisier->nume, $mimeType);
             }
         }
+
+        abort(404);
+    }
+
+    public function fisierDownload(Comanda $comanda, $numeFisier)
+    {
+        foreach ($comanda->fisiereInterne as $fisier) {
+            if ($fisier->nume === $numeFisier) {
+                $path = $fisier->cale . '/' . $fisier->nume;
+
+                if (! Storage::exists($path)) {
+                    abort(404);
+                }
+
+                $mimeType = Storage::mimeType($path) ?? 'application/octet-stream';
+
+                return $this->downloadStorageFile($path, $fisier->nume, $mimeType);
+            }
+        }
+
+        abort(404);
+    }
+
+    protected function streamStorageFile(string $path, string $downloadName, string $mimeType): StreamedResponse
+    {
+        $stream = Storage::readStream($path);
+
+        if ($stream === false) {
+            abort(404);
+        }
+
+        return response()->stream(function () use ($stream) {
+            fpassthru($stream);
+
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }, 200, [
+            'Content-Type' => $mimeType,
+            'Content-Disposition' => BrowserViewableFile::contentDisposition('inline', $downloadName),
+        ]);
+    }
+
+    protected function downloadStorageFile(string $path, string $downloadName, string $mimeType): StreamedResponse
+    {
+        $stream = Storage::readStream($path);
+
+        if ($stream === false) {
+            abort(404);
+        }
+
+        return response()->streamDownload(function () use ($stream) {
+            fpassthru($stream);
+
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        }, $downloadName, [
+            'Content-Type' => $mimeType,
+        ]);
     }
 
     public function fisierSterge(Comanda $comanda, $numeFisier)

--- a/app/Support/BrowserViewableFile.php
+++ b/app/Support/BrowserViewableFile.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+
+class BrowserViewableFile
+{
+    /**
+     * Extensions that are generally safe to render inline in the browser.
+     *
+     * @var array<int, string>
+     */
+    protected const VIEWABLE_EXTENSIONS = [
+        'pdf',
+        'png',
+        'jpg',
+        'jpeg',
+        'gif',
+        'bmp',
+        'webp',
+        'svg',
+        'txt',
+        'csv',
+    ];
+
+    /**
+     * Determine if a file is likely viewable directly in the browser.
+     */
+    public static function isViewable(string $filename, ?string $mimeType = null): bool
+    {
+        if ($mimeType !== null) {
+            if (Str::startsWith($mimeType, ['image/', 'text/'])) {
+                return true;
+            }
+
+            if ($mimeType === 'application/pdf') {
+                return true;
+            }
+        }
+
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+        return in_array($extension, self::VIEWABLE_EXTENSIONS, true);
+    }
+
+    /**
+     * Build a safe Content-Disposition header for the provided disposition type.
+     */
+    public static function contentDisposition(string $disposition, string $filename): string
+    {
+        $escaped = addcslashes($filename, "\\\"");
+
+        return sprintf('%s; filename="%s"', $disposition, $escaped);
+    }
+}

--- a/resources/views/comenzi/fisiereInterne/afisareFisiereIncarcateDejaSiFormular.blade.php
+++ b/resources/views/comenzi/fisiereInterne/afisareFisiereIncarcateDejaSiFormular.blade.php
@@ -2,6 +2,7 @@
 
 @php
     use \Carbon\Carbon;
+    use App\Support\BrowserViewableFile;
 @endphp
 
 @section('content')
@@ -53,16 +54,32 @@
                                     </thead>
                                     <tbody>
                                         @foreach ($comanda->fisiereInterne as $fisier)
+                                            @php
+                                                $isViewable = BrowserViewableFile::isViewable($fisier->nume ?? '');
+                                                $previewUrl = url('/comenzi/' . $comanda->id . '/fisiere-interne/deschide/' . $fisier->nume);
+                                                $downloadUrl = url('/comenzi/' . $comanda->id . '/fisiere-interne/descarca/' . $fisier->nume);
+                                            @endphp
                                             <tr>
                                                 <td>{{ $loop->iteration }}</td>
-                                                <td>
-                                                    <a href="/comenzi/{{$comanda->id}}/fisiere-interne/deschide/{{ $fisier->nume }}" target="_blank" style="text-decoration:cornflowerblue">
-                                                        {{-- <i class="fa-solid fa-file"></i> --}}
-                                                        {{ $fisier->nume ?? '' }}
-                                                    </a>
+                                                <td class="text-break">
+                                                    {{ $fisier->nume ?? '' }}
                                                 </td>
                                                 <td class="d-flex justify-content-end">
-                                                    <div class="d-flex">
+                                                    <div class="d-flex flex-wrap gap-2 justify-content-end">
+                                                        @if ($isViewable)
+                                                            <a href="{{ $previewUrl }}" target="_blank" rel="noopener" title="Deschide fișierul">
+                                                                <span class="badge bg-primary d-inline-flex align-items-center gap-1">
+                                                                    <i class="fa-solid fa-up-right-from-square"></i>
+                                                                    Deschide
+                                                                </span>
+                                                            </a>
+                                                        @endif
+                                                        <a href="{{ $downloadUrl }}" title="Descarcă fișierul">
+                                                            <span class="badge bg-secondary d-inline-flex align-items-center gap-1">
+                                                                <i class="fa-solid fa-download"></i>
+                                                                Descarcă
+                                                            </span>
+                                                        </a>
                                                         <a
                                                             href="#"
                                                             data-bs-toggle="modal"

--- a/resources/views/comenziIncarcareDocumenteDeCatreTransportator/afisareDocumenteIncarcateDejaSiFormular.blade.php
+++ b/resources/views/comenziIncarcareDocumenteDeCatreTransportator/afisareDocumenteIncarcateDejaSiFormular.blade.php
@@ -2,6 +2,7 @@
 
 @php
     use \Carbon\Carbon;
+    use App\Support\BrowserViewableFile;
 @endphp
 
 @section('content')
@@ -153,13 +154,15 @@
                                     </thead>
                                     <tbody>
                                         @foreach ($comanda->fisiereIncarcateDeTransportator as $fisier)
+                                            @php
+                                                $isViewable = BrowserViewableFile::isViewable($fisier->nume ?? '');
+                                                $previewUrl = url('/comanda-incarcare-documente-de-catre-transportator/' . $comanda->cheie_unica . '/deschide/' . $fisier->nume);
+                                                $downloadUrl = url('/comanda-incarcare-documente-de-catre-transportator/' . $comanda->cheie_unica . '/descarca/' . $fisier->nume);
+                                            @endphp
                                             <tr>
                                                 <td>{{ $loop->iteration }}</td>
-                                                <td>
-                                                    <a href="/comanda-incarcare-documente-de-catre-transportator/{{$comanda->cheie_unica}}/deschide/{{ $fisier->nume }}" target="_blank" style="text-decoration:cornflowerblue">
-                                                        {{-- <i class="fa-solid fa-file"></i> --}}
-                                                        {{ $fisier->nume ?? '' }}
-                                                    </a>
+                                                <td class="text-break">
+                                                    {{ $fisier->nume ?? '' }}
                                                 </td>
                                                 <td>
                                                     {{-- If the file is uploaded by operators is shouldn't require validation --}}
@@ -172,7 +175,21 @@
                                                     @endif
                                                 </td>
                                                 <td>
-                                                    <div class="d-flex">
+                                                    <div class="d-flex flex-wrap gap-2">
+                                                        @if ($isViewable)
+                                                            <a href="{{ $previewUrl }}" target="_blank" rel="noopener" title="Deschide fișierul">
+                                                                <span class="badge bg-primary d-inline-flex align-items-center gap-1">
+                                                                    <i class="fa-solid fa-up-right-from-square"></i>
+                                                                    Deschide
+                                                                </span>
+                                                            </a>
+                                                        @endif
+                                                        <a href="{{ $downloadUrl }}" title="Descarcă fișierul">
+                                                            <span class="badge bg-secondary d-inline-flex align-items-center gap-1">
+                                                                <i class="fa-solid fa-download"></i>
+                                                                Descarcă
+                                                            </span>
+                                                        </a>
                                                         @auth
                                                             {{-- If the file is uploaded by operators is shouldn't require validation --}}
                                                             @if (!$fisier->user_id)

--- a/resources/views/fileManagerPersonalizat/index.blade.php
+++ b/resources/views/fileManagerPersonalizat/index.blade.php
@@ -1,5 +1,9 @@
 @extends ('layouts.app')
 
+@php
+    use App\Support\BrowserViewableFile;
+@endphp
+
 @section('content')
 <div class="container mx-auto mx-3 px-3 card" style="border-radius: 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0 0;">
@@ -193,12 +197,27 @@
                                 @php
                                     $exploded = explode("/", $fisier);
                                     $fileName = end($exploded);
+                                    $isViewable = BrowserViewableFile::isViewable($fileName ?? '');
+                                    $previewUrl = url('/file-manager-personalizat-fisier/deschide/' . $fisier);
+                                    $downloadUrl = url('/file-manager-personalizat-fisier/descarca/' . $fisier);
                                 @endphp
                                 <tr>
                                     <td>
-                                        <a href="/file-manager-personalizat-fisier/deschide/{{ $fisier }}" target="_blank" style="text-decoration:cornflowerblue">
-                                            <i class="fas fa-file"></i> {{ $fileName }}
-                                        </a>
+                                        <div class="d-flex flex-column">
+                                            <span class="text-break"><i class="fas fa-file"></i> {{ $fileName }}</span>
+                                            <div class="d-flex flex-wrap gap-2 mt-1">
+                                                @if ($isViewable)
+                                                    <a href="{{ $previewUrl }}" target="_blank" rel="noopener" class="badge bg-primary d-inline-flex align-items-center gap-1" title="Deschide fișierul">
+                                                        <i class="fa-solid fa-up-right-from-square"></i>
+                                                        Deschide
+                                                    </a>
+                                                @endif
+                                                <a href="{{ $downloadUrl }}" class="badge bg-secondary d-inline-flex align-items-center gap-1" title="Descarcă fișierul">
+                                                    <i class="fa-solid fa-download"></i>
+                                                    Descarcă
+                                                </a>
+                                            </div>
+                                        </div>
                                     </td>
                                     @can('documente-manage')
                                         <td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,7 @@ Route::get('/axios/trimitere-cod-autentificare-prin-email', [AxiosController::cl
 Route::get('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'afisareDocumenteIncarcateDejaSiFormular']);
 Route::post('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'salvareDocumente']);
 Route::get('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}/deschide/{numeFisier?}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'fisierDeschide']);
+Route::get('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}/descarca/{numeFisier?}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'fisierDownload']);
 Route::delete('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}/sterge/{numeFisier?}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'fisierSterge']);
 Route::post('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}/trimitere-email-transportator-catre-maseco-documente-incarcate/{categorieEmail}', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'trimitereEmailTransportatorCatreMasecoDocumenteIncarcate']);
 Route::get('/comanda-incarcare-documente-de-catre-transportator/{cheie_unica}/mesaj-succes-trimitere-notificare', [ComandaIncarcareDocumenteDeCatreTransportatorController::class, 'trimitereEmailTransportatorCatreMasecoDocumenteIncarcateMesajSucces']);
@@ -113,6 +114,7 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware('permission:documente')->group(function () {
         Route::get('/file-manager-personalizat/{cale?}', [FileManagerPersonalizatController::class, 'afisareDirectoareSiFisiere'])->where('cale', '.*');
         Route::get('/file-manager-personalizat-fisier/deschide/{cale?}', [FileManagerPersonalizatController::class, 'fisierDeschide'])->where('cale', '.*');
+        Route::get('/file-manager-personalizat-fisier/descarca/{cale?}', [FileManagerPersonalizatController::class, 'fisierDownload'])->where('cale', '.*');
 
         Route::middleware('permission:documente-manage')->group(function () {
             Route::post('/file-manager-personalizat-director/creaza', [FileManagerPersonalizatController::class, 'directorCreaza']);
@@ -179,6 +181,7 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/comenzi/{comanda}/fisiere-interne', [ComandaFisierInternController::class, 'afisareFisiereIncarcateDejaSiFormular']);
         Route::post('/comenzi/{comanda}/fisiere-interne', [ComandaFisierInternController::class, 'salvareDocumente']);
         Route::get('/comenzi/{comanda}/fisiere-interne/deschide/{numeFisier?}', [ComandaFisierInternController::class, 'fisierDeschide']);
+        Route::get('/comenzi/{comanda}/fisiere-interne/descarca/{numeFisier?}', [ComandaFisierInternController::class, 'fisierDownload']);
         Route::delete('/comenzi/{comanda}/fisiere-interne/sterge/{numeFisier?}', [ComandaFisierInternController::class, 'fisierSterge']);
 
         Route::resource('/comenzi', ComandaController::class)->parameters(['comenzi' => 'comanda']);


### PR DESCRIPTION
## Summary
- add a BrowserViewableFile helper to detect inline-viewable documents and build Content-Disposition headers
- stream command and file-manager documents inline when safe and provide download responses for the rest
- update document listings to show "Deschide" buttons for previewable files and download links for all entries
- register download routes so each document source can serve attachments with accurate headers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6901d101601483268ee9fc07be81cad5