### PR TITLE
Stop sending stale vehicle memento alerts after urgent notification

### DIFF
--- a/app/Http/Controllers/CronJobController.php
+++ b/app/Http/Controllers/CronJobController.php
@@ -311,9 +311,19 @@ class CronJobController extends Controller
             }
 
             $thresholds = collect(MasinaDocument::notificationThresholds())->sortKeys();
+            $lowerThresholdAlreadyTriggered = false;
 
             foreach ($thresholds as $threshold => $column) {
-                if ($days <= $threshold && !$document->{$column}) {
+                if ($document->{$column}) {
+                    $lowerThresholdAlreadyTriggered = true;
+                    continue;
+                }
+
+                if ($lowerThresholdAlreadyTriggered) {
+                    break;
+                }
+
+                if ($days <= $threshold) {
                     $recipients = collect([
                         $document->email_notificare,
                         optional($document->masina->memento)->email_notificari,


### PR DESCRIPTION
## Summary
- ensure the cron job never sends less-urgent vehicle memento alerts after a one-day warning has already been triggered
- add a regression test that covers the scenario where only the one-day notification should fire

## Testing
- php artisan test --filter=MasiniMementouriTest *(fails: missing vendor/autoload.php in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_69026a6fd5188326a114c72d9a73f1b7