### PR TITLE
Refactor masini mementouri document management flow

### DIFF
--- a/app/Http/Controllers/Masini/MasiniDocumentController.php
+++ b/app/Http/Controllers/Masini/MasiniDocumentController.php
@@ -11,9 +11,23 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Redirect;
+use Illuminate\View\View;
 
 class MasiniDocumentController extends Controller
 {
+    public function edit(Masina $masina, MasinaDocument $document): View
+    {
+        abort_unless($document->masina_id === $masina->id, 404);
+
+        $document->loadMissing('fisiere');
+
+        return view('masini-mementouri.document-edit', [
+            'masina' => $masina,
+            'document' => $document,
+            'documentLabel' => $document->label(),
+        ]);
+    }
+
     public function update(Request $request, Masina $masina, MasinaDocument $document): JsonResponse|RedirectResponse
     {
         abort_unless($document->masina_id === $masina->id, 404);

--- a/app/Http/Controllers/Masini/MasiniMementoController.php
+++ b/app/Http/Controllers/Masini/MasiniMementoController.php
@@ -25,7 +25,6 @@ class MasiniMementoController extends Controller
 
         $gridDocumentTypes = MasinaDocument::gridDocumentTypes();
         $vignetteCountries = MasinaDocument::vignetteCountries();
-        $uploadDocumentLabels = MasinaDocument::uploadDocumentLabels();
 
         $masiniModalData = $masini
             ->mapWithKeys(function (Masina $masina) {
@@ -46,7 +45,6 @@ class MasiniMementoController extends Controller
             'masini',
             'gridDocumentTypes',
             'vignetteCountries',
-            'uploadDocumentLabels',
             'masiniModalData'
         ));
     }

--- a/resources/views/masini-mementouri/document-edit.blade.php
+++ b/resources/views/masini-mementouri/document-edit.blade.php
@@ -1,0 +1,102 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-6">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-car me-1"></i>{{ $masina->numar_inmatriculare }}
+            </span>
+            <span class="badge bg-light text-dark border ms-2">
+                {{ $documentLabel }}
+            </span>
+        </div>
+        <div class="col-lg-6 text-end">
+            <a href="{{ route('masini-mementouri.index') }}" class="btn btn-sm btn-secondary border border-dark rounded-3">
+                <i class="fa-solid fa-arrow-left me-1"></i>Înapoi la listă
+            </a>
+        </div>
+    </div>
+
+    <div class="card-body px-0 py-3">
+        @include('errors')
+
+        @if (session('status'))
+            <div class="alert alert-success border border-success-subtle rounded-4 mx-3">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <div class="mx-3">
+            <div class="row justify-content-center g-4">
+                <div class="col-xl-6 col-lg-7">
+                    <div class="card border border-secondary-subtle rounded-4 h-100">
+                        <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold">Actualizează data expirării</span>
+                        </div>
+                        <div class="card-body">
+                            <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}">
+                                @csrf
+                                @method('PATCH')
+
+                                <div class="mb-3">
+                                    <label class="form-label" for="data_expirare">Dată expirare</label>
+                                    <input type="date"
+                                           id="data_expirare"
+                                           name="data_expirare"
+                                           class="form-control rounded-3"
+                                           value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
+                                </div>
+
+                                <div class="text-end">
+                                    <button type="submit" class="btn btn-primary border border-dark rounded-3">
+                                        <i class="fa-solid fa-floppy-disk me-1"></i>Salvează data
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-xl-6 col-lg-7">
+                    <div class="card border border-secondary-subtle rounded-4 h-100">
+                        <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold">Încarcă documente (PDF)</span>
+                        </div>
+                        <div class="card-body">
+                            <form method="POST"
+                                  action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}"
+                                  enctype="multipart/form-data">
+                                @csrf
+
+                                <div class="mb-3">
+                                    <label class="form-label" for="fisier">Selectează fișier</label>
+                                    <input type="file" id="fisier" name="fisier" class="form-control rounded-3"
+                                           accept="application/pdf" required>
+                                </div>
+
+                                <div class="text-end">
+                                    <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
+                                        <i class="fa-solid fa-upload me-1"></i>Încarcă
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="col-xl-8 col-lg-10">
+                    <div class="card border border-secondary-subtle rounded-4">
+                        <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
+                            <span class="fw-semibold">Documente existente</span>
+                        </div>
+                        <div class="card-body">
+                            @include('masini-mementouri.partials.document-files-list', ['masina' => $masina, 'document' => $document])
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/masini-mementouri/edit.blade.php
+++ b/resources/views/masini-mementouri/edit.blade.php
@@ -15,97 +15,13 @@
         </div>
     </div>
 
