### PR TITLE
Add filtering controls and file access to calup invoices

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -106,11 +106,18 @@ class PlataCalupController extends Controller
 
     public function show(PlataCalup $plataCalup)
     {
-        $plataCalup->load(['facturi' => fn ($query) => $query->orderByRaw('data_scadenta IS NULL')->orderBy('data_scadenta')]);
+        $plataCalup->load([
+            'facturi' => fn ($query) => $query
+                ->with('fisiere')
+                ->orderByRaw('data_scadenta IS NULL')
+                ->orderBy('data_scadenta'),
+        ]);
 
         $facturiCalup = $plataCalup->facturi
             ->sortBy(fn (FacturaFurnizor $factura) => $factura->data_scadenta?->timestamp ?? PHP_INT_MAX)
             ->values();
+
+        $facturiCalup->load('fisiere');
 
         $totaluriFacturiCalupPeMoneda = $facturiCalup
             ->groupBy(fn (FacturaFurnizor $factura) => $factura->moneda)


### PR DESCRIPTION
## Summary
- eager load invoice files alongside calup invoices to avoid N+1 queries
- render file action icons for each attached invoice with open/download behaviors
- add supplier and invoice number filters when attaching invoices to a calup, with toggle-all updates

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_69046cf621c483269a42be3707e37916