### PR TITLE
Add image upload support for DocumentWord editor

### DIFF
--- a/app/Http/Controllers/DocumentWordController.php
+++ b/app/Http/Controllers/DocumentWordController.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 use App\Http\Requests\DocumentWordRequest;
 use PDF; // Barryvdh\DomPDF\Facade
@@ -168,5 +170,26 @@ class DocumentWordController extends Controller
         ]);
 
         return redirect($request->session()->get('documentWordReturnUrl') ?? ('/documente-word'))->with('status', 'Documentul word „' . ($documentWord->nume ?? '') . '” a fost deblocat cu succes!');
+    }
+
+    public function uploadImage(Request $request): JsonResponse
+    {
+        $this->authorize('create', DocumentWord::class);
+
+        $request->validate([
+            'image' => ['required', 'image', 'max:5120'],
+        ]);
+
+        $file = $request->file('image');
+        $path = $file->store('documente-word/images', 'public');
+
+        return response()->json([
+            'url' => Storage::disk('public')->url($path),
+            'path' => $path,
+            'disk' => 'public',
+            'original_name' => $file->getClientOriginalName(),
+            'mime_type' => $file->getClientMimeType(),
+            'size' => $file->getSize(),
+        ], 201);
     }
 }

--- a/resources/js/components/TiptapEditor.vue
+++ b/resources/js/components/TiptapEditor.vue
@@ -70,6 +70,19 @@
                 <button type="button" @click="unsetLink" title="Unset link"><i class="fa-solid fa-link-slash"></i></button>
             </div>
 
+            <!-- Images -->
+            <div class="btn-group me-3" role="group">
+                <button
+                    type="button"
+                    class="btn"
+                    @click="triggerImageUpload"
+                    :disabled="isUploading"
+                    title="Încarcă imagine"
+                >
+                    <i class="fa-solid fa-image"></i>
+                </button>
+            </div>
+
             <!-- Table Controls -->
             <!-- <div class="btn-group me-3">
                 <button type="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
@@ -136,7 +149,11 @@
 
 
     <!-- Tiptap Editor -->
-    <div class="editor-container border rounded p-2 bg-white" :style="{ height: height }">
+    <div
+      ref="editorContainer"
+      class="editor-container border rounded p-2 bg-white"
+      :style="{ height: height }"
+    >
       <editor-content :editor="editor" />
 
       <!-- Floating Menu for Tables -->
@@ -170,6 +187,15 @@
       :name="inputname"
       :value="editorContent"
     />
+
+    <!-- Hidden file input for image uploads -->
+    <input
+      ref="imageInput"
+      type="file"
+      class="d-none"
+      accept="image/*"
+      @change="handleFileChange"
+    />
   </div>
 </template>
 
@@ -186,6 +212,7 @@ import Table from '@tiptap/extension-table';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import TableRow from '@tiptap/extension-table-row';
+import Image from '@tiptap/extension-image';
 
 import { mergeCells, splitCell} from 'prosemirror-tables';
 
@@ -204,12 +231,27 @@ export default {
         type: String,
         default: '400px', // Default editor height
     },
+    uploadUrl: {
+      type: String,
+      required: true,
+    },
+    uploadHeaders: {
+      type: Object,
+      default: () => ({}),
+    },
+    uploadFieldName: {
+      type: String,
+      default: 'image',
+    },
   },
   data() {
     return {
         editor: null,
         textColor: '#000000',
         isFullscreen: false,
+        activeUploads: 0,
+        boundDragOverHandler: null,
+        boundDropHandler: null,
     };
   },
   computed: {
@@ -265,6 +307,25 @@ export default {
     isStrikeActive() {
       return this.editor?.isActive('strike');
     },
+    isUploading() {
+      return this.activeUploads > 0;
+    },
+    uploadRequestHeaders() {
+      const headers = {
+        Accept: 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+        ...(this.uploadHeaders || {}),
+      };
+
+      if (!headers['X-CSRF-TOKEN']) {
+        const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+        if (token) {
+          headers['X-CSRF-TOKEN'] = token;
+        }
+      }
+
+      return headers;
+    },
   },
   mounted() {
     let initialContent;
@@ -314,6 +375,7 @@ export default {
           },
         }),
         Color,
