### PR TITLE
Define 15-day colour class inline for masini mementouri

### DIFF
--- a/app/Http/Controllers/Masini/MasiniDocumentController.php
+++ b/app/Http/Controllers/Masini/MasiniDocumentController.php
@@ -61,6 +61,7 @@ class MasiniDocumentController extends Controller
         if ($shouldResetNotifications) {
             $document->notificare_60_trimisa = false;
             $document->notificare_30_trimisa = false;
+            $document->notificare_15_trimisa = false;
             $document->notificare_1_trimisa = false;
         }
 

--- a/app/Http/Controllers/Masini/MasiniDocumentFisierController.php
+++ b/app/Http/Controllers/Masini/MasiniDocumentFisierController.php
@@ -101,6 +101,7 @@ class MasiniDocumentFisierController extends Controller
         if ($shouldResetNotifications) {
             $document->notificare_60_trimisa = false;
             $document->notificare_30_trimisa = false;
+            $document->notificare_15_trimisa = false;
             $document->notificare_1_trimisa = false;
         }
 

--- a/app/Models/Masini/MasinaDocument.php
+++ b/app/Models/Masini/MasinaDocument.php
@@ -32,6 +32,7 @@ class MasinaDocument extends Model
         'data_expirare' => 'date',
         'notificare_60_trimisa' => 'boolean',
         'notificare_30_trimisa' => 'boolean',
+        'notificare_15_trimisa' => 'boolean',
         'notificare_1_trimisa' => 'boolean',
     ];
 
@@ -209,6 +210,10 @@ class MasinaDocument extends Model
             return 'bg-danger text-white';
         }
 
+        if ($diff <= 15) {
+            return 'bg-expiring-15 text-white';
+        }
+
         if ($diff <= 30) {
             return 'bg-warning';
         }
@@ -234,6 +239,7 @@ class MasinaDocument extends Model
         return [
             60 => 'notificare_60_trimisa',
             30 => 'notificare_30_trimisa',
+            15 => 'notificare_15_trimisa',
             1 => 'notificare_1_trimisa',
         ];
     }
@@ -243,6 +249,7 @@ class MasinaDocument extends Model
         $this->forceFill([
             'notificare_60_trimisa' => false,
             'notificare_30_trimisa' => false,
+            'notificare_15_trimisa' => false,
             'notificare_1_trimisa' => false,
         ])->saveQuietly();
     }

--- a/database/migrations/2025_03_24_000200_create_masini_documente_table.php
+++ b/database/migrations/2025_03_24_000200_create_masini_documente_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email_notificare')->nullable();
             $table->boolean('notificare_60_trimisa')->default(false);
             $table->boolean('notificare_30_trimisa')->default(false);
+            $table->boolean('notificare_15_trimisa')->default(false);
             $table->boolean('notificare_1_trimisa')->default(false);
             $table->timestamps();
 

--- a/database/migrations/2025_03_24_010000_seed_masini_mementouri_data.php
+++ b/database/migrations/2025_03_24_010000_seed_masini_mementouri_data.php
@@ -89,6 +89,7 @@ return new class extends Migration
                         'email_notificare' => null,
                         'notificare_60_trimisa' => false,
                         'notificare_30_trimisa' => false,
+                        'notificare_15_trimisa' => false,
                         'notificare_1_trimisa' => false,
                         'created_at' => $timestamp,
                         'updated_at' => $timestamp,

--- a/database/migrations/2025_03_24_020000_add_notificare_15_trimisa_to_masini_documente_table.php
+++ b/database/migrations/2025_03_24_020000_add_notificare_15_trimisa_to_masini_documente_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('masini_documente', function (Blueprint $table) {
+            $table->boolean('notificare_15_trimisa')->default(false)->after('notificare_30_trimisa');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('masini_documente', function (Blueprint $table) {
+            $table->dropColumn('notificare_15_trimisa');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -84,3 +84,8 @@
     outline: 2px solid currentColor;
     outline-offset: 2px;
 }
+
+.bg-expiring-15 {
+    background-color: #fd7e14 !important;
+    color: #fff !important;
+}

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -26,6 +26,11 @@
             text-decoration: underline;
         }
 
+        .bg-expiring-15 {
+            background-color: #fd7e14 !important;
+            color: #fff !important;
+        }
+
         .document-cell.bg-warning {
             color: #000 !important;
         }
@@ -57,6 +62,9 @@
                     <ul class="list-inline small mb-0 d-flex flex-wrap gap-2 align-items-center">
                         <li class="list-inline-item mb-1">
                             <span class="document-legend-pill bg-danger text-white">Expirat / ≤ 1 zi</span>
+                        </li>
+                        <li class="list-inline-item mb-1">
+                            <span class="document-legend-pill bg-expiring-15 text-white">≤ 15 zile</span>
                         </li>
                         <li class="list-inline-item mb-1">
                             <span class="document-legend-pill bg-warning">≤ 30 zile</span>

--- a/tests/Unit/Models/MasinaDocumentTest.php
+++ b/tests/Unit/Models/MasinaDocumentTest.php
@@ -28,7 +28,8 @@ class MasinaDocumentTest extends TestCase
             'missing date' => [null, 'bg-secondary-subtle'],
             'expired date' => ['2024-04-30', 'bg-danger text-white'],
             'expires in 1 day' => ['2024-05-02', 'bg-danger text-white'],
-            'expires in 15 days' => ['2024-05-16', 'bg-warning'],
+            'expires in 10 days' => ['2024-05-11', 'bg-expiring-15 text-white'],
+            'expires in 20 days' => ['2024-05-21', 'bg-warning'],
             'expires in 45 days' => ['2024-06-15', 'bg-success text-white'],
             'long term' => ['2024-07-15', ''],
         ];


### PR DESCRIPTION
## Summary
- define the bg-expiring-15 helper directly in the masini mementouri view styles so the new state has the expected colour

## Testing
- not run (composer dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_69033141a9a083269d8bbf78327aa693