### PR TITLE
Make masini mementouri table header sticky

### DIFF
--- a/resources/views/masini-mementouri/index.blade.php
+++ b/resources/views/masini-mementouri/index.blade.php
@@ -44,6 +44,13 @@
             padding: 0.35rem 0.75rem;
             font-weight: 600;
         }
+
+        .masini-mementouri-table thead th {
+            position: sticky;
+            top: 0;
+            z-index: 2;
+            background-color: inherit;
+        }
     </style>
 @endpush
 
@@ -101,7 +108,7 @@
         @endphp
 
         <div class="table-responsive rounded">
-            <table class="table table-striped table-hover align-middle table-sm mb-0">
+            <table class="table table-striped table-hover align-middle table-sm mb-0 masini-mementouri-table">
                 <thead class="text-white rounded culoare2">
                     <tr>
                         <th>#</th>


### PR DESCRIPTION
## Summary
- add a page-scoped CSS rule that makes the masini-mementouri table header sticky while scrolling
- apply a dedicated class to the masini-mementouri table so the sticky styling stays scoped to this page

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dc8fcbd788326b6f65a26ab38d54d)