### PR TITLE
Fix masini mementouri document links and actions

### DIFF
--- a/app/Http/Controllers/Masini/MasiniDocumentController.php
+++ b/app/Http/Controllers/Masini/MasiniDocumentController.php
@@ -15,8 +15,10 @@ use Illuminate\View\View;
 
 class MasiniDocumentController extends Controller
 {
-    public function edit(Masina $masina, MasinaDocument|string|int $document): View
+    public function edit(Masina $masini_mementouri, MasinaDocument|string|int $document): View
     {
+        $masina = $masini_mementouri;
+
         $document = $this->resolveDocument($masina, $document);
 
         abort_unless($document->masina_id === $masina->id, 404);
@@ -30,8 +32,10 @@ class MasiniDocumentController extends Controller
         ]);
     }
 
-    public function update(Request $request, Masina $masina, MasinaDocument|string|int $document): JsonResponse|RedirectResponse
+    public function update(Request $request, Masina $masini_mementouri, MasinaDocument|string|int $document): JsonResponse|RedirectResponse
     {
+        $masina = $masini_mementouri;
+
         $document = $this->resolveDocument($masina, $document);
 
         abort_unless($document->masina_id === $masina->id, 404);
@@ -78,12 +82,12 @@ class MasiniDocumentController extends Controller
         return Redirect::back()->with('status', 'Documentul a fost actualizat.');
     }
 
-    protected function resolveDocument(Masina $masina, MasinaDocument|string|int $document): MasinaDocument
+    protected function resolveDocument(Masina $masini_mementouri, MasinaDocument|string|int $document): MasinaDocument
     {
         if ($document instanceof MasinaDocument) {
             return $document;
         }
 
-        return MasinaDocument::resolveForMasina($masina, $document);
+        return MasinaDocument::resolveForMasina($masini_mementouri, $document);
     }
 }

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -125,10 +125,6 @@
                             @endforeach
                             <td class="text-end">
                                 <div class="d-inline-flex gap-2 justify-content-end">
-                                    <button type="button" class="btn btn-sm btn-outline-primary border border-dark rounded-3"
-                                            data-action="edit-masina" data-masina-id="{{ $masina->id }}">
-                                        <i class="fa-solid fa-pen-to-square me-1"></i>Editează
-                                    </button>
                                     <button type="button" class="btn btn-sm btn-outline-danger border border-dark rounded-3"
                                             data-bs-toggle="modal" data-bs-target="#deleteMasinaModal"
                                             data-delete-url="{{ route('masini-mementouri.destroy', $masina) }}"


### PR DESCRIPTION
## Summary
- ensure the masini mementouri document routes resolve the parent masina binding correctly
- remove the unused edit action button from the masini mementouri listing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901e55b4f6883269f729f1d7de6ed80