### PR TITLE
Fix status message rendering on masini mementouri index

### DIFF
--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -48,15 +48,13 @@
 
         @php($statusMessage = session('status') ?? session('success'))
 
-        @if ($statusMessage)
+        @if (filled($statusMessage))
             <div class="alert alert-success border border-success-subtle rounded-4 mx-3">
                 {{ $statusMessage }}
             </div>
         @endif
 
-        @php
-            $columnCount = 2 + count($gridDocumentTypes) + count($vignetteCountries) + 1;
-        @endphp
+        @php($columnCount = 2 + count($gridDocumentTypes) + count($vignetteCountries) + 1)
 
         <div class="table-responsive rounded">
             <table class="table table-striped table-hover align-middle mb-0">


### PR DESCRIPTION
## Summary
- ensure the masini mementouri index view only renders the status alert when there is a message
- compute the grid column count with a single-line Blade directive to avoid leaking PHP tags in the markup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901eca571188326960445fc6e2bf9e0