### PR TITLE
Add IBAN column to supplier subtotals table

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -133,10 +133,12 @@ class PlataCalupController extends Controller
             ->map(function ($facturi) {
                 /** @var \Illuminate\Support\Collection<int, FacturaFurnizor> $facturi */
                 $primul = $facturi->first();
+                $facturaCuIban = $facturi->firstWhere(fn (FacturaFurnizor $factura) => filled($factura->cont_iban));
 
                 return [
                     'furnizor_id' => $primul->furnizor_id ?? null,
                     'furnizor' => $primul->denumire_furnizor,
+                    'cont_iban' => $facturaCuIban?->cont_iban,
                     'totals' => $facturi
                         ->groupBy(fn (FacturaFurnizor $factura) => $factura->moneda)
                         ->map(fn ($facturiMoneda) => $facturiMoneda->sum('suma'))

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -185,6 +185,7 @@
                                     <thead class="bg-light">
                                         <tr>
                                             <th>Furnizor</th>
+                                            <th>Cont IBAN</th>
                                             <th class="text-end">Totaluri</th>
                                         </tr>
                                     </thead>
@@ -192,6 +193,7 @@
                                         @foreach ($totaluriFacturiCalupPeFurnizor as $subtotal)
                                             <tr>
                                                 <td class="fw-semibold">{{ $subtotal['furnizor'] }}</td>
+                                                <td>{{ $subtotal['cont_iban'] ?? '—' }}</td>
                                                 <td class="text-end">
                                                     @foreach ($subtotal['totals'] as $moneda => $total)
                                                         <div>{{ number_format($total, 2) }} {{ $moneda }}</div>


### PR DESCRIPTION
## Summary
- capture available supplier IBAN values while building subtotal data for payment batches
- display the new Cont IBAN column in the Subtotaluri pe furnizor table on the calup details page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6904896a435083268546e5a7b6af04c9