### PR TITLE
Adjust document expiry layout

### DIFF
--- a/resources/views/masini-mementouri/document-edit.blade.php
+++ b/resources/views/masini-mementouri/document-edit.blade.php
@@ -43,21 +43,25 @@
                                 @csrf
 
                                 <div class="mb-3" data-no-expiry-container>
-                                    <label class="form-label" for="data_expirare">Dată expirare</label>
-                                    <div class="d-flex align-items-center gap-3 flex-wrap">
-                                        <input type="date"
-                                               id="data_expirare"
-                                               name="data_expirare"
-                                               class="form-control rounded-3"
-                                               value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
-                                        <div class="form-check mb-0">
-                                            <input type="checkbox"
-                                                   class="form-check-input"
-                                                   id="fara_expirare"
-                                                   name="fara_expirare"
-                                                   value="1"
-                                                   @checked(old('fara_expirare', $document->fara_expirare))>
-                                            <label class="form-check-label" for="fara_expirare">Fără expirare</label>
+                                    <div class="row g-3 align-items-center">
+                                        <div class="col-12 col-md-6">
+                                            <label class="form-label" for="data_expirare">Dată expirare</label>
+                                            <input type="date"
+                                                   id="data_expirare"
+                                                   name="data_expirare"
+                                                   class="form-control rounded-3"
+                                                   value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
+                                        </div>
+                                        <div class="col-12 col-md-6">
+                                            <div class="form-check d-flex align-items-center gap-2 mb-0">
+                                                <input type="checkbox"
+                                                       class="form-check-input"
+                                                       id="fara_expirare"
+                                                       name="fara_expirare"
+                                                       value="1"
+                                                       @checked(old('fara_expirare', $document->fara_expirare))>
+                                                <label class="form-check-label" for="fara_expirare">Fără expirare</label>
+                                            </div>
                                         </div>
                                     </div>
                                     <small class="text-muted">Modificarea datei necesită încărcarea unui fișier în același timp.</small>


### PR DESCRIPTION
## Summary
- place the document expiry date input and no-expiry checkbox in responsive columns for improved alignment

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da3186a188326beb21106fc15ff95)