-    <div class="card-body px-0 py-3">
-        @include('errors')
-
+    <div class="card-body px-0 py-4">
         <div class="mx-3">
-            <div class="row g-3">
-                @forelse ($masina->documente as $document)
-                    @php
-                        $labelKey = $document->document_type . ($document->tara ? ':' . $document->tara : '');
-                        $label = $uploadDocumentLabels[$labelKey] ?? \Illuminate\Support\Str::of($document->document_type)->headline();
-                    @endphp
-                    <div class="col-lg-6">
-                        <div class="card h-100 border border-secondary-subtle rounded-4"
-                             data-document-wrapper
-                             data-document-id="{{ $document->id }}"
-                             data-empty-label="Fără dată"
-                             data-color-holder
-                             data-base-class="card h-100 border border-secondary-subtle rounded-4">
-                            <div class="card-header d-flex justify-content-between align-items-center rounded-4">
-                                <span class="fw-semibold">{{ $label }}</span>
-                                <span class="badge bg-light text-dark border"
-                                      data-document-badge
-                                      data-empty-label="Fără dată">{{ optional($document->data_expirare)->isoFormat('DD.MM.YYYY') ?? 'Fără dată' }}</span>
-                            </div>
-                            <div class="card-body">
-                                <form method="POST"
-                                      action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}"
-                                      class="row g-3 mb-3"
-                                      data-document-update>
-                                    @csrf
-                                    @method('PATCH')
-                                    <div class="col-md-6">
-                                        <label class="form-label" for="data_expirare_{{ $document->id }}">Dată expirare</label>
-                                        <input type="date" class="form-control rounded-3" id="data_expirare_{{ $document->id }}" name="data_expirare"
-                                               value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
-                                    </div>
-                                    <div class="col-md-6">
-                                        <label class="form-label" for="email_notificare_{{ $document->id }}">Email alertă</label>
-                                        <input type="email" class="form-control rounded-3" id="email_notificare_{{ $document->id }}" name="email_notificare"
-                                               value="{{ old('email_notificare', $document->email_notificare) }}">
-                                    </div>
-                                    <div class="col-12 text-end">
-                                        <button type="submit" class="btn btn-primary border border-dark rounded-3">
-                                            <i class="fa-solid fa-floppy-disk me-1"></i>Salvează documentul
-                                        </button>
-                                    </div>
-                                </form>
-
-                                <form method="POST"
-                                      action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}"
-                                      enctype="multipart/form-data"
-                                      class="row g-2 align-items-end"
-                                      data-document-upload>
-                                    @csrf
-                                    <div class="col-md-8">
-                                        <label class="form-label" for="fisier_{{ $document->id }}">Încarcă fișier (PDF)</label>
-                                        <input type="file" class="form-control rounded-3" id="fisier_{{ $document->id }}" name="fisier" accept="application/pdf" required>
-                                    </div>
-                                    <div class="col-md-4">
-                                        <button type="submit" class="btn btn-success text-white border border-dark w-100 rounded-3">
-                                            <i class="fa-solid fa-upload me-1"></i>Încarcă
-                                        </button>
-                                    </div>
-                                </form>
-
-                                <hr>
-
-                                <div data-document-files>
-                                    @include('masini-mementouri.partials.document-files-list', ['masina' => $masina, 'document' => $document])
-                                </div>
-
-                                <div class="small mt-3" data-feedback-target hidden></div>
-                            </div>
-                        </div>
-                    </div>
-                @empty
-                    <div class="col-12">
-                        <div class="alert alert-info rounded-4 border border-info-subtle">
-                            Nu există documente definite pentru această mașină.
-                        </div>
-                    </div>
-                @endforelse
+            <div class="alert alert-info border border-info-subtle rounded-4">
+                Administrarea datelor și a documentelor pentru această mașină se face din pagina principală a mementourilor,
+                folosind link-urile din tabel pentru fiecare tip de document.
             </div>
         </div>
-</div>
+    </div>
 </div>
 @endsection
-
-@include('masini-mementouri.partials.document-form-scripts')
-
-@push('page-scripts')
-    <script>
-        window.MasiniMementouriDocuments?.initOnLoad();
-    </script>
-@endpush

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -2,53 +2,28 @@
 
 @push('page-styles')
     <style>
