### PR TITLE
Revamp general files management for car mementos

### DIFF
--- a/app/Http/Controllers/Masini/MasiniMementoController.php
+++ b/app/Http/Controllers/Masini/MasiniMementoController.php
@@ -74,11 +74,8 @@ class MasiniMementoController extends Controller
         $masini_mementouri->syncDefaultDocuments();
         $masini_mementouri->loadMissing(['memento', 'documente.fisiere']);
 
-        $uploadDocumentLabels = MasinaDocument::uploadDocumentLabels();
-
         return view('masini-mementouri.show', [
             'masina' => $masini_mementouri,
-            'uploadDocumentLabels' => $uploadDocumentLabels,
         ]);
     }
 

--- a/app/Http/Requests/Masini/StoreMasinaFisierGeneralRequest.php
+++ b/app/Http/Requests/Masini/StoreMasinaFisierGeneralRequest.php
@@ -14,8 +14,8 @@ class StoreMasinaFisierGeneralRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'fisier' => [
-                'required',
+            'fisier' => ['required', 'array', 'min:1'],
+            'fisier.*' => [
                 'file',
                 'mimes:pdf,jpg,jpeg,png,gif,webp,bmp,svg,txt,csv,doc,docx,xls,xlsx,ppt,pptx',
                 'max:51200',
@@ -27,6 +27,7 @@ class StoreMasinaFisierGeneralRequest extends FormRequest
     {
         return [
             'fisier' => __('fișier'),
+            'fisier.*' => __('fișier'),
         ];
     }
 }

--- a/resources/views/masini-mementouri/create.blade.php
+++ b/resources/views/masini-mementouri/create.blade.php
@@ -61,7 +61,7 @@
 
                 <div class="col-12">
                     <div class="alert alert-info border border-info-subtle rounded-4">
-                        După salvare vei fi redirecționat către pagina dedicată mașinii pentru a gestiona documentele și fișierele.
+                        După salvare vei fi redirecționat către pagina dedicată mașinii de unde poți gestiona și fișierele
                     </div>
                 </div>
 

--- a/resources/views/masini-mementouri/fisiere-generale/index.blade.php
+++ b/resources/views/masini-mementouri/fisiere-generale/index.blade.php
@@ -16,7 +16,15 @@
     </div>
 
     <div class="card-body px-0 py-3">
-        @include('errors')
+        @include('errors', ['showSessionAlerts' => false])
+
+        @php($statusMessage = session('status') ?? session('success'))
+
+        @if ($statusMessage)
+            <div class="alert alert-success border border-success-subtle rounded-4 mx-3 mb-4">
+                {{ $statusMessage }}
+            </div>
+        @endif
 
         <div class="mx-3">
             @include('masini-mementouri.partials.general-files-section', [

--- a/resources/views/masini-mementouri/partials/general-files-list.blade.php
+++ b/resources/views/masini-mementouri/partials/general-files-list.blade.php
@@ -2,57 +2,81 @@
     $files = $fisiere ?? $masina->fisiereGenerale;
 @endphp
 
-<ul class="list-unstyled mb-0">
+<ul class="list-unstyled mb-0" data-general-files-list>
     @forelse ($files as $fisier)
         @php
             $previewRoute = route('masini-mementouri.fisiere-generale.preview', [$masina, $fisier]);
             $downloadRoute = route('masini-mementouri.fisiere-generale.download', [$masina, $fisier]);
             $deleteRoute = route('masini-mementouri.fisiere-generale.destroy', [$masina, $fisier]);
+            $deleteModalId = 'deleteGeneralFileModal-' . $fisier->id;
+            $deleteFormId = 'delete-general-file-form-' . $fisier->id;
+
+            $details = [number_format(($fisier->dimensiune ?? 0) / 1024, 1) . ' KB'];
+
+            if ($fisier->uploaded_by_name) {
+                $uploadedBy = $fisier->uploaded_by_name;
+
+                if ($fisier->uploaded_by_email) {
+                    $uploadedBy .= ' <' . $fisier->uploaded_by_email . '>';
+                }
+
+                $details[] = $uploadedBy;
+            }
+
+            if ($fisier->created_at) {
+                $details[] = $fisier->created_at->format('d.m.Y H:i');
+            }
         @endphp
-        <li class="d-flex flex-column flex-md-row gap-2 justify-content-between align-items-md-center py-2 border-bottom">
-            <div class="me-md-3">
-                <i class="fa-solid {{ $fisier->iconClass() }} me-2"></i>
-                <span class="fw-semibold">{{ $fisier->nume_original }}</span>
-                <small class="text-muted ms-2">{{ number_format(($fisier->dimensiune ?? 0) / 1024, 1) }} KB</small>
-                @if ($fisier->uploaded_by_name)
-                    <small class="text-muted ms-2">
-                        {{ $fisier->uploaded_by_name }}
-                        @if ($fisier->uploaded_by_email)
-                            &lt;{{ $fisier->uploaded_by_email }}&gt;
-                        @endif
-                    </small>
-                @endif
-                @if ($fisier->created_at)
-                    <small class="text-muted ms-2">{{ $fisier->created_at->format('d.m.Y H:i') }}</small>
-                @endif
+        <li class="d-flex flex-column flex-lg-row align-items-lg-center gap-3 py-2 border-bottom" data-general-file data-file-id="{{ $fisier->id }}">
+            <div class="d-flex align-items-start gap-3 flex-grow-1">
+                <i class="fa-solid {{ $fisier->iconClass() }} fs-5"></i>
+                <div>
+                    <div class="fw-semibold">{{ $fisier->nume_original }}</div>
+                    <div class="text-muted small">{{ implode(' • ', array_filter($details)) }}</div>
+                </div>
             </div>
             <div class="d-flex align-items-center gap-2">
                 <div class="btn-group btn-group-sm" role="group">
                     @if ($fisier->isPreviewable())
                         <a href="{{ $previewRoute }}" class="btn btn-outline-primary border" target="_blank" rel="noopener" title="{{ __('Previzualizează fișierul') }}">
-                            <i class="fa-solid fa-eye me-1"></i>
-                            <span class="d-none d-sm-inline">{{ __('Previzualizează') }}</span>
+                            <i class="fa-solid fa-eye"></i>
                         </a>
                     @endif
-                    <a href="{{ $downloadRoute }}"
-                       class="btn btn-outline-secondary border"
-                       download="{{ $fisier->downloadName() }}"
-                       title="{{ __('Descarcă fișierul') }}">
-                        <i class="fa-solid fa-download me-1"></i>
-                        <span class="d-none d-sm-inline">{{ __('Descarcă') }}</span>
+                    <a href="{{ $downloadRoute }}" class="btn btn-outline-secondary border" download="{{ $fisier->downloadName() }}" title="{{ __('Descarcă fișierul') }}">
+                        <i class="fa-solid fa-download"></i>
                     </a>
-                </div>
-                <form method="POST" action="{{ $deleteRoute }}"
-                      onsubmit="return confirm('{{ __('Ștergi fișierul?') }}');">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-sm btn-outline-danger border border-dark">
-                        <i class="fa-solid fa-trash me-1"></i>{{ __('Șterge') }}
+                    <button type="button" class="btn btn-outline-danger border" title="{{ __('Șterge fișierul') }}" data-bs-toggle="modal" data-bs-target="#{{ $deleteModalId }}">
+                        <i class="fa-solid fa-trash"></i>
                     </button>
-                </form>
+                </div>
+            </div>
+
+            <form id="{{ $deleteFormId }}" method="POST" action="{{ $deleteRoute }}" class="d-none">
+                @csrf
+                @method('DELETE')
+            </form>
+
+            <div class="modal fade" id="{{ $deleteModalId }}" tabindex="-1" aria-labelledby="{{ $deleteModalId }}Label" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="{{ $deleteModalId }}Label">{{ __('Confirmă ștergerea') }}</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ __('Închide') }}"></button>
+                        </div>
+                        <div class="modal-body">
+                            {{ __('Ești sigur că dorești să ștergi fișierul „:nume”? Această acțiune nu poate fi anulată.', ['nume' => $fisier->nume_original]) }}
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">{{ __('Anulează') }}</button>
+                            <button type="button" class="btn btn-danger" onclick="document.getElementById('{{ $deleteFormId }}').submit();">
+                                <i class="fa-solid fa-trash me-1"></i>{{ __('Șterge fișierul') }}
+                            </button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </li>
     @empty
-        <li class="text-muted">{{ __('Nu există fișiere încărcate.') }}</li>
+        <li class="text-muted" data-general-files-empty>{{ __('Nu există fișiere încărcate.') }}</li>
     @endforelse
 </ul>

--- a/resources/views/masini-mementouri/partials/general-files-section.blade.php
+++ b/resources/views/masini-mementouri/partials/general-files-section.blade.php
@@ -1,30 +1,55 @@
 @php($files = $fisiere ?? $masina->fisiereGenerale)
 @php($uploadInputId = $uploadInputId ?? 'fisier_general')
-<div>
-    <div class="mb-4">
-        <form method="POST"
-              action="{{ route('masini-mementouri.fisiere-generale.store', $masina) }}"
-              enctype="multipart/form-data"
-              class="row g-3 align-items-end">
-            @csrf
-            <div class="col-md-8">
-                <label class="form-label" for="{{ $uploadInputId }}">{{ __('Încarcă fișier') }}</label>
-                <input type="file" id="{{ $uploadInputId }}" name="fisier" class="form-control rounded-3" required>
-                <small class="text-muted">{{ __('Fișiere permise: pdf, imagini, documente Office (maxim 50 MB).') }}</small>
+
+<div class="row justify-content-center g-4" data-general-files-section>
+    <div class="col-xl-6 col-lg-7">
+        <div class="card border border-secondary-subtle rounded-4 h-100">
+            <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
+                <span class="fw-semibold">
+                    <i class="fa-solid fa-upload me-2"></i>{{ __('Încarcă fișiere generale') }}
+                </span>
             </div>
-            <div class="col-md-4 text-md-end">
-                <button type="submit" class="btn btn-success text-white border border-dark w-100 rounded-3">
-                    <i class="fa-solid fa-upload me-1"></i>{{ __('Încarcă') }}
-                </button>
+            <div class="card-body">
+                <form method="POST"
+                      action="{{ route('masini-mementouri.fisiere-generale.store', $masina) }}"
+                      enctype="multipart/form-data">
+                    @csrf
+
+                    <div class="mb-3">
+                        <label class="form-label" for="{{ $uploadInputId }}">{{ __('Selectează fișiere') }}</label>
+                        <input type="file"
+                               id="{{ $uploadInputId }}"
+                               name="fisier[]"
+                               class="form-control rounded-3"
+                               multiple
+                               required
+                               accept="application/pdf,image/*,.txt,.csv,.doc,.docx,.xls,.xlsx,.ppt,.pptx">
+                        <small class="text-muted">{{ __('Fișiere permise: PDF, imagini, documente Office (maxim 50 MB fiecare).') }}</small>
+                    </div>
+
+                    <div class="text-end">
+                        <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
+                            <i class="fa-solid fa-floppy-disk me-1"></i>{{ __('Salvează fișierele') }}
+                        </button>
+                    </div>
+                </form>
             </div>
-        </form>
+        </div>
     </div>
 
-    <div>
-        <h5 class="mb-3">{{ __('Fișiere generale') }}</h5>
-        @include('masini-mementouri.partials.general-files-list', [
-            'masina' => $masina,
-            'fisiere' => $files,
-        ])
+    <div class="col-xl-8 col-lg-10">
+        <div class="card border border-secondary-subtle rounded-4">
+            <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
+                <span class="fw-semibold">
+                    <i class="fa-solid fa-folder-open me-2"></i>{{ __('Fișiere existente') }}
+                </span>
+            </div>
+            <div class="card-body">
+                @include('masini-mementouri.partials.general-files-list', [
+                    'masina' => $masina,
+                    'fisiere' => $files,
+                ])
+            </div>
+        </div>
     </div>
 </div>

--- a/resources/views/masini-mementouri/show.blade.php
+++ b/resources/views/masini-mementouri/show.blade.php
@@ -16,53 +16,62 @@
     </div>
 
     <div class="card-body px-0 py-3">
-        @include('errors')
+        @include('errors', ['showSessionAlerts' => false])
 
-        @if (session('status'))
+        @php($statusMessage = session('status') ?? session('success'))
+
+        @if ($statusMessage)
             <div class="alert alert-success border border-success-subtle rounded-4 mx-3 mb-4">
-                {{ session('status') }}
+                {{ $statusMessage }}
             </div>
         @endif
 
         <div class="mx-3 mb-4">
-            <form method="POST" action="{{ route('masini-mementouri.update', $masina) }}" class="row g-3">
-                @csrf
-                @method('PUT')
-                <div class="col-md-3">
-                    <label class="form-label" for="numar_inmatriculare">Număr înmatriculare</label>
-                    <input type="text" id="numar_inmatriculare" name="numar_inmatriculare" class="form-control rounded-3"
-                           value="{{ old('numar_inmatriculare', $masina->numar_inmatriculare) }}" required>
+            <div class="card border border-secondary-subtle rounded-4">
+                <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
+                    <span class="fw-semibold"><i class="fa-solid fa-pen-to-square me-2"></i>Detalii mașină</span>
                 </div>
-                <div class="col-md-3">
-                    <label class="form-label" for="descriere">Descriere</label>
-                    <input type="text" id="descriere" name="descriere" class="form-control rounded-3"
-                           value="{{ old('descriere', $masina->descriere) }}">
+                <div class="card-body">
+                    <form method="POST" action="{{ route('masini-mementouri.update', $masina) }}" class="row g-3">
+                        @csrf
+                        @method('PUT')
+                        <div class="col-md-3">
+                            <label class="form-label" for="numar_inmatriculare">Număr înmatriculare</label>
+                            <input type="text" id="numar_inmatriculare" name="numar_inmatriculare" class="form-control rounded-3"
+                                   value="{{ old('numar_inmatriculare', $masina->numar_inmatriculare) }}" required>
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label" for="descriere">Descriere</label>
+                            <input type="text" id="descriere" name="descriere" class="form-control rounded-3"
+                                   value="{{ old('descriere', $masina->descriere) }}">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label" for="marca_masina">Marca mașină</label>
+                            <input type="text" id="marca_masina" name="marca_masina" class="form-control rounded-3"
+                                   value="{{ old('marca_masina', $masina->marca_masina) }}">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label" for="serie_sasiu">Serie șasiu</label>
+                            <input type="text" id="serie_sasiu" name="serie_sasiu" class="form-control rounded-3"
+                                   value="{{ old('serie_sasiu', $masina->serie_sasiu) }}">
+                        </div>
+                        <div class="col-md-3">
+                            <label class="form-label" for="email_notificari">Email notificări</label>
+                            <input type="email" id="email_notificari" name="email_notificari" class="form-control rounded-3"
+                                   value="{{ old('email_notificari', optional($masina->memento)->email_notificari) }}">
+                        </div>
+                        <div class="col-12">
+                            <label class="form-label" for="observatii">Observații</label>
+                            <textarea id="observatii" name="observatii" class="form-control rounded-3" rows="2">{{ old('observatii', optional($masina->memento)->observatii) }}</textarea>
+                        </div>
+                        <div class="col-12 text-end">
+                            <button type="submit" class="btn btn-primary border border-dark rounded-3">
+                                <i class="fa-solid fa-floppy-disk me-1"></i>Salvează datele mașinii
+                            </button>
+                        </div>
+                    </form>
                 </div>
-                <div class="col-md-3">
-                    <label class="form-label" for="marca_masina">Marca mașină</label>
-                    <input type="text" id="marca_masina" name="marca_masina" class="form-control rounded-3"
-                           value="{{ old('marca_masina', $masina->marca_masina) }}">
-                </div>
-                <div class="col-md-3">
-                    <label class="form-label" for="serie_sasiu">Serie șasiu</label>
-                    <input type="text" id="serie_sasiu" name="serie_sasiu" class="form-control rounded-3"
-                           value="{{ old('serie_sasiu', $masina->serie_sasiu) }}">
-                </div>
-                <div class="col-md-3">
-                    <label class="form-label" for="email_notificari">Email notificări</label>
-                    <input type="email" id="email_notificari" name="email_notificari" class="form-control rounded-3"
-                           value="{{ old('email_notificari', optional($masina->memento)->email_notificari) }}">
-                </div>
-                <div class="col-12">
-                    <label class="form-label" for="observatii">Observații</label>
-                    <textarea id="observatii" name="observatii" class="form-control rounded-3" rows="2">{{ old('observatii', optional($masina->memento)->observatii) }}</textarea>
-                </div>
-                <div class="col-12 text-end">
-                    <button type="submit" class="btn btn-primary border border-dark rounded-3">
-                        <i class="fa-solid fa-floppy-disk me-1"></i>Salvează datele mașinii
-                    </button>
-                </div>
-            </form>
+            </div>
         </div>
 
         <div class="mx-3 mb-4">
@@ -70,103 +79,6 @@
                 'masina' => $masina,
                 'uploadInputId' => 'fisier_general_show',
             ])
