### PR TITLE
Show Brennero vignette without prefix

### DIFF
--- a/app/Models/Masini/MasinaDocument.php
+++ b/app/Models/Masini/MasinaDocument.php
@@ -158,6 +158,24 @@ class MasinaDocument extends Model
         ];
     }
 
+    public static function vignetteDisplayLabel(?string $countryCode): string
+    {
+        $countryCode = $countryCode !== null ? strtolower($countryCode) : null;
+        $countries = self::vignetteCountries();
+
+        $suffix = strtoupper((string) $countryCode);
+
+        if ($countryCode !== null && array_key_exists($countryCode, $countries)) {
+            $suffix = $countries[$countryCode];
+        }
+
+        if ($countryCode === 'brennero') {
+            return $suffix !== '' ? $suffix : 'Brennero';
+        }
+
+        return 'Vignetă ' . $suffix;
+    }
+
     public static function uploadDocumentLabels(): array
     {
         $labels = [
@@ -168,8 +186,8 @@ class MasinaDocument extends Model
             self::TYPE_ASIGURARE_CMR => 'Asigurare CMR',
         ];
 
-        foreach (self::vignetteCountries() as $code => $label) {
-            $labels[self::TYPE_VIGNETA . ':' . $code] = 'Vignetă ' . $label;
+        foreach (self::vignetteCountries() as $code => $_label) {
+            $labels[self::TYPE_VIGNETA . ':' . $code] = self::vignetteDisplayLabel($code);
         }
 
         return $labels;
@@ -247,10 +265,7 @@ class MasinaDocument extends Model
     public function label(): string
     {
         if ($this->document_type === self::TYPE_VIGNETA) {
-            $countries = self::vignetteCountries();
-            $suffix = $countries[$this->tara] ?? strtoupper((string) $this->tara);
-
-            return 'Vignetă ' . $suffix;
+            return self::vignetteDisplayLabel($this->tara);
         }
 
         return match ($this->document_type) {

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -88,9 +88,7 @@
             </div>
         @endif
 
-        @php
-            ($columnCount = 2 + count($gridDocumentTypes) + count($vignetteCountries) + 1)
-        @endphp
+        @php($columnCount = 2 + count($gridDocumentTypes) + count($vignetteCountries) + 1)
 
         <div class="table-responsive rounded">
             <table class="table table-striped table-hover align-middle table-sm mb-0">
@@ -101,8 +99,9 @@
                         @foreach ($gridDocumentTypes as $label)
                             <th class="text-center">{{ $label }}</th>
                         @endforeach
-                        @foreach ($vignetteCountries as $code => $label)
-                            <th class="text-center">Vignetă {{ $label }}</th>
+                        @foreach ($vignetteCountries as $code => $_label)
+                            @php($displayLabel = \App\Models\Masini\MasinaDocument::vignetteDisplayLabel($code))
+                            <th class="text-center">{{ $displayLabel }}</th>
                         @endforeach
                         <th class="text-end">Acț.</th>
                     </tr>
@@ -139,14 +138,15 @@
                                     </a>
                                 </td>
                             @endforeach
-                            @foreach ($vignetteCountries as $code => $label)
+                            @foreach ($vignetteCountries as $code => $_label)
                                 @php
                                     $documentKey = \App\Models\Masini\MasinaDocument::TYPE_VIGNETA . ':' . $code;
                                     $document = $documents->get($documentKey);
                                     $displayDate = optional($document?->data_expirare)->format('d.m.Y') ?? '—';
                                     $colorClass = $document?->colorClass() ?? 'bg-secondary-subtle text-body-secondary';
                                     $isEmpty = !$document?->data_expirare;
-                                    $ariaLabel = "Actualizează Vignetă {$label} pentru {$masina->numar_inmatriculare}";
+                                    $displayLabel = \App\Models\Masini\MasinaDocument::vignetteDisplayLabel($code);
+                                    $ariaLabel = "Actualizează {$displayLabel} pentru {$masina->numar_inmatriculare}";
                                     $routeDocumentParam = $document?->getRouteKey() ?? \App\Models\Masini\MasinaDocument::buildRouteKey(\App\Models\Masini\MasinaDocument::TYPE_VIGNETA, $code);
                                 @endphp
                                 <td class="text-center">

--- a/tests/Feature/Masini/MasiniMementouriTest.php
+++ b/tests/Feature/Masini/MasiniMementouriTest.php
@@ -104,7 +104,7 @@ class MasiniMementouriTest extends TestCase
         $response->assertOk();
         $response->assertSee('Legendă culori');
         $response->assertSee('Asigurare CMR');
-        $response->assertSee('Vignetă Brennero');
+        $response->assertSee('Brennero');
         $response->assertSee('<a href="' . route('masini-mementouri.edit', $masina) . '"', false);
         $response->assertSee('aria-label="Editează ITP pentru ' . $masina->numar_inmatriculare . '"', false);
         $response->assertSee($document->data_expirare->format('d.m.Y'));

--- a/tests/Unit/Models/MasinaDocumentTest.php
+++ b/tests/Unit/Models/MasinaDocumentTest.php
@@ -62,6 +62,7 @@ class MasinaDocumentTest extends TestCase
         return [
             'itp' => [MasinaDocument::TYPE_ITP, null, 'ITP'],
             'vignette known country' => [MasinaDocument::TYPE_VIGNETA, 'hu', 'Vignetă HU'],
+            'vignette brennero' => [MasinaDocument::TYPE_VIGNETA, 'brennero', 'Brennero'],
             'vignette unknown country' => [MasinaDocument::TYPE_VIGNETA, 'de', 'Vignetă DE'],
             'talon' => [MasinaDocument::TYPE_TALON, null, 'Talon'],
             'fallback' => ['neidentificat', null, 'Neidentificat'],


### PR DESCRIPTION
## Summary
- add a vignette display helper so Brennero renders without the “Vignetă” prefix while preserving other country labels
- reuse the helper when building the mementouri table headers and aria labels so users only see “Brennero”
- update the existing feature and unit tests to match the new wording
- fix the column-count blade directive so the index view compiles without a syntax error

## Testing
- php artisan test *(fails: missing vendor/autoload; composer install requires a GitHub token in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_69030349873483268561b7fd3d8e1f66