### PR TITLE
Add Brennero column and extra vehicle metadata to mementouri

### DIFF
--- a/app/Http/Controllers/Masini/MasiniMementoController.php
+++ b/app/Http/Controllers/Masini/MasiniMementoController.php
@@ -33,6 +33,8 @@ class MasiniMementoController extends Controller
                         'id' => $masina->id,
                         'numar_inmatriculare' => $masina->numar_inmatriculare,
                         'descriere' => $masina->descriere,
+                        'marca_masina' => $masina->marca_masina,
+                        'serie_sasiu' => $masina->serie_sasiu,
                         'email_notificari' => optional($masina->memento)->email_notificari,
                         'observatii' => optional($masina->memento)->observatii,
                         'update_url' => route('masini-mementouri.update', $masina),
@@ -54,11 +56,18 @@ class MasiniMementoController extends Controller
         $validated = $request->validate([
             'numar_inmatriculare' => ['required', 'string', 'max:50', 'unique:masini,numar_inmatriculare'],
             'descriere' => ['nullable', 'string', 'max:255'],
+            'marca_masina' => ['nullable', 'string', 'max:255'],
+            'serie_sasiu' => ['nullable', 'string', 'max:255'],
             'email_notificari' => ['nullable', 'email:rfc'],
             'observatii' => ['nullable', 'string'],
         ]);
 
-        $masina = Masina::create(Arr::only($validated, ['numar_inmatriculare', 'descriere']));
+        $masina = Masina::create(Arr::only($validated, [
+            'numar_inmatriculare',
+            'descriere',
+            'marca_masina',
+            'serie_sasiu',
+        ]));
 
         $masina->memento?->update(Arr::only($validated, ['email_notificari', 'observatii']));
 
@@ -96,11 +105,18 @@ class MasiniMementoController extends Controller
         $validated = $request->validate([
             'numar_inmatriculare' => ['required', 'string', 'max:50', Rule::unique('masini', 'numar_inmatriculare')->ignore($masini_mementouri->id)],
             'descriere' => ['nullable', 'string', 'max:255'],
+            'marca_masina' => ['nullable', 'string', 'max:255'],
+            'serie_sasiu' => ['nullable', 'string', 'max:255'],
             'email_notificari' => ['nullable', 'email:rfc'],
             'observatii' => ['nullable', 'string'],
         ]);
 
-        $masini_mementouri->update(Arr::only($validated, ['numar_inmatriculare', 'descriere']));
+        $masini_mementouri->update(Arr::only($validated, [
+            'numar_inmatriculare',
+            'descriere',
+            'marca_masina',
+            'serie_sasiu',
+        ]));
         $masini_mementouri->memento?->update(Arr::only($validated, ['email_notificari', 'observatii']));
 
         $redirect = $request->input('redirect');

--- a/app/Models/Masini/Masina.php
+++ b/app/Models/Masini/Masina.php
@@ -14,6 +14,8 @@ class Masina extends Model
     protected $fillable = [
         'numar_inmatriculare',
         'descriere',
+        'marca_masina',
+        'serie_sasiu',
     ];
 
     public function memento()

--- a/app/Models/Masini/MasinaDocument.php
+++ b/app/Models/Masini/MasinaDocument.php
@@ -142,6 +142,7 @@ class MasinaDocument extends Model
             self::TYPE_ITP => 'ITP',
             self::TYPE_RCA => 'RCA',
             self::TYPE_COPIE_CONFORMA => 'Copie conformă',
+            self::TYPE_ASIGURARE_CMR => 'Asigurare CMR',
         ];
     }
 
@@ -151,6 +152,7 @@ class MasinaDocument extends Model
             'ro' => 'RO',
             'hu' => 'HU',
             'at' => 'AT',
+            'brennero' => 'Brennero',
             'cz' => 'CZ',
             'sk' => 'SK',
         ];

--- a/database/factories/Masini/MasinaFactory.php
+++ b/database/factories/Masini/MasinaFactory.php
@@ -17,6 +17,8 @@ class MasinaFactory extends Factory
         return [
             'numar_inmatriculare' => strtoupper($this->faker->bothify('??##???')),
             'descriere' => $this->faker->optional()->sentence(3),
+            'marca_masina' => $this->faker->optional()->company(),
+            'serie_sasiu' => $this->faker->optional()->regexify('[A-HJ-NPR-Z0-9]{17}'),
         ];
     }
 }

--- a/database/migrations/2025_03_24_020000_add_vehicle_details_to_masini_table.php
+++ b/database/migrations/2025_03_24_020000_add_vehicle_details_to_masini_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Masini\Masina;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('masini', function (Blueprint $table) {
+            $table->string('marca_masina')->nullable()->after('descriere');
+            $table->string('serie_sasiu')->nullable()->after('marca_masina');
+        });
+
+        Masina::query()->each(function (Masina $masina): void {
+            $masina->syncDefaultDocuments();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('masini', function (Blueprint $table) {
+            $table->dropColumn(['marca_masina', 'serie_sasiu']);
+        });
+    }
+};