-        </div>
-
-        <div class="mx-3">
-            <h5 class="mb-3">Documente</h5>
-            <div class="row g-3">
-                @foreach ($uploadDocumentLabels as $key => $label)
-                    @php
-                        if (str_contains($key, ':')) {
-                            [$type, $country] = explode(':', $key, 2);
-                            $document = $masina->documente->firstWhere(fn($doc) => $doc->document_type === $type && $doc->tara === $country);
-                        } else {
-                            $document = $masina->documente->firstWhere('document_type', $key);
-                        }
-                    @endphp
-                    @if ($document)
-                        <div class="col-lg-6">
-                            <div class="card h-100 border border-secondary-subtle rounded-4">
-                                <div class="card-header d-flex justify-content-between align-items-center rounded-4">
-                                    <span class="fw-semibold">{{ $label }}</span>
-                                    <span class="badge bg-light text-dark border">{{ optional($document->data_expirare)->isoFormat('DD.MM.YYYY') }}</span>
-                                </div>
-                                <div class="card-body">
-                                    <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}" class="row g-2 mb-3">
-                                        @csrf
-                                        @method('PATCH')
-                                        <div class="col-md-6">
-                                            <label class="form-label" for="data_expirare_{{ $document->id }}">Dată expirare</label>
-                                            <input type="date" class="form-control" id="data_expirare_{{ $document->id }}" name="data_expirare" value="{{ optional($document->data_expirare)->format('Y-m-d') }}">
-                                        </div>
-                                        <div class="col-md-6">
-                                            <label class="form-label" for="email_notificare_{{ $document->id }}">Email alertă</label>
-                                            <input type="email" class="form-control" id="email_notificare_{{ $document->id }}" name="email_notificare" value="{{ $document->email_notificare }}">
-                                        </div>
-                                        <div class="col-12 text-end">
-                                            <button type="submit" class="btn btn-outline-primary border border-dark">
-                                                <i class="fa-solid fa-floppy-disk me-1"></i>Salvează documentul
-                                            </button>
-                                        </div>
-                                    </form>
-
-                                    <form method="POST" action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}" enctype="multipart/form-data" class="row g-2 align-items-end">
-                                        @csrf
-                                        <div class="col-md-8">
-                                            <label class="form-label" for="fisier_{{ $document->id }}">Încarcă fișier (PDF)</label>
-                                            <input type="file" class="form-control" id="fisier_{{ $document->id }}" name="fisier" accept="application/pdf" required>
-                                        </div>
-                                        <div class="col-md-4">
-                                            <button type="submit" class="btn btn-success text-white border border-dark w-100">
-                                                <i class="fa-solid fa-upload me-1"></i>Încarcă
-                                            </button>
-                                        </div>
-                                    </form>
-
-                                    <hr>
-                                    <ul class="list-unstyled mb-0">
-                                        @forelse ($document->fisiere as $fisier)
-                                            @php
-                                                $iconClass = $fisier->iconClass();
-                                            @endphp
-                                            <li class="d-flex flex-column flex-md-row gap-2 justify-content-between align-items-md-center py-2 border-bottom">
-                                                <div class="me-md-3">
-                                                    <i class="fa-solid {{ $iconClass }} me-2"></i>
-                                                    <span class="fw-semibold">{{ $fisier->nume_original }}</span>
-                                                    <small class="text-muted ms-2">{{ number_format(($fisier->dimensiune ?? 0) / 1024, 1) }} KB</small>
-                                                </div>
-                                                <div class="d-flex align-items-center gap-2">
-                                                    <div class="btn-group btn-group-sm" role="group">
-                                                        @if ($fisier->isPreviewable())
-                                                            <a href="{{ route('masini-mementouri.documente.fisiere.preview', [$masina, $document, $fisier]) }}" class="btn btn-outline-primary border" target="_blank" rel="noopener" title="Deschide în filă nouă">
-                                                                <i class="fa-solid fa-eye me-1"></i>
-                                                                <span class="d-none d-sm-inline">Deschide</span>
-                                                            </a>
-                                                        @endif
-                                                        <a href="{{ route('masini-mementouri.documente.fisiere.download', [$masina, $document, $fisier]) }}" class="btn btn-outline-secondary border" download="{{ $fisier->downloadName() }}" title="Descarcă fișierul">
-                                                            <i class="fa-solid fa-download me-1"></i>
-                                                            <span class="d-none d-sm-inline">Descarcă</span>
-                                                        </a>
-                                                    </div>
-                                                    <form method="POST" action="{{ route('masini-mementouri.documente.fisiere.destroy', [$masina, $document, $fisier]) }}" onsubmit="return confirm('Ștergi fișierul?');">
-                                                        @csrf
-                                                        @method('DELETE')
-                                                        <button type="submit" class="btn btn-sm btn-outline-danger border border-dark">
-                                                            <i class="fa-solid fa-trash me-1"></i>Șterge
-                                                        </button>
-                                                    </form>
-                                                </div>
-                                            </li>
-                                        @empty
-                                            <li class="text-muted">Nu există fișiere încărcate.</li>
-                                        @endforelse
-                                    </ul>
-                                </div>
-                            </div>
-                        </div>
-                    @endif
-                @endforeach
-            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- update the add-car helper text with the new copy
- restyle the car details and general files sections, removing the unused document block
- align the general files UX with the document pages and support multi-file uploads server-side

## Testing
- php artisan test *(fails: vendor directory is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_690328ee865883269346b256a1dc44e1