### PR TITLE
Add sofer role with dedicated driver dashboard

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -40,6 +40,10 @@ class LoginController extends Controller
     {
         $user = Auth::user();
 
+        if ($user && $user->hasRole('sofer')) {
+            return route('sofer.dashboard');
+        }
+
         if ($user && $user->hasPermission('dashboard')) {
             return route('dashboard');
         }

--- a/app/Http/Controllers/SoferDashboardController.php
+++ b/app/Http/Controllers/SoferDashboardController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\MasinaValabilitati;
+use Illuminate\Support\Carbon;
+
+class SoferDashboardController extends Controller
+{
+    public function __invoke()
+    {
+        $today = Carbon::today();
+
+        $valabilitati = MasinaValabilitati::query()
+            ->select([
+                'id',
+                'nr_auto',
+                'nume_sofer',
+                'detalii_sofer',
+                'divizie',
+                'valabilitate_1',
+                'valabilitate_1_inceput',
+                'valabilitate_1_sfarsit',
+                'observatii_1',
+                'valabilitate_2',
+                'valabilitate_2_inceput',
+                'valabilitate_2_sfarsit',
+                'observatii_2',
+            ])
+            ->where(function ($query) use ($today) {
+                $query->where(function ($subQuery) use ($today) {
+                    $subQuery
+                        ->whereNotNull('valabilitate_1_sfarsit')
+                        ->whereDate('valabilitate_1_sfarsit', '>=', $today);
+                })
+                ->orWhere(function ($subQuery) use ($today) {
+                    $subQuery
+                        ->whereNull('valabilitate_1_sfarsit')
+                        ->whereNotNull('valabilitate_1_inceput')
+                        ->whereDate('valabilitate_1_inceput', '<=', $today);
+                })
+                ->orWhere(function ($subQuery) use ($today) {
+                    $subQuery
+                        ->whereNotNull('valabilitate_2_sfarsit')
+                        ->whereDate('valabilitate_2_sfarsit', '>=', $today);
+                })
+                ->orWhere(function ($subQuery) use ($today) {
+                    $subQuery
+                        ->whereNull('valabilitate_2_sfarsit')
+                        ->whereNotNull('valabilitate_2_inceput')
+                        ->whereDate('valabilitate_2_inceput', '<=', $today);
+                });
+            })
+            ->orderByRaw('COALESCE(valabilitate_1_sfarsit, valabilitate_2_sfarsit) IS NULL ASC')
+            ->orderByRaw('COALESCE(valabilitate_1_sfarsit, valabilitate_2_sfarsit) ASC')
+            ->orderBy('nr_auto')
+            ->get();
+
+        return view('sofer.dashboard', [
+            'valabilitati' => $valabilitati,
+        ]);
+    }
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -119,5 +119,6 @@ return [
             'documente-word-manage',
             'masini-valabilitati',
         ],
+        'sofer' => [],
     ],
 ];

--- a/database/seeders/RolesTableSeeder.php
+++ b/database/seeders/RolesTableSeeder.php
@@ -62,6 +62,14 @@ class RolesTableSeeder extends Seeder
             ]
         );
 
+        $sofer = Role::firstOrCreate(
+            ['slug' => 'sofer'],
+            [
+                'name' => 'Șofer',
+                'description' => 'Acces restrâns la panoul mobil de valabilități.',
+            ]
+        );
+
         $permissions = Permission::all();
         $permissionMap = $permissions->keyBy('module');
         $roleDefaults = collect(config('permissions.role_defaults', []));
@@ -91,6 +99,7 @@ class RolesTableSeeder extends Seeder
         $syncPermissions($mecanic);
         $syncPermissions($documenteWordOperator);
         $syncPermissions($documenteWordAdministrator);
+        $syncPermissions($sofer);
 
         $user = User::find(1);
 

