### PR TITLE
Hide upload form when document marked without expiry

### DIFF
--- a/resources/views/masini-mementouri/document-edit.blade.php
+++ b/resources/views/masini-mementouri/document-edit.blade.php
@@ -35,50 +35,59 @@
                     <div class="card border border-secondary-subtle rounded-4 h-100">
                         <div class="card-header rounded-4 d-flex justify-content-between align-items-center">
                             <span class="fw-semibold">Actualizează documentul</span>
+                            <form method="POST"
+                                  action="{{ route('masini-mementouri.documente.update', [$masina, $document]) }}"
+                                  class="mb-0">
+                                @csrf
+                                @method('PATCH')
+
+                                @if ($document->fara_expirare)
+                                    <input type="hidden" name="fara_expirare" value="0">
+                                    <button type="submit" class="btn btn-outline-secondary border border-dark rounded-3">
+                                        <i class="fa-solid fa-rotate-left me-1"></i>Anulează fără expirare
+                                    </button>
+                                @else
+                                    <input type="hidden" name="fara_expirare" value="1">
+                                    <button type="submit" class="btn btn-outline-primary border border-dark rounded-3">
+                                        <i class="fa-solid fa-infinity me-1"></i>Fără expirare
+                                    </button>
+                                @endif
+                            </form>
                         </div>
                         <div class="card-body">
-                            <form method="POST"
-                                  action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}"
-                                  enctype="multipart/form-data">
-                                @csrf
+                            @if ($document->fara_expirare)
+                                <div class="alert alert-info border border-info-subtle rounded-4 mb-0">
+                                    Documentul este marcat fără expirare.
+                                </div>
+                            @else
+                                <form method="POST"
+                                      action="{{ route('masini-mementouri.documente.fisiere.store', [$masina, $document]) }}"
+                                      enctype="multipart/form-data">
+                                    @csrf
 
-                                <div class="mb-3" data-no-expiry-container>
-                                    <div class="row g-3 align-items-end">
-                                        <div class="col-12 col-md-6">
-                                            <label class="form-label" for="data_expirare">Dată expirare</label>
-                                            <input type="date"
-                                                   id="data_expirare"
-                                                   name="data_expirare"
-                                                   class="form-control rounded-3"
-                                                   value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
-                                        </div>
-                                        <div class="col-12 col-md-6">
-                                            <div class="form-check d-flex align-items-center gap-2 mb-0">
-                                                <input type="checkbox"
-                                                       class="form-check-input"
-                                                       id="fara_expirare"
-                                                       name="fara_expirare"
-                                                       value="1"
-                                                       @checked(old('fara_expirare', $document->fara_expirare))>
-                                                <label class="form-check-label" for="fara_expirare">Fără expirare</label>
-                                            </div>
-                                        </div>
+                                    <div class="mb-3">
+                                        <label class="form-label" for="data_expirare">Dată expirare</label>
+                                        <input type="date"
+                                               id="data_expirare"
+                                               name="data_expirare"
+                                               class="form-control rounded-3"
+                                               value="{{ old('data_expirare', optional($document->data_expirare)->format('Y-m-d')) }}">
+                                        <small class="text-muted">Modificarea datei necesită încărcarea unui fișier în același timp.</small>
                                     </div>
-                                    <small class="text-muted">Modificarea datei necesită încărcarea unui fișier în același timp.</small>
-                                </div>
 
-                                <div class="mb-3">
-                                    <label class="form-label" for="fisier">Selectează fișiere (PDF)</label>
-                                    <input type="file" id="fisier" name="fisier[]" class="form-control rounded-3"
-                                           accept="application/pdf" multiple required>
-                                </div>
+                                    <div class="mb-3">
+                                        <label class="form-label" for="fisier">Selectează fișiere (PDF)</label>
+                                        <input type="file" id="fisier" name="fisier[]" class="form-control rounded-3"
+                                               accept="application/pdf" multiple>
+                                    </div>
 
