### PR TITLE
Add storage-backed general file records for Masina

### DIFF
--- a/app/Models/Masini/Masina.php
+++ b/app/Models/Masini/Masina.php
@@ -28,6 +28,11 @@ class Masina extends Model
         return $this->hasMany(MasinaDocument::class);
     }
 
+    public function fisiereGenerale()
+    {
+        return $this->hasMany(MasinaFisierGeneral::class, 'masina_id');
+    }
+
     protected static function booted(): void
     {
         static::created(function (Masina $masina) {
@@ -37,6 +42,7 @@ class Masina extends Model
 
         static::deleting(function (Masina $masina) {
             $masina->documente->each->delete();
+            $masina->fisiereGenerale->each->delete();
         });
     }
 

--- a/app/Models/Masini/MasinaFisierGeneral.php
+++ b/app/Models/Masini/MasinaFisierGeneral.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models\Masini;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+
+class MasinaFisierGeneral extends Model
+{
+    use HasFactory;
+
+    public const STORAGE_DISK = 'local';
+    public const STORAGE_DIRECTORY = 'masini-fisiere-generale';
+
+    protected $table = 'masini_fisiere_generale';
+
+    protected $fillable = [
+        'masina_id',
+        'cale',
+        'nume_original',
+        'mime_type',
+        'dimensiune',
+        'uploaded_by_id',
+        'uploaded_by_name',
+        'uploaded_by_email',
+    ];
+
+    public function masina()
+    {
+        return $this->belongsTo(Masina::class, 'masina_id');
+    }
+
+    protected static function booted(): void
+    {
+        static::deleting(function (MasinaFisierGeneral $fisier) {
+            if (!$fisier->cale) {
+                return;
+            }
+
+            Storage::disk(self::STORAGE_DISK)->delete($fisier->cale);
+        });
+    }
+}

--- a/database/migrations/2025_03_24_000500_create_masini_fisiere_generale_table.php
+++ b/database/migrations/2025_03_24_000500_create_masini_fisiere_generale_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('masini_fisiere_generale', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('masina_id')
+                ->constrained('masini')
+                ->cascadeOnDelete();
+            $table->string('cale');
+            $table->string('nume_original');
+            $table->string('mime_type')->nullable();
+            $table->unsignedBigInteger('dimensiune')->nullable();
+            $table->unsignedBigInteger('uploaded_by_id')->nullable();
+            $table->string('uploaded_by_name')->nullable();
+            $table->string('uploaded_by_email')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('masini_fisiere_generale');
+    }
+};


### PR DESCRIPTION
## Summary
- add the `masini_fisiere_generale` table for storing general file metadata per vehicle
- create the `MasinaFisierGeneral` model with storage cleanup hooks
- expose the `fisiereGenerale` relation on `Masina` and cascade deletions to stored files

## Testing
- php artisan test *(fails: missing vendor/autoload.php in container)*

------
https://chatgpt.com/codex/tasks/task_e_69030f661cf8832698fd92369b2a42a5