### PR TITLE
Add general file management for Masini mementouri

### DIFF
--- a/app/Http/Controllers/Masini/MasinaFisierGeneralController.php
+++ b/app/Http/Controllers/Masini/MasinaFisierGeneralController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\Masini;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Masini\StoreMasinaFisierGeneralRequest;
+use App\Models\Masini\Masina;
+use App\Models\Masini\MasinaFisierGeneral;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\View\View;
+
+class MasinaFisierGeneralController extends Controller
+{
+    private const STORAGE_DISK = MasinaFisierGeneral::STORAGE_DISK;
+    private const STORAGE_DIRECTORY = MasinaFisierGeneral::STORAGE_DIRECTORY;
+
+    public function index(Request $request, Masina $masini_mementouri): View|JsonResponse
+    {
+        $masina = $masini_mementouri->loadMissing('fisiereGenerale');
+
+        if ($request->expectsJson()) {
+            return response()->json([
+                'status' => 'ok',
+                'files_html' => view('masini-mementouri.partials.general-files-list', [
+                    'masina' => $masina,
+                    'fisiere' => $masina->fisiereGenerale,
+                ])->render(),
+            ]);
+        }
+
+        return view('masini-mementouri.fisiere-generale.index', [
+            'masina' => $masina,
+            'fisiere' => $masina->fisiereGenerale,
+        ]);
+    }
+
+    public function store(StoreMasinaFisierGeneralRequest $request, Masina $masini_mementouri): JsonResponse|RedirectResponse
+    {
+        $masina = $masini_mementouri;
+
+        $file = $request->file('fisier');
+
+        $path = $file->store(self::STORAGE_DIRECTORY . '/' . $masina->id, self::STORAGE_DISK);
+
+        $masina->fisiereGenerale()->create([
+            'cale' => $path,
+            'nume_original' => $file->getClientOriginalName(),
+            'mime_type' => $file->getMimeType(),
+            'dimensiune' => $file->getSize(),
+            'uploaded_by_id' => $request->user()?->id,
+            'uploaded_by_name' => $request->user()?->name,
+            'uploaded_by_email' => $request->user()?->email,
+        ]);
+
+        $message = __('Fișierul a fost încărcat.');
+
+        if ($request->expectsJson()) {
+            $masina->load('fisiereGenerale');
+
+            return response()->json([
+                'status' => 'ok',
+                'message' => $message,
+                'files_html' => view('masini-mementouri.partials.general-files-list', [
+                    'masina' => $masina,
+                    'fisiere' => $masina->fisiereGenerale,
+                ])->render(),
+            ]);
+        }
+
+        return Redirect::back()->with('status', $message);
+    }
+
+    public function download(Masina $masini_mementouri, MasinaFisierGeneral $fisier)
+    {
+        $masina = $masini_mementouri;
+
+        abort_unless($fisier->masina_id === $masina->id, 404);
+
+        $headers = [];
+
+        if ($mimeType = $fisier->guessMimeType()) {
+            $headers['Content-Type'] = $mimeType;
+        }
+
+        return Storage::disk(self::STORAGE_DISK)->download(
+            $fisier->cale,
+            $fisier->downloadName(),
+            $headers
+        );
+    }
+
+    public function destroy(Request $request, Masina $masini_mementouri, MasinaFisierGeneral $fisier): JsonResponse|RedirectResponse
+    {
+        $masina = $masini_mementouri;
+
+        abort_unless($fisier->masina_id === $masina->id, 404);
+
+        if ($fisier->cale) {
+            Storage::disk(self::STORAGE_DISK)->delete($fisier->cale);
+        }
+
+        $fisier->delete();
+
+        $message = __('Fișierul a fost șters.');
+
+        if ($request->expectsJson()) {
+            $masina->load('fisiereGenerale');
+
+            return response()->json([
+                'status' => 'ok',
+                'message' => $message,
+                'files_html' => view('masini-mementouri.partials.general-files-list', [
+                    'masina' => $masina,
+                    'fisiere' => $masina->fisiereGenerale,
+                ])->render(),
+            ]);
+        }
+
+        return Redirect::back()->with('status', $message);
+    }
+}

--- a/app/Http/Requests/Masini/StoreMasinaFisierGeneralRequest.php
+++ b/app/Http/Requests/Masini/StoreMasinaFisierGeneralRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Masini;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMasinaFisierGeneralRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'fisier' => [
+                'required',
+                'file',
+                'mimes:pdf,jpg,jpeg,png,gif,webp,bmp,svg,txt,csv,doc,docx,xls,xlsx,ppt,pptx',
+                'max:51200',
+            ],
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'fisier' => __('fișier'),
+        ];
+    }
+}

