### PR TITLE
Support masina document entries without expiry dates

### DIFF
--- a/app/Models/Masini/MasinaDocument.php
+++ b/app/Models/Masini/MasinaDocument.php
@@ -26,6 +26,7 @@ class MasinaDocument extends Model
         'tara',
         'data_expirare',
         'email_notificare',
+        'fara_expirare',
     ];
 
     protected $casts = [
@@ -34,6 +35,7 @@ class MasinaDocument extends Model
         'notificare_30_trimisa' => 'boolean',
         'notificare_15_trimisa' => 'boolean',
         'notificare_1_trimisa' => 'boolean',
+        'fara_expirare' => 'boolean',
     ];
 
     public function masina()
@@ -196,7 +198,11 @@ class MasinaDocument extends Model
 
     public function colorClass(): string
     {
-        if (!$this->data_expirare) {
+        if ($this->isWithoutExpiry()) {
+            return 'bg-secondary-subtle';
+        }
+
+        if (!$this->hasExpiryDate()) {
             return 'bg-secondary-subtle';
         }
 
@@ -227,11 +233,39 @@ class MasinaDocument extends Model
 
     public function daysUntilExpiry(): ?int
     {
-        if (!$this->data_expirare) {
+        if (!$this->hasExpiryDate()) {
             return null;
         }
 
         return Carbon::now()->startOfDay()->diffInDays($this->data_expirare, false);
+    }
+
+    public function hasExpiryDate(): bool
+    {
+        return !$this->fara_expirare && $this->data_expirare !== null;
+    }
+
+    public function isWithoutExpiry(): bool
+    {
+        return (bool) $this->fara_expirare;
+    }
+
+    public function formattedExpiryDate(): ?string
+    {
+        if (!$this->hasExpiryDate()) {
+            return null;
+        }
+
+        return $this->data_expirare?->format('Y-m-d');
+    }
+
+    public function readableExpiryDate(): string
+    {
+        if ($this->isWithoutExpiry()) {
+            return 'FĂRĂ';
+        }
+
+        return $this->data_expirare?->format('d.m.Y') ?? '—';
     }
 
     public static function notificationThresholds(): array

--- a/database/migrations/2025_03_24_030000_add_fara_expirare_to_masini_documente_table.php
+++ b/database/migrations/2025_03_24_030000_add_fara_expirare_to_masini_documente_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('masini_documente', function (Blueprint $table) {
+            $table->boolean('fara_expirare')->default(false)->nullable()->after('data_expirare');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('masini_documente', function (Blueprint $table) {
+            $table->dropColumn('fara_expirare');
+        });
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -85,6 +85,18 @@
     outline-offset: 2px;
 }
 
+.document-inline-controls {
+    width: 100%;
+}
+
+.document-inline-controls .form-control {
+    min-width: 150px;
+}
+
+.document-inline-controls .form-check-label {
+    white-space: nowrap;
+}
+
 .bg-expiring-15 {
     background-color: #fd7e14 !important;
     color: #fff !important;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -7,6 +7,7 @@
 import './bootstrap';
 
 import '../sass/app.scss'
+import '../css/app.css'
 import '../css/andrei.css'
 
 
@@ -1138,6 +1139,298 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Optional: stop timer when navigating away
     window.addEventListener('beforeunload', () => { if (timerId) clearTimeout(timerId); });
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const initializeNoExpiryControls = (container, { autoSync = true } = {}) => {
+        if (!container) {
+            return { checkbox: null, dateInput: null, hiddenInput: null, syncState: () => {} };
+        }
+
+        const checkbox = container.querySelector('[data-no-expiry-toggle]');
+        const dateInput = container.querySelector('[data-date-input]');
+        const hiddenInput = container.querySelector('[data-no-expiry-hidden]');
+
+        if (!checkbox || !dateInput) {
+            return { checkbox: null, dateInput: null, hiddenInput: null, syncState: () => {} };
+        }
+
+        const syncState = () => {
+            const checked = checkbox.checked;
+            dateInput.disabled = checked;
+
+            if (checked) {
+                dateInput.value = '';
+            }
+
+            if (hiddenInput) {
+                hiddenInput.value = checked ? '1' : '0';
+            }
+        };
+
+        if (autoSync) {
+            checkbox.addEventListener('change', syncState);
+        }
+
+        syncState();
+
+        return { checkbox, dateInput, hiddenInput, syncState };
+    };
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? null;
+
+    document.querySelectorAll('[data-document-update]').forEach((form) => {
+        const wrapper = form.closest('[data-document-wrapper]');
+        const colorHolder = wrapper?.querySelector('[data-color-holder]') ?? wrapper;
+        const baseClass = wrapper?.dataset.baseClass ?? (colorHolder?.className ?? '');
+        const emptyLabel = wrapper?.dataset.emptyLabel ?? '—';
+        const noExpiryLabel = wrapper?.dataset.noExpiryLabel ?? 'FĂRĂ';
+
+        const dateText = form.querySelector('[data-date-text]');
+        const editTrigger = form.querySelector('[data-edit-trigger]');
+        const editControls = form.querySelector('[data-edit-controls]');
+        const cancelButton = form.querySelector('[data-cancel-edit]');
+        const saveButton = form.querySelector('[data-save-trigger]');
+        const feedbackTarget = form.querySelector('[data-feedback-target]');
+
+        const { checkbox, dateInput, syncState } = initializeNoExpiryControls(
+            form.querySelector('[data-no-expiry-container]'),
+            { autoSync: false }
+        );
+
+        if (checkbox) {
+            checkbox.addEventListener('change', () => {
+                syncState();
+                if (form.dataset.autoSubmit === 'true') {
+                    submitForm();
+                }
+            });
+        }
+
+        if (dateInput && form.dataset.autoSubmit === 'true') {
+            dateInput.addEventListener('change', () => submitForm());
+        }
+
+        const clearFeedback = () => {
+            if (!feedbackTarget) {
+                return;
+            }
+
+            feedbackTarget.hidden = true;
+            feedbackTarget.textContent = '';
+            feedbackTarget.classList.remove('text-danger', 'text-success');
+        };
+
+        const showFeedback = (message, type = 'success') => {
+            if (!feedbackTarget || !message) {
+                return;
+            }
+
+            feedbackTarget.hidden = false;
+            feedbackTarget.textContent = message;
+            feedbackTarget.classList.toggle('text-danger', type === 'error');
+            feedbackTarget.classList.toggle('text-success', type !== 'error');
+        };
+
+        let isEditing = false;
+        let isSubmitting = false;
+        let originalDateValue = dateInput?.value ?? '';
+        let originalNoExpiry = checkbox?.checked ?? false;
+
+        const rememberOriginalValues = () => {
+            originalDateValue = dateInput?.value ?? '';
+            originalNoExpiry = checkbox?.checked ?? false;
+        };
+
+        const setEditing = (state) => {
+            isEditing = state;
+
+            if (editControls) {
+                editControls.classList.toggle('visually-hidden', !state);
+            }
+
+            if (dateText) {
+                dateText.classList.toggle('visually-hidden', state);
+            }
+
+            if (editTrigger) {
+                editTrigger.classList.toggle('d-none', state);
+                editTrigger.setAttribute('aria-expanded', state ? 'true' : 'false');
+            }
+        };
+
+        const resetToOriginal = () => {
+            if (dateInput) {
+                dateInput.value = originalDateValue;
+            }
+
+            if (checkbox) {
+                checkbox.checked = originalNoExpiry;
+            }
+
+            syncState();
+        };
+
+        const updateColorClass = (colorClass) => {
+            if (!colorHolder) {
+                return;
+            }
+
+            const composed = [baseClass, colorClass ?? ''].filter(Boolean).join(' ').trim();
+            colorHolder.className = composed;
+        };
+
+        const submitForm = async () => {
+            if (isSubmitting) {
+                return;
+            }
+
+            isSubmitting = true;
+
+            const formData = new FormData(form);
+
+            if (checkbox) {
+                formData.set('fara_expirare', checkbox.checked ? '1' : '0');
+                if (checkbox.checked) {
+                    formData.set('data_expirare', '');
+                }
+            }
+
+            if (csrfToken && !formData.has('_token')) {
+                formData.set('_token', csrfToken);
+            }
+
+            try {
+                const response = await fetch(form.action, {
+                    method: 'POST',
+                    headers: {
+                        'Accept': 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    credentials: 'same-origin',
+                    body: formData,
+                });
+
+                if (response.status === 422) {
+                    const data = await response.json().catch(() => ({}));
+                    const errors = data.errors ?? {};
+                    const firstError = Object.values(errors)[0]?.[0] ?? 'Date invalide.';
+                    showFeedback(firstError, 'error');
+                    return;
+                }
+
+                if (!response.ok) {
+                    throw new Error('Request failed');
+                }
+
+                const payload = await response.json();
+
+                const readableDate = payload.readable_date ?? '';
+                const formattedDate = payload.formatted_date ?? '';
+                const faraExpirare = Boolean(payload.fara_expirare);
+
+                if (dateText) {
+                    let displayValue = readableDate;
+
+                    if (!displayValue) {
+                        displayValue = faraExpirare ? noExpiryLabel : emptyLabel;
+                    }
+
+                    dateText.textContent = displayValue;
+                }
+
+                if (dateInput) {
+                    dateInput.value = formattedDate;
+                }
+
+                if (checkbox) {
+                    checkbox.checked = faraExpirare;
+                }
+
+                syncState();
+                rememberOriginalValues();
+                updateColorClass(payload.color_class ?? '');
+
+                if (payload.message) {
+                    showFeedback(payload.message, 'success');
+                } else {
+                    clearFeedback();
+                }
+
+                setEditing(false);
+            } catch (error) {
+                console.error('Document update failed', error);
+                showFeedback('A apărut o eroare. Reîncearcă.', 'error');
+            } finally {
+                isSubmitting = false;
+            }
+        };
+
+        form.addEventListener('submit', (event) => {
+            event.preventDefault();
+            submitForm();
+        });
+
+        if (saveButton) {
+            saveButton.addEventListener('click', (event) => {
+                event.preventDefault();
+                submitForm();
+            });
+        }
+
+        if (cancelButton) {
+            cancelButton.addEventListener('click', (event) => {
+                event.preventDefault();
+
+                if (isSubmitting) {
+                    return;
+                }
+
+                resetToOriginal();
+                clearFeedback();
+                setEditing(false);
+            });
+        }
+
+        if (editTrigger) {
+            editTrigger.addEventListener('click', () => {
+                if (isEditing) {
+                    resetToOriginal();
+                    clearFeedback();
+                    setEditing(false);
+                    return;
+                }
+
+                rememberOriginalValues();
+                clearFeedback();
+                setEditing(true);
+
+                if (checkbox?.checked) {
+                    checkbox.focus();
+                } else if (dateInput) {
+                    dateInput.focus();
+
+                    if (typeof dateInput.showPicker === 'function') {
+                        try {
+                            dateInput.showPicker();
+                        } catch (error) {
+                            // Ignore showPicker errors in unsupported browsers
+                        }
+                    }
+                }
+            });
+        }
+
+        setEditing(false);
+    });
+
+    document.querySelectorAll('[data-no-expiry-container]').forEach((container) => {
+        if (container.closest('[data-document-update]')) {
+            return;
+        }
+
+        initializeNoExpiryControls(container);
+    });
 });
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/resources/views/masini-mementouri/document-edit.blade.php
+++ b/resources/views/masini-mementouri/document-edit.blade.php
@@ -42,13 +42,30 @@
                                   enctype="multipart/form-data">
                                 @csrf
 
-                                <div class="mb-3">
+                                @php
+                                    $faraExpirare = old('fara_expirare', $document->fara_expirare) ? true : false;
+                                @endphp
+                                <div class="mb-3" data-no-expiry-container>
                                     <label class="form-label" for="data_expirare">Dată expirare</label>
-                                    <input type="date"
-                                           id="data_expirare"
-                                           name="data_expirare"
-                                           class="form-control rounded-3"
-                                           value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
+                                    <div class="d-flex align-items-center gap-3 flex-wrap">
+                                        <input type="date"
+                                               id="data_expirare"
+                                               name="data_expirare"
+                                               class="form-control rounded-3"
+                                               value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}"
+                                               data-date-input>
+                                        <div class="form-check mb-0">
+                                            <input type="hidden" name="fara_expirare" value="0" data-no-expiry-hidden>
+                                            <input type="checkbox"
+                                                   class="form-check-input"
+                                                   id="fara_expirare"
+                                                   name="fara_expirare"
+                                                   value="1"
+                                                   {{ $faraExpirare ? 'checked' : '' }}
+                                                   data-no-expiry-toggle>
+                                            <label class="form-check-label" for="fara_expirare">Fără expirare</label>
+                                        </div>
+                                    </div>
                                     <small class="text-muted">Modificarea datei necesită încărcarea unui fișier în același timp.</small>
                                 </div>
 

--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -133,9 +133,11 @@
                             @foreach ($gridDocumentTypes as $type => $label)
                                 @php
                                     $document = $documents->get($type);
-                                    $displayDate = optional($document?->data_expirare)->format('d.m.Y') ?? '—';
+                                    $readableDate = $document ? $document->readableExpiryDate() : '—';
                                     $colorClass = $document?->colorClass() ?? 'bg-secondary-subtle text-body-secondary';
-                                    $isEmpty = !$document?->data_expirare;
+                                    $hasExpiry = $document?->hasExpiryDate() ?? false;
+                                    $isWithoutExpiry = $document?->isWithoutExpiry() ?? false;
+                                    $isEmpty = !$document || (!$hasExpiry && !$isWithoutExpiry);
                                     $ariaLabel = "Actualizează {$label} pentru {$masina->numar_inmatriculare}";
                                     $routeDocumentParam = $document?->getRouteKey() ?? \App\Models\Masini\MasinaDocument::buildRouteKey($type);
                                 @endphp
@@ -144,7 +146,7 @@
                                        class="document-cell-link d-inline-flex w-100 justify-content-center {{ $isEmpty ? 'document-cell-link--empty' : '' }}"
                                        aria-label="{{ $ariaLabel }}">
                                         <span class="document-cell px-2 py-1 w-100 {{ $colorClass }}">
-                                            {{ $displayDate }}
+                                            {{ $readableDate }}
                                         </span>
                                     </a>
                                 </td>
@@ -153,9 +155,11 @@
                                 @php
                                     $documentKey = \App\Models\Masini\MasinaDocument::TYPE_VIGNETA . ':' . $code;
                                     $document = $documents->get($documentKey);
-                                    $displayDate = optional($document?->data_expirare)->format('d.m.Y') ?? '—';
+                                    $readableDate = $document ? $document->readableExpiryDate() : '—';
                                     $colorClass = $document?->colorClass() ?? 'bg-secondary-subtle text-body-secondary';
-                                    $isEmpty = !$document?->data_expirare;
+                                    $hasExpiry = $document?->hasExpiryDate() ?? false;
+                                    $isWithoutExpiry = $document?->isWithoutExpiry() ?? false;
+                                    $isEmpty = !$document || (!$hasExpiry && !$isWithoutExpiry);
                                     $displayLabel = \App\Models\Masini\MasinaDocument::vignetteDisplayLabel($code);
                                     $ariaLabel = "Actualizează {$displayLabel} pentru {$masina->numar_inmatriculare}";
                                     $routeDocumentParam = $document?->getRouteKey() ?? \App\Models\Masini\MasinaDocument::buildRouteKey(\App\Models\Masini\MasinaDocument::TYPE_VIGNETA, $code);
@@ -165,7 +169,7 @@
                                        class="document-cell-link d-inline-flex w-100 justify-content-center {{ $isEmpty ? 'document-cell-link--empty' : '' }}"
                                        aria-label="{{ $ariaLabel }}">
                                         <span class="document-cell px-2 py-1 w-100 {{ $colorClass }}">
-                                            {{ $displayDate }}
+                                            {{ $readableDate }}
                                         </span>
                                     </a>
                                 </td>

--- a/resources/views/masini-mementouri/partials/document-cell.blade.php
+++ b/resources/views/masini-mementouri/partials/document-cell.blade.php
@@ -1,8 +1,10 @@
 @php
     $baseClass = 'document-cell rounded-3 px-2 py-2 text-center';
     $colorClass = $document->colorClass();
-
-    $displayDate = optional($document->data_expirare)->format('d.m.Y');
+    $displayDate = $document->readableExpiryDate();
+    $formattedDate = $document->formattedExpiryDate();
+    $noExpiry = $document->isWithoutExpiry();
+    $noExpiryInputId = 'document-' . $document->id . '-fara-expirare';
 @endphp
 
 <div class="{{ $baseClass }} {{ $colorClass }}"
@@ -10,7 +12,8 @@
      data-base-class="{{ $baseClass }}"
      data-document-wrapper
      data-document-id="{{ $document->id }}"
-     data-empty-label="—">
+     data-empty-label="—"
+     data-no-expiry-label="FĂRĂ">
     <form method="POST" action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}"
           class="document-date-form"
           data-document-update data-auto-submit="true">
@@ -18,13 +21,36 @@
         @method('PATCH')
 
         <span class="document-date-text" data-date-text>
-            {{ $displayDate ?? '—' }}
+            {{ $displayDate }}
         </span>
 
-        <input type="date" name="data_expirare"
-               class="document-date-input visually-hidden"
-               value="{{ optional($document->data_expirare)->format('Y-m-d') }}"
-               data-date-input>
+        <div class="document-inline-controls visually-hidden mt-2" data-edit-controls>
+            <div class="d-flex align-items-center justify-content-center gap-2 flex-wrap" data-no-expiry-container>
+                <input type="date" name="data_expirare"
+                       class="form-control form-control-sm"
+                       value="{{ $formattedDate }}"
+                       data-date-input>
+                <input type="hidden" name="fara_expirare" value="0" data-no-expiry-hidden>
+                <div class="form-check mb-0">
+                    <input type="checkbox"
+                           class="form-check-input"
+                           id="{{ $noExpiryInputId }}"
+                           name="fara_expirare"
+                           value="1"
+                           {{ $noExpiry ? 'checked' : '' }}
+                           data-no-expiry-toggle>
+                    <label class="form-check-label small" for="{{ $noExpiryInputId }}">Fără expirare</label>
+                </div>
+            </div>
+            <div class="d-flex justify-content-center gap-2 mt-2">
+                <button type="submit" class="btn btn-sm btn-primary" data-save-trigger>
+                    <i class="fa-solid fa-floppy-disk me-1"></i>Salvează
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-secondary" data-cancel-edit>
+                    Renunță
+                </button>
+            </div>
+        </div>
 
         <button type="button" class="btn btn-link p-0 document-date-edit" data-edit-trigger aria-label="Editează data">
             <i class="fa-solid fa-pen"></i>

--- a/tests/Feature/Masini/MasiniMementouriTest.php
+++ b/tests/Feature/Masini/MasiniMementouriTest.php
@@ -185,7 +185,7 @@ class MasiniMementouriTest extends TestCase
         $this->assertSame($document->colorClass(), $response->json('color_class'));
         $this->assertSame($document->daysUntilExpiry(), $response->json('days_until_expiry'));
         $this->assertSame($document->data_expirare?->format('Y-m-d'), $response->json('formatted_date'));
-        $this->assertSame($document->data_expirare?->format('d.m.Y'), $response->json('readable_date'));
+        $this->assertSame($document->readableExpiryDate(), $response->json('readable_date'));
     }
 
     public function test_document_inline_update_preserves_notifications_when_date_is_unchanged(): void
@@ -250,7 +250,7 @@ class MasiniMementouriTest extends TestCase
         $response->assertJson([
             'status' => 'ok',
             'formatted_date' => null,
-            'readable_date' => null,
+            'readable_date' => '—',
             'color_class' => 'bg-secondary-subtle',
         ]);
 
@@ -261,6 +261,92 @@ class MasiniMementouriTest extends TestCase
         $this->assertFalse($document->notificare_30_trimisa);
         $this->assertFalse($document->notificare_15_trimisa);
         $this->assertFalse($document->notificare_1_trimisa);
+    }
+
+    public function test_document_inline_update_can_mark_document_without_expiry(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        $document = $masina->documente()->where('document_type', MasinaDocument::TYPE_VIGNETA)->first();
+
+        $document->update([
+            'data_expirare' => Carbon::now()->addDays(12)->toDateString(),
+            'notificare_60_trimisa' => true,
+            'notificare_30_trimisa' => true,
+            'notificare_15_trimisa' => true,
+            'notificare_1_trimisa' => true,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->patchJson(route('masini-mementouri.documente.update', [$masina, $document]), [
+                'fara_expirare' => true,
+            ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'status' => 'ok',
+            'formatted_date' => null,
+            'readable_date' => 'FĂRĂ',
+            'fara_expirare' => true,
+        ]);
+
+        $document->refresh();
+
+        $this->assertTrue($document->isWithoutExpiry());
+        $this->assertNull($document->data_expirare);
+        $this->assertFalse($document->notificare_60_trimisa);
+        $this->assertFalse($document->notificare_30_trimisa);
+        $this->assertFalse($document->notificare_15_trimisa);
+        $this->assertFalse($document->notificare_1_trimisa);
+        $this->assertSame($document->colorClass(), $response->json('color_class'));
+    }
+
+    public function test_document_inline_update_can_restore_expiry_after_marking_without_expiry(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        $document = $masina->documente()->where('document_type', MasinaDocument::TYPE_ITP)->first();
+
+        $document->update([
+            'fara_expirare' => true,
+            'data_expirare' => null,
+            'notificare_60_trimisa' => true,
+            'notificare_30_trimisa' => true,
+            'notificare_15_trimisa' => true,
+            'notificare_1_trimisa' => true,
+        ]);
+
+        $newDate = Carbon::now()->addDays(45)->toDateString();
+
+        $response = $this
+            ->actingAs($user)
+            ->patchJson(route('masini-mementouri.documente.update', [$masina, $document]), [
+                'fara_expirare' => false,
+                'data_expirare' => $newDate,
+            ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'status' => 'ok',
+            'formatted_date' => $newDate,
+            'readable_date' => Carbon::parse($newDate)->format('d.m.Y'),
+            'fara_expirare' => false,
+        ]);
+
+        $document->refresh();
+
+        $this->assertFalse($document->isWithoutExpiry());
+        $this->assertSame($newDate, optional($document->data_expirare)->toDateString());
+        $this->assertFalse($document->notificare_60_trimisa);
+        $this->assertFalse($document->notificare_30_trimisa);
+        $this->assertFalse($document->notificare_15_trimisa);
+        $this->assertFalse($document->notificare_1_trimisa);
+        $this->assertSame($document->colorClass(), $response->json('color_class'));
     }
 
     public function test_document_inline_update_handles_invalid_payloads(): void
@@ -323,6 +409,46 @@ class MasiniMementouriTest extends TestCase
 
         $this->assertSame($newDate, optional($document->data_expirare)->toDateString());
         $this->assertSame('alerts@example.com', $document->email_notificare);
+        $this->assertFalse($document->notificare_60_trimisa);
+        $this->assertFalse($document->notificare_30_trimisa);
+        $this->assertFalse($document->notificare_15_trimisa);
+        $this->assertFalse($document->notificare_1_trimisa);
+    }
+
+    public function test_document_update_via_standard_form_can_mark_document_without_expiry(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create(['numar_inmatriculare' => 'B90FARA']);
+        $document = $masina->documente()->first();
+
+        $document->update([
+            'data_expirare' => Carbon::now()->addDays(20)->toDateString(),
+            'email_notificare' => 'initial@example.com',
+            'notificare_60_trimisa' => true,
+            'notificare_30_trimisa' => true,
+            'notificare_15_trimisa' => true,
+            'notificare_1_trimisa' => true,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('masini-mementouri.edit', $masina))
+            ->patch(route('masini-mementouri.documente.update', [$masina, $document]), [
+                'data_expirare' => '',
+                'fara_expirare' => '1',
+                'email_notificare' => 'final@example.com',
+            ]);
+
+        $response->assertRedirect(route('masini-mementouri.edit', $masina));
+        $response->assertSessionHas('status', 'Documentul a fost actualizat.');
+
+        $document->refresh();
+
+        $this->assertTrue($document->isWithoutExpiry());
+        $this->assertNull($document->data_expirare);
+        $this->assertSame('final@example.com', $document->email_notificare);
         $this->assertFalse($document->notificare_60_trimisa);
         $this->assertFalse($document->notificare_30_trimisa);
         $this->assertFalse($document->notificare_15_trimisa);


### PR DESCRIPTION
## Summary
- add a fara_expirare column for masina documents and expose model helpers for the new state
- adjust controllers, blade templates, styles, and javascript to surface the no-expiry checkbox and inline editor handling
- extend feature coverage to exercise toggling the no-expiry flag via JSON and standard form submissions

## Testing
- ⚠️ `composer install` *(fails: GitHub download restrictions prevent installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_690d0d890a3c8326b79c1f66ee563833