+        Image,
         StarterKit.configure({
             bold: true,
             italic: true,
@@ -362,8 +424,25 @@ export default {
     this.editor.on('selectionUpdate', () => {
       this.$forceUpdate();
     });
+
+    const container = this.$refs.editorContainer;
+    if (container) {
+      this.boundDragOverHandler = this.handleEditorDragOver.bind(this);
+      this.boundDropHandler = this.handleEditorDrop.bind(this);
+      container.addEventListener('dragover', this.boundDragOverHandler);
+      container.addEventListener('drop', this.boundDropHandler);
+    }
   },
   beforeUnmount() {
+    const container = this.$refs.editorContainer;
+    if (container) {
+      if (this.boundDragOverHandler) {
+        container.removeEventListener('dragover', this.boundDragOverHandler);
+      }
+      if (this.boundDropHandler) {
+        container.removeEventListener('drop', this.boundDropHandler);
+      }
+    }
     this.editor.destroy();
   },
   methods: {
@@ -459,6 +538,120 @@ export default {
     },
     splitCell() {
       this.editor.chain().focus().splitCell().run();
+    },
+    triggerImageUpload() {
+      this.$refs.imageInput?.click();
+    },
+    handleFileChange(event) {
+      const files = event.target.files;
+      if (files?.length) {
+        this.processImageFiles(files);
+      }
+      event.target.value = '';
+    },
+    async processImageFiles(fileList, position = null) {
+      if (!this.editor) {
+        return;
+      }
+
+      const files = Array.from(fileList || []).filter((file) => this.isImageFile(file));
+      if (!files.length) {
+        return;
+      }
+
+      let insertionPoint = typeof position === 'number' ? position : null;
+
+      for (const file of files) {
+        await this.uploadAndInsertImage(file, insertionPoint);
+        if (typeof insertionPoint === 'number') {
+          insertionPoint = this.editor.state.selection.to;
+        }
+      }
+    },
+    async uploadAndInsertImage(file, position = null) {
+      if (!file || !this.editor) {
+        return;
+      }
+
+      this.activeUploads += 1;
+
+      try {
+        const payload = await this.uploadImage(file);
+        if (!payload?.url) {
+          return;
+        }
+
+        const imageAttrs = {
+          src: payload.url,
+          alt: payload.original_name || file.name || '',
+          title: payload.original_name || file.name || '',
+        };
+
+        const chain = this.editor.chain().focus();
+
+        if (typeof position === 'number') {
+          chain.insertContentAt(position, {
+            type: 'image',
+            attrs: imageAttrs,
+          });
+        } else {
+          chain.setImage(imageAttrs);
+        }
+
+        chain.run();
+      } catch (error) {
+        console.error('Failed to upload image', error);
+      } finally {
+        this.activeUploads = Math.max(0, this.activeUploads - 1);
+      }
+    },
+    async uploadImage(file) {
+      if (!this.uploadUrl) {
+        throw new Error('Upload URL is not configured');
+      }
+
+      const formData = new FormData();
+      formData.append(this.uploadFieldName, file);
+
+      const response = await fetch(this.uploadUrl, {
+        method: 'POST',
+        headers: this.uploadRequestHeaders,
+        body: formData,
+        credentials: 'same-origin',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Upload failed with status ${response.status}`);
+      }
+
+      return await response.json();
+    },
+    handleEditorDragOver(event) {
+      if (event.dataTransfer?.types?.includes('Files')) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'copy';
+      }
+    },
+    async handleEditorDrop(event) {
+      if (!event.dataTransfer?.files?.length) {
+        return;
+      }
+
+      const imageFiles = Array.from(event.dataTransfer.files).some((file) => this.isImageFile(file));
+      if (!imageFiles) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const { clientX, clientY } = event;
+      const coords = this.editor?.view?.posAtCoords({ left: clientX, top: clientY });
+      const position = coords?.pos ?? null;
+
+      await this.processImageFiles(event.dataTransfer.files, position);
+    },
+    isImageFile(file) {
+      return file && file.type.startsWith('image/');
     },
   },
 };

--- a/resources/views/documenteWord/form.blade.php
+++ b/resources/views/documenteWord/form.blade.php
@@ -31,6 +31,8 @@
                         :inputvalue='@json(old('continut', $documentWord->continut ?? ''))'
                         inputname="continut"
                         height="600px"
+                        upload-url="{{ route('documente-word.images') }}"
+                        :upload-headers='@json(['X-CSRF-TOKEN' => csrf_token()])'
                     ></tiptap-editor>
                 </div>
                 <!-- PRINT-AREA end -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -147,6 +147,9 @@ Route::middleware(['auth'])->group(function () {
     });
 
     Route::middleware('permission:documente-word')->group(function () {
+        Route::post('/documente-word/images', [DocumentWordController::class, 'uploadImage'])
+            ->name('documente-word.images');
+
         Route::resource('/documente-word', DocumentWordController::class)
             ->only(['index', 'show', 'create', 'store', 'edit', 'update'])
             ->parameters(['documente-word' => 'documentWord']);

--- a/tests/Feature/DocumentWordImageTest.php
+++ b/tests/Feature/DocumentWordImageTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\DocumentWord;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\Concerns\CreatesUsersWithRoles;
+use Tests\TestCase;
+
+class DocumentWordImageTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesUsersWithRoles;
+
+    public function test_authorized_user_can_upload_image_for_document_word(): void
+    {
+        Storage::fake('public');
+
+        $user = $this->createUserWithRoles('documente-word-operator');
+
+        $response = $this->actingAs($user)->postJson(route('documente-word.images'), [
+            'image' => UploadedFile::fake()->image('editor-upload.png', 800, 600),
+        ]);
+
+        $response->assertCreated();
+        $response->assertJsonStructure([
+            'url',
+            'path',
+            'disk',
+            'original_name',
+            'mime_type',
+            'size',
+        ]);
+
+        $path = $response->json('path');
+        $this->assertNotEmpty($path);
+        Storage::disk('public')->assertExists($path);
+    }
+
+    public function test_unauthorized_user_cannot_upload_document_word_images(): void
+    {
+        Storage::fake('public');
+
+        $user = $this->createUserWithRoles('mecanic');
+
+        $response = $this->actingAs($user)->postJson(route('documente-word.images'), [
+            'image' => UploadedFile::fake()->image('blocked.png'),
+        ]);
+
+        $response->assertForbidden();
+    }
+
+    public function test_document_word_payload_accepts_image_nodes(): void
+    {
+        $user = $this->createUserWithRoles('documente-word-operator');
+
+        $payload = [
+            'nume' => 'Document cu imagine',
+            'continut' => json_encode([
+                'type' => 'doc',
+                'content' => [
+                    [
+                        'type' => 'paragraph',
+                        'content' => [
+                            ['type' => 'text', 'text' => 'Imagine înainte'],
+                        ],
+                    ],
+                    [
+                        'type' => 'image',
+                        'attrs' => [
+                            'src' => 'https://example.com/image.png',
+                            'alt' => 'Example image',
+                            'title' => 'Example image',
+                        ],
+                    ],
+                ],
+            ]),
+        ];
+
+        $response = $this->actingAs($user)->post('/documente-word', $payload);
+
+        $response->assertRedirect('/documente-word');
+
+        $this->assertDatabaseHas('documente_word', [
+            'nume' => 'Document cu imagine',
+        ]);
+
+        $document = DocumentWord::where('nume', 'Document cu imagine')->firstOrFail();
+        $this->assertJson($document->continut);
+
+        $decoded = json_decode($document->continut, true);
+        $this->assertSame('image', $decoded['content'][1]['type']);
+        $this->assertSame('https://example.com/image.png', $decoded['content'][1]['attrs']['src']);
+    }
+}


### PR DESCRIPTION
## Summary
- add an authenticated `/documente-word/images` endpoint that stores uploads for the DocumentWord editor
- extend the DocumentWord controller to validate image uploads and return public URLs for the editor
- enhance the Tiptap editor component with image toolbar actions, drag-and-drop handling, and configurable upload props
- add coverage ensuring image nodes are accepted in DocumentWord payloads and unauthorized users cannot upload images

## Testing
- ⚠️ `composer install --quiet` *(fails: cannot clone symfony/finder because outbound access is blocked)*
- ⚠️ `php artisan test` *(fails: vendor/autoload.php missing after composer install could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_690a4fbb6dd08326ba3cffa7bdfa8594