-                                <div class="text-end">
-                                    <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
-                                        <i class="fa-solid fa-floppy-disk me-1"></i>Salvează documentul
-                                    </button>
-                                </div>
-                            </form>
+                                    <div class="text-end">
+                                        <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
+                                            <i class="fa-solid fa-floppy-disk me-1"></i>Salvează documentul
+                                        </button>
+                                    </div>
+                                </form>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/tests/Feature/Masini/MasiniMementouriTest.php
+++ b/tests/Feature/Masini/MasiniMementouriTest.php
@@ -138,6 +138,48 @@ class MasiniMementouriTest extends TestCase
         $response->assertSee($document->data_expirare->format('d.m.Y'));
     }
 
+    public function test_document_edit_page_displays_form_when_document_has_expiry(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class]);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create(['numar_inmatriculare' => 'B12FORM']);
+        $document = $masina->documente()->first();
+
+        $response = $this
+            ->actingAs($user)
+            ->get(route('masini-mementouri.documente.edit', [$masina, $document]));
+
+        $response->assertOk();
+        $response->assertSee('Fără expirare');
+        $response->assertSee('name="data_expirare"', false);
+        $response->assertSee('Salvează documentul');
+    }
+
+    public function test_document_edit_page_hides_form_when_document_is_without_expiry(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class]);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create(['numar_inmatriculare' => 'B34FREE']);
+        $document = $masina->documente()->first();
+
+        $document->update([
+            'fara_expirare' => true,
+            'data_expirare' => null,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->get(route('masini-mementouri.documente.edit', [$masina, $document]));
+
+        $response->assertOk();
+        $response->assertSee('Anulează fără expirare');
+        $response->assertSee('Documentul este marcat fără expirare.');
+        $response->assertDontSee('name="data_expirare"', false);
+        $response->assertDontSee('Salvează documentul');
+    }
+
     public function test_document_inline_update_returns_json_and_resets_notifications(): void
     {
         $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
@@ -594,56 +636,6 @@ class MasiniMementouriTest extends TestCase
         );
     }
 
-    public function test_document_file_upload_can_mark_document_without_expiry(): void
-    {
-        $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
-
-        Storage::fake(MasinaDocumentFisier::STORAGE_DISK);
-
-        $user = User::factory()->create();
-        $masina = Masina::factory()->create();
-        $document = $masina->documente()->first();
-
-        $document->update([
-            'data_expirare' => Carbon::now()->addDays(25)->toDateString(),
-            'fara_expirare' => false,
-            'notificare_60_trimisa' => true,
-            'notificare_30_trimisa' => true,
-            'notificare_15_trimisa' => true,
-            'notificare_1_trimisa' => true,
-        ]);
-
-        $file = UploadedFile::fake()->create('atestat.pdf', 128, 'application/pdf');
-
-        $response = $this
-            ->actingAs($user)
-            ->from(route('masini-mementouri.documente.edit', [$masina, $document]))
-            ->post(route('masini-mementouri.documente.fisiere.store', [$masina, $document]), [
-                'data_expirare' => '',
-                'fara_expirare' => '1',
-                'fisier' => [$file],
-            ]);
-
-        $response->assertRedirect(route('masini-mementouri.documente.edit', [
-            $masina,
-            MasinaDocument::buildRouteKey($document->document_type, $document->tara),
-        ]));
-        $response->assertSessionHas('status', 'Fișierul a fost încărcat.');
-
-        $document->refresh();
-
-        $this->assertTrue($document->isWithoutExpiry());
-        $this->assertNull($document->data_expirare);
-        $this->assertFalse($document->notificare_60_trimisa);
-        $this->assertFalse($document->notificare_30_trimisa);
-        $this->assertFalse($document->notificare_15_trimisa);
-        $this->assertFalse($document->notificare_1_trimisa);
-
-        Storage::disk(MasinaDocumentFisier::STORAGE_DISK)->assertExists(
-            MasinaDocumentFisier::STORAGE_DIRECTORY . '/' . $document->id . '/' . $file->hashName()
-        );
-    }
-
     public function test_document_file_upload_via_standard_form_redirects_to_edit_page(): void
     {
         $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
@@ -675,6 +667,96 @@ class MasiniMementouriTest extends TestCase
             'document_id' => $document->id,
             'nume_original' => $file->getClientOriginalName(),
         ]);