-        .expanded-row-wrapper {
-            background-color: #f8fafc;
-            border-radius: 1.25rem;
-            border: 1px solid rgba(0, 0, 0, 0.075);
-            padding: 1.5rem;
-            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
-            overflow: hidden;
-            max-height: 0;
-            opacity: 0;
-            transition: max-height 0.3s ease, opacity 0.25s ease;
-        }
-
-        .expanded-row-wrapper.is-visible {
-            max-height: 1200px;
-            opacity: 1;
-        }
-
-        .expanded-row-document {
-            border: 1px solid rgba(15, 23, 42, 0.12);
-            border-radius: 1rem;
-            background-color: #ffffff;
-            display: flex;
-            flex-direction: column;
-            height: 100%;
-        }
-
-        .expanded-row-document__header {
-            padding: 0.85rem 1.1rem;
-            border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-            display: flex;
-            justify-content: space-between;
+        .document-cell {
+            border-radius: 0.75rem;
+            display: inline-flex;
             align-items: center;
-            gap: 0.75rem;
+            justify-content: center;
+            min-width: 90px;
+            transition: transform 0.15s ease;
         }
 
-        .expanded-row-document__body {
-            padding: 1rem 1.1rem 1.25rem;
-            flex: 1;
-            display: flex;
-            flex-direction: column;
-            gap: 1rem;
+        .document-cell-link {
+            text-decoration: none;
         }
 
-        .expanded-row-document__files {
-            border-top: 1px dashed rgba(15, 23, 42, 0.12);
-            padding-top: 0.75rem;
-            margin-top: 0.25rem;
+        .document-cell-link:hover .document-cell {
+            transform: scale(1.02);
+        }
+
+        .document-cell-link--empty .document-cell {
+            background-color: transparent !important;
+            border: 1px dashed var(--bs-primary);
+            color: var(--bs-primary) !important;
+            text-decoration: underline;
         }
     </style>
 @endpush
@@ -71,24 +46,28 @@
     <div class="card-body px-0 py-3">
         @include('errors')
 
+        @if (session('status'))
+            <div class="alert alert-success border border-success-subtle rounded-4 mx-3">
+                {{ session('status') }}
+            </div>
+        @endif
+
         @php
-            $columnCount = 5 + count($gridDocumentTypes) + count($vignetteCountries);
-            $today = now()->format('Y-m-d');
+            $columnCount = 2 + count($gridDocumentTypes) + count($vignetteCountries) + 1;
         @endphp
+
         <div class="table-responsive rounded">
             <table class="table table-striped table-hover align-middle mb-0">
                 <thead class="text-white rounded culoare2">
                     <tr>
                         <th>#</th>
                         <th>Număr auto</th>
-                        <th>Descriere</th>
                         @foreach ($gridDocumentTypes as $label)
                             <th class="text-center">{{ $label }}</th>
                         @endforeach
                         @foreach ($vignetteCountries as $code => $label)
                             <th class="text-center">Vignetă {{ $label }}</th>
                         @endforeach
-                        <th class="text-center">Documente</th>
                         <th class="text-end">Acțiuni</th>
                     </tr>
                 </thead>
@@ -100,138 +79,68 @@
                         <tr>
                             <td>{{ $loop->iteration }}</td>
                             <td class="fw-semibold">
-                                <button type="button" class="btn btn-link p-0 align-baseline text-decoration-none fw-semibold" data-action="edit-masina" data-masina-id="{{ $masina->id }}">
+                                <button type="button" class="btn btn-link p-0 align-baseline text-decoration-none fw-semibold"
+                                        data-action="edit-masina" data-masina-id="{{ $masina->id }}">
                                     {{ $masina->numar_inmatriculare }}
                                 </button>
                             </td>
-                            <td>{{ $masina->descriere }}</td>
                             @foreach ($gridDocumentTypes as $type => $label)
                                 @php
                                     $document = $documents->get($type);
                                     $displayDate = optional($document?->data_expirare)->format('d.m.Y') ?? 'N/A';
                                     $colorClass = $document?->colorClass() ?? 'bg-secondary-subtle text-body-secondary';
-                                    $ariaLabel = "Editează {$label} pentru {$masina->numar_inmatriculare}";
+                                    $isEmpty = !$document?->data_expirare;
+                                    $ariaLabel = "Actualizează {$label} pentru {$masina->numar_inmatriculare}";
                                 @endphp
                                 <td class="text-center">
-                                    <a href="{{ route('masini-mementouri.edit', $masina) }}"
-                                       class="d-inline-flex w-100 justify-content-center text-decoration-none text-reset"
-                                       aria-label="{{ $ariaLabel }}">
-                                        <span class="document-cell rounded-3 px-2 py-2 text-center d-inline-flex justify-content-center align-items-center w-100 {{ $colorClass }}">
-                                            {{ $displayDate }}
-                                        </span>
-                                    </a>
+                                    @if ($document)
+                                        <a href="{{ route('masini-mementouri.documente.edit', [$masina, $document]) }}"
+                                           class="document-cell-link d-inline-flex w-100 justify-content-center {{ $isEmpty ? 'document-cell-link--empty' : '' }}"
+                                           aria-label="{{ $ariaLabel }}">
+                                            <span class="document-cell px-2 py-2 w-100 {{ $colorClass }}">
+                                                {{ $displayDate }}
+                                            </span>
+                                        </a>
+                                    @else
+                                        <span class="document-cell px-2 py-2 w-100 bg-secondary-subtle text-body-secondary">N/A</span>
+                                    @endif
                                 </td>
                             @endforeach
                             @foreach ($vignetteCountries as $code => $label)
                                 @php
-                                    $document = $documents->get(\App\Models\Masini\MasinaDocument::TYPE_VIGNETA . ':' . $code);
+                                    $documentKey = \App\Models\Masini\MasinaDocument::TYPE_VIGNETA . ':' . $code;
+                                    $document = $documents->get($documentKey);
                                     $displayDate = optional($document?->data_expirare)->format('d.m.Y') ?? 'N/A';
                                     $colorClass = $document?->colorClass() ?? 'bg-secondary-subtle text-body-secondary';
-                                    $ariaLabel = "Editează Vignetă {$label} pentru {$masina->numar_inmatriculare}";
+                                    $isEmpty = !$document?->data_expirare;
+                                    $ariaLabel = "Actualizează Vignetă {$label} pentru {$masina->numar_inmatriculare}";
                                 @endphp
                                 <td class="text-center">
-                                    <a href="{{ route('masini-mementouri.edit', $masina) }}"
-                                       class="d-inline-flex w-100 justify-content-center text-decoration-none text-reset"
-                                       aria-label="{{ $ariaLabel }}">
-                                        <span class="document-cell rounded-3 px-2 py-2 text-center d-inline-flex justify-content-center align-items-center w-100 {{ $colorClass }}">
-                                            {{ $displayDate }}
-                                        </span>
-                                    </a>
+                                    @if ($document)
+                                        <a href="{{ route('masini-mementouri.documente.edit', [$masina, $document]) }}"
+                                           class="document-cell-link d-inline-flex w-100 justify-content-center {{ $isEmpty ? 'document-cell-link--empty' : '' }}"
+                                           aria-label="{{ $ariaLabel }}">
+                                            <span class="document-cell px-2 py-2 w-100 {{ $colorClass }}">
+                                                {{ $displayDate }}
+                                            </span>
+                                        </a>
+                                    @else
+                                        <span class="document-cell px-2 py-2 w-100 bg-secondary-subtle text-body-secondary">N/A</span>
+                                    @endif
                                 </td>
                             @endforeach
-                            <td class="text-center">
-                                <a href="{{ route('masini-mementouri.show', $masina) }}" class="btn btn-sm btn-outline-primary border border-dark rounded-3">
-                                    <i class="fa-solid fa-file-lines me-1"></i>Documente
-                                </a>
-                            </td>
                             <td class="text-end">
                                 <div class="d-inline-flex gap-2 justify-content-end">
-                                    <button type="button" class="badge bg-primary border-0" data-toggle-row data-masina-id="{{ $masina->id }}" aria-expanded="false">
-                                        Editează
+                                    <button type="button" class="btn btn-sm btn-outline-primary border border-dark rounded-3"
+                                            data-action="edit-masina" data-masina-id="{{ $masina->id }}">
+                                        <i class="fa-solid fa-pen-to-square me-1"></i>Editează
                                     </button>
-                                    <form method="POST" action="{{ route('masini-mementouri.destroy', $masina) }}" onsubmit="return confirm('Sigur dorești să ștergi această mașină?');">
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="badge bg-danger border-0">Șterge</button>
-                                    </form>
-                                </div>
-                            </td>
-                        </tr>
-                        <tr class="expanded-row" data-expanded-row="{{ $masina->id }}" style="display: none;">
-                            <td colspan="{{ $columnCount }}" class="border-top-0">
-                                <div class="expanded-row-wrapper" data-expanded-row-content>
-                                    <div class="d-flex flex-column flex-lg-row gap-3 align-items-lg-center mb-3">
-                                        <div class="flex-grow-1">
-                                            <label class="form-label mb-1" for="expanded_reference_date_{{ $masina->id }}">Dată de referință</label>
-                                            <input type="date" id="expanded_reference_date_{{ $masina->id }}" class="form-control form-control-sm rounded-3"
-                                                   value="{{ $today }}" data-master-date data-masina-id="{{ $masina->id }}">
-                                            <div class="form-text">Folosește această dată pentru a completa rapid câmpurile goale.</div>
-                                        </div>
-                                        <div class="text-lg-end">
-                                            <a href="{{ route('masini-mementouri.show', $masina) }}" class="btn btn-outline-secondary border border-dark rounded-3">
-                                                <i class="fa-solid fa-up-right-from-square me-1"></i>Vezi pagina completă
-                                            </a>
-                                        </div>
-                                    </div>
-
-                                    <div class="row g-3">
-                                        @foreach ($masina->documente as $document)
-                                            @php
-                                                $documentKey = $document->document_type . ($document->tara ? ':' . $document->tara : '');
-                                                $documentLabel = $uploadDocumentLabels[$documentKey] ?? ($gridDocumentTypes[$document->document_type] ?? $document->document_type);
-                                                $documentDateValue = optional($document->data_expirare)->format('Y-m-d');
-                                            @endphp
-                                            <div class="col-xl-4 col-lg-6">
-                                                <div class="expanded-row-document" data-document-wrapper data-document-id="{{ $document->id }}" data-empty-label="Fără dată">
-                                                    <div class="expanded-row-document__header">
-                                                        <span class="fw-semibold">{{ $documentLabel }}</span>
-                                                        <span class="badge text-bg-light text-dark border" data-document-badge data-empty-label="Fără dată">{{ optional($document->data_expirare)->isoFormat('DD.MM.YYYY') ?? 'Fără dată' }}</span>
-                                                    </div>
-                                                    <div class="expanded-row-document__body">
-                                                        <div class="document-feedback small" data-feedback-target hidden></div>
-
-                                                        <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}" class="row g-2 align-items-end" data-document-update>
-                                                            @csrf
-                                                            @method('PATCH')
-                                                            <div class="col-12">
-                                                                <label class="form-label" for="document_expiration_{{ $document->id }}">Dată expirare</label>
-                                                                <input type="date" class="form-control form-control-sm" id="document_expiration_{{ $document->id }}" name="data_expirare" data-date-input
-                                                                       value="{{ $documentDateValue ?? $today }}" data-sync-target="{{ $masina->id }}">
-                                                            </div>
-                                                            <div class="col-12">
-                                                                <label class="form-label" for="document_email_{{ $document->id }}">Email alertă</label>
-                                                                <input type="email" class="form-control form-control-sm" id="document_email_{{ $document->id }}" name="email_notificare"
-                                                                       value="{{ $document->email_notificare }}">
-                                                            </div>
-                                                            <div class="col-12 text-end">
-                                                                <button type="submit" class="btn btn-sm btn-outline-primary border border-dark rounded-3">
-                                                                    <i class="fa-solid fa-floppy-disk me-1"></i>Salvează
-                                                                </button>
-                                                            </div>
-                                                        </form>
-
-                                                        <form method="POST" action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}" enctype="multipart/form-data" class="row g-2 align-items-end" data-document-upload>
-                                                            @csrf
-                                                            <div class="col-12">
-                                                                <label class="form-label" for="document_file_{{ $document->id }}">Adaugă document (PDF)</label>
-                                                                <input type="file" class="form-control form-control-sm" id="document_file_{{ $document->id }}" name="fisier" accept="application/pdf" required>
-                                                            </div>
-                                                            <div class="col-12 text-end">
-                                                                <button type="submit" class="btn btn-sm btn-success text-white border border-dark rounded-3">
-                                                                    <i class="fa-solid fa-upload me-1"></i>Încarcă
-                                                                </button>
-                                                            </div>
-                                                        </form>
-
-                                                        <div class="expanded-row-document__files" data-document-files>
-                                                            <p class="fw-semibold small mb-2">Fișiere existente</p>
-                                                            @include('masini-mementouri.partials.document-files-list', ['masina' => $masina, 'document' => $document])
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        @endforeach
-                                    </div>
+                                    <button type="button" class="btn btn-sm btn-outline-danger border border-dark rounded-3"
+                                            data-bs-toggle="modal" data-bs-target="#deleteMasinaModal"
+                                            data-delete-url="{{ route('masini-mementouri.destroy', $masina) }}"
+                                            data-masina-name="{{ $masina->numar_inmatriculare }}">
+                                        <i class="fa-solid fa-trash me-1"></i>Șterge
+                                    </button>
                                 </div>
                             </td>
                         </tr>
@@ -245,6 +154,7 @@
         </div>
     </div>
 </div>
+
 <div class="modal fade" id="masinaModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <form method="POST" class="modal-content rounded-4" data-store-url="{{ route('masini-mementouri.store') }}">
@@ -287,222 +197,151 @@
         </form>
     </div>
 </div>
+
+<div class="modal fade" id="deleteMasinaModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <form method="POST" class="modal-content rounded-4 border-0 shadow">
+            @csrf
+            @method('DELETE')
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title">Ștergere mașină</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Închide"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0">Ești sigur că vrei să ștergi mașina <strong data-delete-name></strong>?</p>
+            </div>
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-outline-secondary border border-dark" data-bs-dismiss="modal">Renunță</button>
+                <button type="submit" class="btn btn-danger border border-dark">
+                    <i class="fa-solid fa-trash me-1"></i>Șterge
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
 @endsection
 
-@include('masini-mementouri.partials.document-form-scripts')
-
 @push('page-scripts')
-<script>
-    document.addEventListener('DOMContentLoaded', () => {
-        const modalData = @json($masiniModalData);
-        const defaultEmail = 'masecoexpres@gmail.com';
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const modalData = @json($masiniModalData);
+            const defaultEmail = 'masecoexpres@gmail.com';
+            const modalElement = document.getElementById('masinaModal');
 
-        const modalElement = document.getElementById('masinaModal');
-        const bootstrapModal = modalElement && typeof bootstrap !== 'undefined'
-            ? new bootstrap.Modal(modalElement)
-            : null;
+            if (modalElement && typeof bootstrap !== 'undefined') {
+                const bootstrapModal = new bootstrap.Modal(modalElement);
+                const form = modalElement.querySelector('form');
+                const methodInput = form.querySelector('[data-method-input]');
+                const modalOriginInput = form.querySelector('[data-modal-origin]');
+                const modalMasinaIdInput = form.querySelector('[data-modal-masina-id]');
+                const titleElement = modalElement.querySelector('[data-modal-title]');
+                const submitButton = form.querySelector('[data-submit-button]');
+                const submitIcon = submitButton.querySelector('[data-submit-icon]');
+                const submitText = submitButton.querySelector('[data-submit-text]');
+                const storeUrl = form.dataset.storeUrl;
 
-        const expandedState = {
-            id: null,
-            button: null,
-        };
-
-        const hideExpandedRow = (row) => {
-            if (!row) {
-                return;
-            }
-
-            const content = row.querySelector('[data-expanded-row-content]');
-            if (content) {
-                content.classList.remove('is-visible');
-                const handleTransitionEnd = () => {
-                    row.style.display = 'none';
-                    content.removeEventListener('transitionend', handleTransitionEnd);
+                const inputs = {
+                    numar_inmatriculare: form.querySelector('input[name="numar_inmatriculare"]'),
+                    descriere: form.querySelector('input[name="descriere"]'),
+                    email_notificari: form.querySelector('input[name="email_notificari"]'),
+                    observatii: form.querySelector('textarea[name="observatii"]'),
                 };
-                content.addEventListener('transitionend', handleTransitionEnd);
-            } else {
-                row.style.display = 'none';
+
+                const setMethod = (method = null) => {
+                    if (method) {
+                        methodInput.name = '_method';
+                        methodInput.value = method;
+                    } else {
+                        methodInput.removeAttribute('name');
+                        methodInput.value = '';
+                    }
+                };
+
+                const fillForm = (values = {}) => {
+                    inputs.numar_inmatriculare.value = values.numar_inmatriculare ?? '';
+                    inputs.descriere.value = values.descriere ?? '';
+                    inputs.email_notificari.value = values.email_notificari ?? defaultEmail;
+                    inputs.observatii.value = values.observatii ?? '';
+                };
+
+                const openCreateModal = () => {
+                    form.action = storeUrl;
+                    setMethod(null);
+                    modalOriginInput.value = 'create';
+                    modalMasinaIdInput.value = '';
+                    titleElement.textContent = 'Adaugă mașină';
+                    submitIcon.className = 'fa-solid fa-plus me-1';
+                    submitText.textContent = 'Adaugă mașina';
+                    fillForm({ email_notificari: defaultEmail });
+                    bootstrapModal.show();
+                };
+
+                const openEditModal = (id) => {
+                    const data = modalData[id];
+                    if (!data) {
+                        return;
+                    }
+
+                    form.action = data.update_url;
+                    setMethod('PUT');
+                    modalOriginInput.value = 'edit';
+                    modalMasinaIdInput.value = id;
+                    titleElement.textContent = 'Editează mașina';
+                    submitIcon.className = 'fa-solid fa-floppy-disk me-1';
+                    submitText.textContent = 'Salvează modificările';
+                    fillForm(data);
+                    bootstrapModal.show();
+                };
+
+                document.querySelectorAll('[data-action="add-masina"]').forEach((button) => {
+                    button.addEventListener('click', () => {
+                        openCreateModal();
+                    });
+                });
+
+                document.querySelectorAll('[data-action="edit-masina"]').forEach((button) => {
+                    button.addEventListener('click', () => {
+                        const id = button.dataset.masinaId;
+                        openEditModal(id);
+                    });
+                });
+
+                const oldOrigin = @json(old('modal_origin'));
+                const oldMasinaId = @json(old('modal_masina_id'));
+                const oldValues = {
+                    numar_inmatriculare: @json(old('numar_inmatriculare')),
+                    descriere: @json(old('descriere')),
+                    email_notificari: @json(old('email_notificari')),
+                    observatii: @json(old('observatii')),
+                };
+
+                if (oldOrigin) {
+                    if (oldOrigin === 'create') {
+                        openCreateModal();
+                        fillForm(oldValues);
+                    } else if (oldOrigin === 'edit' && oldMasinaId) {
+                        openEditModal(oldMasinaId);
+                        fillForm(oldValues);
+                    }
+                }
             }
-        };
 
-        const showExpandedRow = (row) => {
-            if (!row) {
-                return;
-            }
+            const deleteModalElement = document.getElementById('deleteMasinaModal');
+            if (deleteModalElement && typeof bootstrap !== 'undefined') {
+                deleteModalElement.addEventListener('show.bs.modal', (event) => {
+                    const button = event.relatedTarget;
+                    const form = deleteModalElement.querySelector('form');
+                    const nameHolder = deleteModalElement.querySelector('[data-delete-name]');
 
-            const content = row.querySelector('[data-expanded-row-content]');
-            row.style.display = 'table-row';
+                    if (form) {
+                        form.action = button?.dataset.deleteUrl ?? '';
+                    }
 
-            requestAnimationFrame(() => {
-                if (content) {
-                    content.classList.add('is-visible');
-                }
-            });
-        };
-
-        document.querySelectorAll('[data-toggle-row]').forEach((button) => {
-            button.addEventListener('click', () => {
-                const id = button.dataset.masinaId;
-                const row = document.querySelector(`[data-expanded-row="${id}"]`);
-
-                if (!row) {
-                    return;
-                }
-
-                const isCurrent = expandedState.id === id;
-
-                if (expandedState.button) {
-                    expandedState.button.setAttribute('aria-expanded', 'false');
-                }
-
-                if (expandedState.id && expandedState.id !== id) {
-                    const previousRow = document.querySelector(`[data-expanded-row="${expandedState.id}"]`);
-                    hideExpandedRow(previousRow);
-                }
-
-                if (isCurrent) {
-                    hideExpandedRow(row);
-                    expandedState.id = null;
-                    expandedState.button = null;
-                    button.setAttribute('aria-expanded', 'false');
-                } else {
-                    showExpandedRow(row);
-                    expandedState.id = id;
-                    expandedState.button = button;
-                    button.setAttribute('aria-expanded', 'true');
-                }
-            });
-        });
-
-        document.querySelectorAll('[data-master-date]').forEach((input) => {
-            const masinaId = input.dataset.masinaId;
-            input.addEventListener('change', () => {
-                document.querySelectorAll(`[data-sync-target="${masinaId}"]`).forEach((target) => {
-                    if (target.dataset.syncEmpty === 'true') {
-                        target.value = input.value;
-                        target.dispatchEvent(new Event('input', { bubbles: true }));
+                    if (nameHolder) {
+                        nameHolder.textContent = button?.dataset.masinaName ?? '';
                     }
                 });
-            });
-        });
-
-        document.querySelectorAll('[data-sync-target]').forEach((input) => {
-            input.dataset.syncEmpty = input.value ? 'false' : 'true';
-
-            input.addEventListener('input', () => {
-                input.dataset.syncEmpty = input.value ? 'false' : 'true';
-            });
-        });
-
-        if (modalElement && bootstrapModal) {
-            const form = modalElement.querySelector('form');
-            const methodInput = form.querySelector('[data-method-input]');
-            const modalOriginInput = form.querySelector('[data-modal-origin]');
-            const modalMasinaIdInput = form.querySelector('[data-modal-masina-id]');
-            const titleElement = modalElement.querySelector('[data-modal-title]');
-            const submitButton = form.querySelector('[data-submit-button]');
-            const submitIcon = submitButton.querySelector('[data-submit-icon]');
-            const submitText = submitButton.querySelector('[data-submit-text]');
-            const storeUrl = form.dataset.storeUrl;
-
-            const inputs = {
-                numar_inmatriculare: form.querySelector('input[name="numar_inmatriculare"]'),
-                descriere: form.querySelector('input[name="descriere"]'),
-                email_notificari: form.querySelector('input[name="email_notificari"]'),
-                observatii: form.querySelector('textarea[name="observatii"]'),
-            };
-
-            const setMethod = (method = null) => {
-                if (method) {
-                    methodInput.name = '_method';
-                    methodInput.value = method;
-                } else {
-                    methodInput.removeAttribute('name');
-                    methodInput.value = '';
-                }
-            };
-
-            const fillForm = (values = {}) => {
-                inputs.numar_inmatriculare.value = values.numar_inmatriculare ?? '';
-                inputs.descriere.value = values.descriere ?? '';
-                inputs.email_notificari.value = values.email_notificari ?? defaultEmail;
-                inputs.observatii.value = values.observatii ?? '';
-            };
-
-            const openCreateModal = () => {
-                form.action = storeUrl;
-                setMethod(null);
-                modalOriginInput.value = 'create';
-                modalMasinaIdInput.value = '';
-                titleElement.textContent = 'Adaugă mașină';
-                submitIcon.className = 'fa-solid fa-plus me-1';
-                submitText.textContent = 'Adaugă mașina';
-                fillForm({ email_notificari: defaultEmail });
-                bootstrapModal.show();
-            };
-
-            const openEditModal = (id) => {
-                const data = modalData[id];
-                if (!data) {
-                    return;
-                }
-
-                form.action = data.update_url;
-                setMethod('PUT');
-                modalOriginInput.value = 'edit';
-                modalMasinaIdInput.value = id;
-                titleElement.textContent = 'Editează mașina';
-                submitIcon.className = 'fa-solid fa-floppy-disk me-1';
-                submitText.textContent = 'Salvează modificările';
-                fillForm(data);
-                bootstrapModal.show();
-            };
-
-            document.querySelectorAll('[data-action="add-masina"]').forEach((button) => {
-                button.addEventListener('click', () => {
-                    openCreateModal();
-                });
-            });
-
-            document.querySelectorAll('[data-action="edit-masina"]').forEach((button) => {
-                button.addEventListener('click', () => {
-                    const id = button.dataset.masinaId;
-                    openEditModal(id);
-                });
-            });
-
-            const oldOrigin = @json(old('modal_origin'));
-            const oldMasinaId = @json(old('modal_masina_id'));
-            const oldValues = {
-                numar_inmatriculare: @json(old('numar_inmatriculare')),
-                descriere: @json(old('descriere')),
-                email_notificari: @json(old('email_notificari')),
-                observatii: @json(old('observatii')),
-            };
-
-            if (oldOrigin) {
-                if (oldOrigin === 'create') {
-                    openCreateModal();
-                    fillForm(oldValues);
-                } else if (oldOrigin === 'edit' && oldMasinaId) {
-                    openEditModal(oldMasinaId);
-                    fillForm(oldValues);
-                }
             }
-        }
-
-        const documentUtilities = window.MasiniMementouriDocuments;
-
-        if (!documentUtilities) {
-            console.error('Modulele pentru formularele documentelor nu au fost încărcate.');
-            return;
-        }
-
-        const {
-            initializeDocumentForms,
-        } = documentUtilities;
-
-        initializeDocumentForms();
-    });
-</script>
+        });
+    </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -223,6 +223,8 @@ Route::middleware(['auth'])->group(function () {
             ->parameters(['masini-mementouri' => 'masini_mementouri']);
 
         Route::scopeBindings()->group(function () {
+            Route::get('masini-mementouri/{masini_mementouri}/documente/{document}', [MasiniDocumentController::class, 'edit'])
+                ->name('masini-mementouri.documente.edit');
             Route::patch('masini-mementouri/{masini_mementouri}/documente/{document}', [MasiniDocumentController::class, 'update'])
                 ->name('masini-mementouri.documente.update');
             Route::post('masini-mementouri/{masini_mementouri}/documente/{document}/fisiere', [MasiniDocumentFisierController::class, 'store'])


### PR DESCRIPTION
## Summary
- replace inline document editing on the masini mementouri listing with links that open a dedicated edit page per document
- add the new document edit page with forms for updating the expiry date and managing attachments
- simplify the listing table, add a confirmation modal for deletions, and remove the unused edit page content

## Testing
- `php artisan test` *(fails: vendor directory is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_6901bd538b2083268be81d91f83032ff