### PR TITLE
Remove email from general file descriptions

### DIFF
--- a/resources/views/masini-mementouri/partials/general-files-list.blade.php
+++ b/resources/views/masini-mementouri/partials/general-files-list.blade.php
@@ -14,13 +14,7 @@
             $details = [number_format(($fisier->dimensiune ?? 0) / 1024, 1) . ' KB'];
 
             if ($fisier->uploaded_by_name) {
-                $uploadedBy = $fisier->uploaded_by_name;
-
-                if ($fisier->uploaded_by_email) {
-                    $uploadedBy .= ' <' . $fisier->uploaded_by_email . '>';
-                }
-
-                $details[] = $uploadedBy;
+                $details[] = $fisier->uploaded_by_name;
             }
 
             if ($fisier->created_at) {


### PR DESCRIPTION
## Summary
- stop including uploader email addresses in the general files list details

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690b994a41ac832696352728f63afa11