### PR TITLE
Move no-expiry toggle to dedicated action

### DIFF
--- a/resources/views/masini-mementouri/document-edit.blade.php
+++ b/resources/views/masini-mementouri/document-edit.blade.php
@@ -35,42 +35,45 @@
                     <div class="card border border-secondary-subtle rounded-4 h-100">
                         <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
                             <span class="fw-semibold">Actualizează documentul</span>
+                            @if (! $document->fara_expirare)
+                                <form method="POST"
+                                      action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}"
+                                      class="mb-0">
+                                    @csrf
+                                    @method('PATCH')
+                                    <input type="hidden" name="fara_expirare" value="1">
+                                    <button type="submit" class="btn btn-outline-primary border border-dark rounded-3">
+                                        <i class="fa-solid fa-infinity me-1"></i>Fără expirare
+                                    </button>
+                                </form>
+                            @endif
                         </div>
                         <div class="card-body">
+                            @if ($document->fara_expirare)
+                                <div class="alert alert-info border border-info-subtle rounded-4 mb-4">
+                                    Documentul este marcat fără expirare.
+                                </div>
+                            @endif
+
                             <form method="POST"
                                   action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}"
                                   enctype="multipart/form-data">
                                 @csrf
 
-                                <div class="mb-3" data-no-expiry-container>
-                                    <div class="row g-3 align-items-end">
-                                        <div class="col-12 col-md-6">
-                                            <label class="form-label" for="data_expirare">Dată expirare</label>
-                                            <input type="date"
-                                                   id="data_expirare"
-                                                   name="data_expirare"
-                                                   class="form-control rounded-3"
-                                                   value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
-                                        </div>
-                                        <div class="col-12 col-md-6">
-                                            <div class="form-check d-flex align-items-center gap-2 mb-0">
-                                                <input type="checkbox"
-                                                       class="form-check-input"
-                                                       id="fara_expirare"
-                                                       name="fara_expirare"
-                                                       value="1"
-                                                       @checked(old('fara_expirare', $document->fara_expirare))>
-                                                <label class="form-check-label" for="fara_expirare">Fără expirare</label>
-                                            </div>
-                                        </div>
-                                    </div>
+                                <div class="mb-3">
+                                    <label class="form-label" for="data_expirare">Dată expirare</label>
+                                    <input type="date"
+                                           id="data_expirare"
+                                           name="data_expirare"
+                                           class="form-control rounded-3"
+                                           value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
                                     <small class="text-muted">Modificarea datei necesită încărcarea unui fișier în același timp.</small>
                                 </div>
 
                                 <div class="mb-3">
                                     <label class="form-label" for="fisier">Selectează fișiere (PDF)</label>
                                     <input type="file" id="fisier" name="fisier[]" class="form-control rounded-3"
-                                           accept="application/pdf" multiple required>
+                                           accept="application/pdf" multiple>
                                 </div>
 
                                 <div class="text-end">


### PR DESCRIPTION
## Summary
- add a dedicated "Fără expirare" button on the document edit view to trigger the no-expiry update separately from file uploads
- adjust the document file upload controller so providing a new expiry date always clears the no-expiry flag while keeping backwards compatibility
- extend the Masini memento feature tests to cover the new button workflow and ensure uploads reset the flag correctly
- align the no-expiry button with the document update header and display the no-expiry status message ahead of the upload form

## Testing
- ⚠️ `./vendor/bin/phpunit --filter MasiniMementouriTest` *(fails: No such file or directory — vendor dependencies are not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da20bb1d08326b314457f7b6c1e25)