--- a/app/Models/Masini/MasinaFisierGeneral.php
+++ b/app/Models/Masini/MasinaFisierGeneral.php
@@ -5,6 +5,7 @@ namespace App\Models\Masini;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class MasinaFisierGeneral extends Model
 {
@@ -29,6 +30,95 @@ class MasinaFisierGeneral extends Model
     public function masina()
     {
         return $this->belongsTo(Masina::class, 'masina_id');
+    }
+
+    public function downloadName(): string
+    {
+        $name = $this->nume_original ?? basename((string) $this->cale);
+
+        $name = is_string($name) ? trim($name) : '';
+
+        return $name === '' ? 'document' : $name;
+    }
+
+    public function guessMimeType(): ?string
+    {
+        if (is_string($this->mime_type) && $this->mime_type !== '') {
+            return $this->mime_type;
+        }
+
+        $extension = strtolower(pathinfo((string) $this->nume_original ?: (string) $this->cale, PATHINFO_EXTENSION));
+
+        return match ($extension) {
+            'pdf' => 'application/pdf',
+            'png' => 'image/png',
+            'jpg', 'jpeg' => 'image/jpeg',
+            'gif' => 'image/gif',
+            'webp' => 'image/webp',
+            'bmp' => 'image/bmp',
+            'svg' => 'image/svg+xml',
+            'txt' => 'text/plain',
+            'csv' => 'text/csv',
+            'doc' => 'application/msword',
+            'docx' => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'xls' => 'application/vnd.ms-excel',
+            'xlsx' => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            'ppt' => 'application/vnd.ms-powerpoint',
+            'pptx' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            default => null,
+        };
+    }
+
+    public function isPreviewable(): bool
+    {
+        $mime = strtolower($this->guessMimeType() ?? '');
+
+        if ($mime === 'application/pdf') {
+            return true;
+        }
+
+        if (Str::startsWith($mime, 'image/')) {
+            return true;
+        }
+
+        if (Str::startsWith($mime, 'text/')) {
+            return true;
+        }
+
+        $extension = strtolower(pathinfo((string) $this->nume_original ?: (string) $this->cale, PATHINFO_EXTENSION));
+
+        return in_array($extension, ['pdf', 'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg', 'txt', 'csv'], true);
+    }
+
+    public function iconClass(): string
+    {
+        $mime = strtolower($this->guessMimeType() ?? '');
+
+        if (Str::startsWith($mime, 'image/')) {
+            return 'fa-file-image text-primary';
+        }
+
+        if ($mime === 'application/pdf') {
+            return 'fa-file-pdf text-danger';
+        }
+
+        if (Str::startsWith($mime, 'text/')) {
+            return 'fa-file-lines text-info';
+        }
+
+        if (Str::contains($mime, 'spreadsheet') || Str::contains($mime, 'excel')) {
+            return 'fa-file-excel text-success';
+        }
+
+        if (Str::contains($mime, 'presentation') || Str::contains($mime, 'powerpoint')) {
+            return 'fa-file-powerpoint text-warning';
+        }
+
+        if (Str::contains($mime, 'word') || Str::contains($mime, 'document')) {
+            return 'fa-file-word text-primary';
+        }
+
+        return 'fa-file-lines text-secondary';
     }
 
     protected static function booted(): void

--- a/resources/views/masini-mementouri/fisiere-generale/index.blade.php
+++ b/resources/views/masini-mementouri/fisiere-generale/index.blade.php
@@ -1,0 +1,43 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-6">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-car me-1"></i>{{ $masina->numar_inmatriculare }}
+            </span>
+        </div>
+        <div class="col-lg-6 text-end">
+            <a href="{{ route('masini-mementouri.show', $masina) }}" class="btn btn-sm btn-secondary border border-dark rounded-3">
+                <i class="fa-solid fa-arrow-left me-1"></i>{{ __('Înapoi la mașină') }}
+            </a>
+        </div>
+    </div>
+
+    <div class="card-body px-0 py-3">
+        @include('errors')
+
+        <div class="mx-3 mb-4">
+            <form method="POST" action="{{ route('masini-mementouri.fisiere-generale.store', $masina) }}" enctype="multipart/form-data" class="row g-3 align-items-end">
+                @csrf
+                <div class="col-md-8">
+                    <label class="form-label" for="fisier">{{ __('Încarcă fișier') }}</label>
+                    <input type="file" id="fisier" name="fisier" class="form-control rounded-3" required>
+                    <small class="text-muted">{{ __('Fișiere permise: pdf, imagini, documente Office (maxim 50 MB).') }}</small>
+                </div>
+                <div class="col-md-4 text-md-end">
+                    <button type="submit" class="btn btn-success text-white border border-dark w-100 rounded-3">
+                        <i class="fa-solid fa-upload me-1"></i>{{ __('Încarcă') }}
+                    </button>
+                </div>
+            </form>
+        </div>
+
+        <div class="mx-3">
+            <h5 class="mb-3">{{ __('Fișiere generale') }}</h5>
+            @include('masini-mementouri.partials.general-files-list', ['masina' => $masina, 'fisiere' => $fisiere])
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/masini-mementouri/partials/general-files-list.blade.php
+++ b/resources/views/masini-mementouri/partials/general-files-list.blade.php
@@ -1,0 +1,45 @@
+@php($files = $fisiere ?? $masina->fisiereGenerale)
+
+<ul class="list-unstyled mb-0">
+    @forelse ($files as $fisier)
+        <li class="d-flex flex-column flex-md-row gap-2 justify-content-between align-items-md-center py-2 border-bottom">
+            <div class="me-md-3">
+                <i class="fa-solid {{ $fisier->iconClass() }} me-2"></i>
+                <span class="fw-semibold">{{ $fisier->nume_original }}</span>
+                <small class="text-muted ms-2">{{ number_format(($fisier->dimensiune ?? 0) / 1024, 1) }} KB</small>
+                @if ($fisier->uploaded_by_name)
+                    <small class="text-muted ms-2">
+                        {{ $fisier->uploaded_by_name }}
+                        @if ($fisier->uploaded_by_email)
+                            &lt;{{ $fisier->uploaded_by_email }}&gt;
+                        @endif
+                    </small>
+                @endif
+                @if ($fisier->created_at)
+                    <small class="text-muted ms-2">{{ $fisier->created_at->format('d.m.Y H:i') }}</small>
+                @endif
+            </div>
+            <div class="d-flex align-items-center gap-2">
+                <div class="btn-group btn-group-sm" role="group">
+                    <a href="{{ route('masini-mementouri.fisiere-generale.download', [$masina, $fisier]) }}"
+                       class="btn btn-outline-secondary border"
+                       download="{{ $fisier->downloadName() }}"
+                       title="{{ __('Descarcă fișierul') }}">
+                        <i class="fa-solid fa-download me-1"></i>
+                        <span class="d-none d-sm-inline">{{ __('Descarcă') }}</span>
+                    </a>
+                </div>
+                <form method="POST" action="{{ route('masini-mementouri.fisiere-generale.destroy', [$masina, $fisier]) }}"
+                      onsubmit="return confirm('{{ __('Ștergi fișierul?') }}');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-outline-danger border border-dark">
+                        <i class="fa-solid fa-trash me-1"></i>{{ __('Șterge') }}
+                    </button>
+                </form>
+            </div>
+        </li>
+    @empty
+        <li class="text-muted">{{ __('Nu există fișiere încărcate.') }}</li>
+    @endforelse
+</ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\FlotaStatusController;
 use App\Http\Controllers\FlotaStatusInformatieController;
 use App\Http\Controllers\FlotaStatusCController;
 use App\Http\Controllers\MasinaValabilitatiController;
+use App\Http\Controllers\Masini\MasinaFisierGeneralController;
 use App\Http\Controllers\Masini\MasiniDocumentController;
 use App\Http\Controllers\Masini\MasiniDocumentFisierController;
 use App\Http\Controllers\Masini\MasiniMementoController;
@@ -238,6 +239,14 @@ Route::middleware(['auth'])->group(function () {
                 ->name('masini-mementouri.documente.fisiere.download');
             Route::get('masini-mementouri/{masini_mementouri}/documente/{document}/fisiere/{fisier}/preview', [MasiniDocumentFisierController::class, 'preview'])
                 ->name('masini-mementouri.documente.fisiere.preview');
+            Route::get('masini-mementouri/{masini_mementouri}/fisiere-generale', [MasinaFisierGeneralController::class, 'index'])
+                ->name('masini-mementouri.fisiere-generale.index');
+            Route::post('masini-mementouri/{masini_mementouri}/fisiere-generale', [MasinaFisierGeneralController::class, 'store'])
+                ->name('masini-mementouri.fisiere-generale.store');
+            Route::delete('masini-mementouri/{masini_mementouri}/fisiere-generale/{fisier}', [MasinaFisierGeneralController::class, 'destroy'])
+                ->name('masini-mementouri.fisiere-generale.destroy');
+            Route::get('masini-mementouri/{masini_mementouri}/fisiere-generale/{fisier}', [MasinaFisierGeneralController::class, 'download'])
+                ->name('masini-mementouri.fisiere-generale.download');
         });
     });
 


### PR DESCRIPTION
## Summary
- add a dedicated controller for listing, uploading, downloading, and deleting general files for each mașină memento, returning HTML partials when needed
- introduce a form request and model helpers to validate uploads and expose file metadata used by the UI
- wire up blade views and nested routes under the existing Masini mementouri middleware scope to surface the new general-files interface

## Testing
- php artisan test *(fails: vendor directory is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_690311a9edd08326820a96a3834900ba