### PR TITLE
Wrap Blade assignments in Masini Mementouri view

### DIFF
--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -46,9 +46,11 @@
     <div class="card-body px-0 py-3">
         @include('errors', ['showSessionAlerts' => false])
 
-        @php($statusMessage = session('status') ?? session('success'))
+        @php
+            $statusMessage = session('status') ?? session('success');
+        @endphp
 
-        @if ($statusMessage)
+        @if (filled($statusMessage))
             <div class="alert alert-success border border-success-subtle rounded-4 mx-3">
                 {{ $statusMessage }}
             </div>


### PR DESCRIPTION
## Summary
- replace inline @php(...) directives with block form in the masini mementouri index view to avoid syntax errors in some environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901eca571188326960445fc6e2bf9e0