--- a/resources/views/masini-mementouri/document-edit.blade.php
+++ b/resources/views/masini-mementouri/document-edit.blade.php
@@ -34,36 +34,7 @@
                 <div class="col-xl-6 col-lg-7">
                     <div class="card border border-secondary-subtle rounded-4 h-100">
                         <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
-                            <span class="fw-semibold">Actualizează data expirării</span>
-                        </div>
-                        <div class="card-body">
-                            <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}">
-                                @csrf
-                                @method('PATCH')
-
-                                <div class="mb-3">
-                                    <label class="form-label" for="data_expirare">Dată expirare</label>
-                                    <input type="date"
-                                           id="data_expirare"
-                                           name="data_expirare"
-                                           class="form-control rounded-3"
-                                           value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
-                                </div>
-
-                                <div class="text-end">
-                                    <button type="submit" class="btn btn-primary border border-dark rounded-3">
-                                        <i class="fa-solid fa-floppy-disk me-1"></i>Salvează data
-                                    </button>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="col-xl-6 col-lg-7">
-                    <div class="card border border-secondary-subtle rounded-4 h-100">
-                        <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
-                            <span class="fw-semibold">Încarcă documente (PDF)</span>
+                            <span class="fw-semibold">Actualizează documentul</span>
                         </div>
                         <div class="card-body">
                             <form method="POST"
@@ -72,14 +43,24 @@
                                 @csrf
 
                                 <div class="mb-3">
-                                    <label class="form-label" for="fisier">Selectează fișiere</label>
+                                    <label class="form-label" for="data_expirare">Dată expirare</label>
+                                    <input type="date"
+                                           id="data_expirare"
+                                           name="data_expirare"
+                                           class="form-control rounded-3"
+                                           value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
+                                    <small class="text-muted">Modificarea datei necesită încărcarea unui fișier în același timp.</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label class="form-label" for="fisier">Selectează fișiere (PDF)</label>
                                     <input type="file" id="fisier" name="fisier[]" class="form-control rounded-3"
                                            accept="application/pdf" multiple required>
                                 </div>
 
                                 <div class="text-end">
                                     <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
-                                        <i class="fa-solid fa-upload me-1"></i>Încarcă
+                                        <i class="fa-solid fa-floppy-disk me-1"></i>Salvează documentul
                                     </button>
                                 </div>
                             </form>

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -21,8 +21,32 @@
 
         .document-cell-link--empty .document-cell {
             background-color: transparent !important;
-            border: 1px dashed var(--bs-primary);
+            border: none;
             color: var(--bs-primary) !important;
+            text-decoration: underline;
+        }
+
+        .document-cell.bg-warning {
+            color: #000 !important;
+        }
+
+        .document-legend {
+            background-color: var(--bs-body-bg);
+        }
+
+        .document-legend-pill {
+            border-radius: 0.75rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 140px;
+            padding: 0.35rem 0.75rem;
+            font-weight: 600;
+        }
+
+        .document-legend-pill--empty {
+            background-color: transparent;
+            color: var(--bs-primary);
             text-decoration: underline;
         }
     </style>
@@ -60,6 +84,29 @@
             ($columnCount = 2 + count($gridDocumentTypes) + count($vignetteCountries) + 1)
         @endphp
 
+        <div class="px-3 mb-3">
+            <div class="p-3 border border-secondary-subtle rounded-4 document-legend">
+                <p class="mb-2 text-uppercase small fw-semibold text-muted">Legendă culori</p>
+                <ul class="list-inline small mb-0 d-flex flex-wrap gap-2">
+                    <li class="list-inline-item mb-1">
+                        <span class="document-legend-pill bg-danger text-white">Expirat / ≤ 1 zi</span>
+                    </li>
+                    <li class="list-inline-item mb-1">
+                        <span class="document-legend-pill bg-warning">≤ 30 zile</span>
+                    </li>
+                    <li class="list-inline-item mb-1">
+                        <span class="document-legend-pill bg-success text-white">≤ 60 zile</span>
+                    </li>
+                    <li class="list-inline-item mb-1">
+                        <span class="document-legend-pill bg-secondary-subtle text-body-secondary">Fără dată</span>
+                    </li>
+                    <li class="list-inline-item mb-1">
+                        <span class="document-legend-pill document-legend-pill--empty">N/A</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
         <div class="table-responsive rounded">
             <table class="table table-striped table-hover align-middle table-sm mb-0">
                 <thead class="text-white rounded culoare2">
@@ -72,7 +119,7 @@
                         @foreach ($vignetteCountries as $code => $label)
                             <th class="text-center">Vignetă {{ $label }}</th>
                         @endforeach