--- a/resources/views/sofer/dashboard.blade.php
+++ b/resources/views/sofer/dashboard.blade.php
@@ -1,0 +1,80 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4 py-md-5">
+    <div class="text-center mb-4">
+        <span class="badge bg-primary-subtle text-primary fw-semibold text-uppercase px-3 py-2 rounded-pill">
+            Panou șofer
+        </span>
+        <h1 class="h4 fw-bold mt-3">Valabilități active</h1>
+        <p class="text-muted small mb-0">Consultați rapid documentele și termenele limită asociate flotei.</p>
+    </div>
+
+    @if ($valabilitati->isEmpty())
+        <div class="card border-0 shadow-sm">
+            <div class="card-body text-center py-5">
+                <i class="fa-solid fa-circle-check fa-3x text-success mb-3"></i>
+                <p class="fw-semibold mb-1">Nu aveți nicio valabilitate activă</p>
+                <p class="text-muted small mb-0">Veți fi notificat de echipă atunci când apar documente noi.</p>
+            </div>
+        </div>
+    @else
+        <div class="d-flex flex-column gap-3">
+            @foreach ($valabilitati as $valabilitate)
+                <article class="card border-0 shadow-sm">
+                    <div class="card-body p-4">
+                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                            <span class="badge bg-primary text-uppercase fw-semibold px-3 py-2">
+                                {{ $valabilitate->nr_auto ?? 'Fără număr' }}
+                            </span>
+                            @if ($valabilitate->divizie)
+                                <span class="text-muted small text-uppercase fw-semibold">
+                                    {{ $valabilitate->divizie }}
+                                </span>
+                            @endif
+                        </div>
+
+                        @if ($valabilitate->nume_sofer)
+                            <p class="fw-semibold mb-1">{{ $valabilitate->nume_sofer }}</p>
+                        @endif
+
+                        @if ($valabilitate->detalii_sofer)
+                            <p class="text-muted small mb-3">{{ $valabilitate->detalii_sofer }}</p>
+                        @endif
+
+                        <div class="row g-4">
+                            @if ($valabilitate->valabilitate_1_inceput || $valabilitate->valabilitate_1_sfarsit || $valabilitate->observatii_1)
+                                <div class="col-12 col-md-6">
+                                    <h2 class="h6 text-uppercase text-muted mb-2">Valabilitate 1</h2>
+                                    <p class="mb-1 fw-semibold">
+                                        {{ optional($valabilitate->valabilitate_1_inceput)->format('d.m.Y') ?? '—' }}
+                                        <span class="text-muted">–</span>
+                                        {{ optional($valabilitate->valabilitate_1_sfarsit)->format('d.m.Y') ?? '—' }}
+                                    </p>
+                                    @if ($valabilitate->observatii_1)
+                                        <p class="text-muted small mb-0">{{ $valabilitate->observatii_1 }}</p>
+                                    @endif
+                                </div>
+                            @endif
+
+                            @if ($valabilitate->valabilitate_2_inceput || $valabilitate->valabilitate_2_sfarsit || $valabilitate->observatii_2)
+                                <div class="col-12 col-md-6">
+                                    <h2 class="h6 text-uppercase text-muted mb-2">Valabilitate 2</h2>
+                                    <p class="mb-1 fw-semibold">
+                                        {{ optional($valabilitate->valabilitate_2_inceput)->format('d.m.Y') ?? '—' }}
+                                        <span class="text-muted">–</span>
+                                        {{ optional($valabilitate->valabilitate_2_sfarsit)->format('d.m.Y') ?? '—' }}
+                                    </p>
+                                    @if ($valabilitate->observatii_2)
+                                        <p class="text-muted small mb-0">{{ $valabilitate->observatii_2 }}</p>
+                                    @endif
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+                </article>
+            @endforeach
+        </div>
+    @endif
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,6 +43,7 @@ use App\Http\Controllers\Service\ServiceSheetController;
 use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\CronJobLogController;
+use App\Http\Controllers\SoferDashboardController;
 
 
 /*
@@ -86,6 +87,10 @@ Route::get('oferte-curse', [OfertaCursaController::class, 'index'])->name('ofert
 Route::redirect('/', '/acasa');
 
 Route::middleware(['auth'])->group(function () {
+    Route::middleware('role:sofer')->group(function () {
+        Route::get('sofer/dashboard', SoferDashboardController::class)->name('sofer.dashboard');
+    });
+
     Route::middleware('permission:dashboard')->group(function () {
         Route::view('acasa', 'acasa')->name('dashboard');
         Route::view('various-tests', 'variousTests');


### PR DESCRIPTION
## Summary
- add and seed the `sofer` role so administrators can assign it to driver accounts
- route `sofer` users to a lightweight dashboard and redirect them automatically after login
- implement the mobile-friendly Blade view listing active valabilități for drivers

## Testing
- php artisan test *(fails: missing `vendor/autoload.php` in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f4018dfc8326ab75076569238167)