### PR TITLE
Sort facturi calup by supplier name

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -109,13 +109,13 @@ class PlataCalupController extends Controller
         $plataCalup->load([
             'facturi' => fn ($query) => $query
                 ->with('fisiere')
+                ->orderByRaw('denumire_furnizor IS NULL')
+                ->orderBy('denumire_furnizor')
                 ->orderByRaw('data_scadenta IS NULL')
                 ->orderBy('data_scadenta'),
         ]);
 
-        $facturiCalup = $plataCalup->facturi
-            ->sortBy(fn (FacturaFurnizor $factura) => $factura->data_scadenta?->timestamp ?? PHP_INT_MAX)
-            ->values();
+        $facturiCalup = $plataCalup->facturi->values();
 
         $facturiCalup->load('fisiere');
 


### PR DESCRIPTION
## Summary
- order calup invoices by supplier name when loading them for the show page
- retain eager loading and preserve existing totals logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690d0e2417948326870c490b72544e96