-                        <th class="text-end">Acțiuni</th>
+                        <th class="text-end">Acț.</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -132,8 +179,10 @@
                                     <button type="button" class="btn btn-sm btn-outline-danger border border-dark rounded-3"
                                             data-bs-toggle="modal" data-bs-target="#deleteMasinaModal"
                                             data-delete-url="{{ route('masini-mementouri.destroy', $masina) }}"
-                                            data-masina-name="{{ $masina->numar_inmatriculare }}">
-                                        <i class="fa-solid fa-trash me-1"></i>Șterge
+                                            data-masina-name="{{ $masina->numar_inmatriculare }}"
+                                            aria-label="Șterge {{ $masina->numar_inmatriculare }}"
+                                            title="Șterge">
+                                        <i class="fa-solid fa-trash"></i>
                                     </button>
                                 </div>
                             </td>
@@ -170,6 +219,14 @@
                     <div class="col-md-6">
                         <label class="form-label" for="modal_descriere">Descriere</label>
                         <input type="text" class="form-control rounded-3" id="modal_descriere" name="descriere">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label" for="modal_marca_masina">Marca mașină</label>
+                        <input type="text" class="form-control rounded-3" id="modal_marca_masina" name="marca_masina">
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label" for="modal_serie_sasiu">Serie șasiu</label>
+                        <input type="text" class="form-control rounded-3" id="modal_serie_sasiu" name="serie_sasiu">
                     </div>
                     <div class="col-md-6">
                         <label class="form-label" for="modal_email_notificari">Email notificări</label>
@@ -237,6 +294,8 @@
                 const inputs = {
                     numar_inmatriculare: form.querySelector('input[name="numar_inmatriculare"]'),
                     descriere: form.querySelector('input[name="descriere"]'),
+                    marca_masina: form.querySelector('input[name="marca_masina"]'),
+                    serie_sasiu: form.querySelector('input[name="serie_sasiu"]'),
                     email_notificari: form.querySelector('input[name="email_notificari"]'),
                     observatii: form.querySelector('textarea[name="observatii"]'),
                 };
@@ -254,6 +313,8 @@
                 const fillForm = (values = {}) => {
                     inputs.numar_inmatriculare.value = values.numar_inmatriculare ?? '';
                     inputs.descriere.value = values.descriere ?? '';
+                    inputs.marca_masina.value = values.marca_masina ?? '';
+                    inputs.serie_sasiu.value = values.serie_sasiu ?? '';
                     inputs.email_notificari.value = values.email_notificari ?? defaultEmail;
                     inputs.observatii.value = values.observatii ?? '';
                 };
@@ -305,6 +366,8 @@
                 const oldValues = {
                     numar_inmatriculare: @json(old('numar_inmatriculare')),
                     descriere: @json(old('descriere')),
+                    marca_masina: @json(old('marca_masina')),
+                    serie_sasiu: @json(old('serie_sasiu')),
                     email_notificari: @json(old('email_notificari')),
                     observatii: @json(old('observatii')),
                 };

--- a/resources/views/masini-mementouri/show.blade.php
+++ b/resources/views/masini-mementouri/show.blade.php
@@ -33,6 +33,16 @@
                            value="{{ old('descriere', $masina->descriere) }}">
                 </div>
                 <div class="col-md-3">
+                    <label class="form-label" for="marca_masina">Marca mașină</label>
+                    <input type="text" id="marca_masina" name="marca_masina" class="form-control rounded-3"
+                           value="{{ old('marca_masina', $masina->marca_masina) }}">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label" for="serie_sasiu">Serie șasiu</label>
+                    <input type="text" id="serie_sasiu" name="serie_sasiu" class="form-control rounded-3"
+                           value="{{ old('serie_sasiu', $masina->serie_sasiu) }}">
+                </div>
+                <div class="col-md-3">
                     <label class="form-label" for="email_notificari">Email notificări</label>
                     <input type="email" id="email_notificari" name="email_notificari" class="form-control rounded-3"
                            value="{{ old('email_notificari', optional($masina->memento)->email_notificari) }}">


### PR DESCRIPTION
## Summary
- add nullable marca mașină and serie șasiu columns with validation, factories, and form inputs across the mementouri views
- extend the mementouri table with Asigurare CMR and Brennero document columns, a color legend, and updated styling/action controls
- consolidate the document edit workflow into a single upload form that enforces file submissions for date changes and expand test coverage

## Testing
- php -l app/Http/Controllers/Masini/MasiniDocumentFisierController.php
- php -l app/Http/Controllers/Masini/MasiniMementoController.php
- php -l tests/Feature/Masini/MasiniMementouriTest.php

------
https://chatgpt.com/codex/tasks/task_e_69024365061c8326a61b72220dfb5dab