### PR TITLE
Reduce masini mementouri table row height

### DIFF
--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -61,7 +61,7 @@
         @endphp
 
         <div class="table-responsive rounded">
-            <table class="table table-striped table-hover align-middle mb-0">
+            <table class="table table-striped table-hover align-middle table-sm mb-0">
                 <thead class="text-white rounded culoare2">
                     <tr>
                         <th>#</th>
@@ -101,7 +101,7 @@
                                     <a href="{{ route('masini-mementouri.documente.edit', [$masina, $routeDocumentParam]) }}"
                                        class="document-cell-link d-inline-flex w-100 justify-content-center {{ $isEmpty ? 'document-cell-link--empty' : '' }}"
                                        aria-label="{{ $ariaLabel }}">
-                                        <span class="document-cell px-2 py-2 w-100 {{ $colorClass }}">
+                                        <span class="document-cell px-2 py-1 w-100 {{ $colorClass }}">
                                             {{ $displayDate }}
                                         </span>
                                     </a>
@@ -121,7 +121,7 @@
                                     <a href="{{ route('masini-mementouri.documente.edit', [$masina, $routeDocumentParam]) }}"
                                        class="document-cell-link d-inline-flex w-100 justify-content-center {{ $isEmpty ? 'document-cell-link--empty' : '' }}"
                                        aria-label="{{ $ariaLabel }}">
-                                        <span class="document-cell px-2 py-2 w-100 {{ $colorClass }}">
+                                        <span class="document-cell px-2 py-1 w-100 {{ $colorClass }}">
                                             {{ $displayDate }}
                                         </span>
                                     </a>


### PR DESCRIPTION
## Summary
- apply the compact Bootstrap styling to the masini-mementouri table
- decrease the padding inside document cells to shrink each row's height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901f3a659708326b4dc85a3aee1fcbd