+    }
+
+    public function test_document_update_shortcut_can_mark_document_without_expiry_without_files(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        $document = $masina->documente()->first();
+
+        $document->update([
+            'data_expirare' => Carbon::now()->addDays(30)->toDateString(),
+            'fara_expirare' => false,
+            'notificare_60_trimisa' => true,
+            'notificare_30_trimisa' => true,
+            'notificare_15_trimisa' => true,
+            'notificare_1_trimisa' => true,
+        ]);
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('masini-mementouri.documente.edit', [$masina, $document]))
+            ->patch(route('masini-mementouri.documente.update', [$masina, $document]), [
+                'fara_expirare' => '1',
+            ]);
+
+        $response->assertRedirect(route('masini-mementouri.documente.edit', [
+            $masina,
+            MasinaDocument::buildRouteKey($document->document_type, $document->tara),
+        ]));
+        $response->assertSessionHas('status', 'Documentul a fost actualizat.');
+
+        $document->refresh();
+
+        $this->assertTrue($document->isWithoutExpiry());
+        $this->assertNull($document->data_expirare);
+        $this->assertFalse($document->notificare_60_trimisa);
+        $this->assertFalse($document->notificare_30_trimisa);
+        $this->assertFalse($document->notificare_15_trimisa);
+        $this->assertFalse($document->notificare_1_trimisa);
+    }
+
+    public function test_document_file_upload_with_new_date_overrides_no_expiry_flag(): void
+    {
+        $this->withoutMiddleware([EnsurePermission::class, VerifyCsrfToken::class]);
+
+        Storage::fake(MasinaDocumentFisier::STORAGE_DISK);
+
+        $user = User::factory()->create();
+        $masina = Masina::factory()->create();
+        $document = $masina->documente()->first();
+
+        $document->update([
+            'data_expirare' => null,
+            'fara_expirare' => true,
+            'notificare_60_trimisa' => true,
+            'notificare_30_trimisa' => true,
+            'notificare_15_trimisa' => true,
+            'notificare_1_trimisa' => true,
+        ]);
+
+        $newDate = Carbon::now()->addDays(120)->format('Y-m-d');
+        $file = UploadedFile::fake()->create('atestat.pdf', 128, 'application/pdf');
+
+        $response = $this
+            ->actingAs($user)
+            ->from(route('masini-mementouri.documente.edit', [$masina, $document]))
+            ->post(route('masini-mementouri.documente.fisiere.store', [$masina, $document]), [
+                'data_expirare' => $newDate,
+                'fisier' => [$file],
+            ]);
+
+        $response->assertRedirect(route('masini-mementouri.documente.edit', [
+            $masina,
+            MasinaDocument::buildRouteKey($document->document_type, $document->tara),
+        ]));
+        $response->assertSessionHas('status', 'Fișierul a fost încărcat.');
+
+        $document->refresh();
+
+        $this->assertFalse($document->isWithoutExpiry());
+        $this->assertSame($newDate, optional($document->data_expirare)->toDateString());
+        $this->assertFalse($document->notificare_60_trimisa);
+        $this->assertFalse($document->notificare_30_trimisa);
+        $this->assertFalse($document->notificare_15_trimisa);
+        $this->assertFalse($document->notificare_1_trimisa);
+
+        Storage::disk(MasinaDocumentFisier::STORAGE_DISK)->assertExists(
+            MasinaDocumentFisier::STORAGE_DIRECTORY . '/' . $document->id . '/' . $file->hashName()
+        );
     }
 
     public function test_document_file_upload_via_standard_form_handles_multiple_files(): void


### PR DESCRIPTION
## Summary
- add a dedicated "Fără expirare" button on the document edit view to trigger the no-expiry update separately from file uploads
- adjust the document file upload controller so providing a new expiry date always clears the no-expiry flag while keeping backwards compatibility
- extend the Masini memento feature tests to cover the new button workflow and ensure uploads reset the flag correctly
- align the no-expiry button with the document update header, display the no-expiry status message ahead of the upload form, and show a companion button to restore expiry
- hide the expiry/upload form entirely whenever a document is marked fără expirare so the toggle is the only available action until the state is reverted

## Testing
- ⚠️ `./vendor/bin/phpunit --filter MasiniMementouriTest` *(fails: No such file or directory — vendor dependencies are not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690da20bb1d08326b314457f7b6c1e25)