### PR TITLE
Add roles seeder trigger to migration center

### DIFF
--- a/app/Http/Controllers/Tech/MigrationCenterController.php
+++ b/app/Http/Controllers/Tech/MigrationCenterController.php
@@ -20,6 +20,9 @@ class MigrationCenterController extends Controller
             'executionOutput' => $request->session()->get('migration_output'),
             'statusMessage' => $request->session()->get('migration_status'),
             'statusLevel' => $request->session()->get('migration_status_level', 'info'),
+            'seederOutput' => $request->session()->get('seeder_output'),
+            'seederStatus' => $request->session()->get('seeder_status'),
+            'seederStatusLevel' => $request->session()->get('seeder_status_level', 'info'),
         ]);
     }
 
@@ -63,6 +66,29 @@ class MigrationCenterController extends Controller
                 ->with([
                     'migration_status' => 'Migration failed: ' . $exception->getMessage(),
                     'migration_status_level' => 'danger',
+                ]);
+        }
+    }
+
+    public function runSeeder(MigrationCenterService $service): RedirectResponse
+    {
+        try {
+            $output = $service->runSeeder();
+
+            return redirect()
+                ->route('tech.migrations.index')
+                ->with([
+                    'seeder_output' => $output,
+                    'seeder_status' => 'Seeder executed successfully. Review the seeder log below.',
+                    'seeder_status_level' => 'success',
+                ]);
+        } catch (Throwable $exception) {
+            return redirect()
+                ->route('tech.migrations.index')
+                ->with([
+                    'seeder_output' => $exception->getMessage(),
+                    'seeder_status' => 'Seeder execution failed: ' . $exception->getMessage(),
+                    'seeder_status_level' => 'danger',
                 ]);
         }
     }

--- a/app/Services/MigrationCenterService.php
+++ b/app/Services/MigrationCenterService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use Database\Seeders\RolesTableSeeder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
@@ -50,6 +51,18 @@ class MigrationCenterService
     public function runMigrations(): string
     {
         Artisan::call('migrate', ['--force' => true]);
+
+        return Artisan::output();
+    }
+
+    public function runSeeder(?string $seederClass = null): string
+    {
+        $class = $seederClass ?? RolesTableSeeder::class;
+
+        Artisan::call('db:seed', [
+            '--class' => $class,
+            '--force' => true,
+        ]);
 
         return Artisan::output();
     }

--- a/resources/views/tech/migrations/index.blade.php
+++ b/resources/views/tech/migrations/index.blade.php
@@ -17,12 +17,24 @@
                         <i class="fa-solid fa-triangle-exclamation me-1"></i>Run migrations
                     </button>
                 </form>
+                <form action="{{ route('tech.migrations.seed') }}" method="post" onsubmit="return confirm('Run the roles seeder now?');">
+                    @csrf
+                    <button class="btn btn-outline-success" type="submit">
+                        <i class="fa-solid fa-seedling me-1"></i>Run roles seeder
+                    </button>
+                </form>
             </div>
         </div>
 
         @if ($statusMessage)
             <div class="alert alert-{{ $statusLevel }}">
                 {{ $statusMessage }}
+            </div>
+        @endif
+
+        @if ($seederStatus)
+            <div class="alert alert-{{ $seederStatusLevel }}">
+                {{ $seederStatus }}
             </div>
         @endif
 
@@ -48,6 +60,19 @@
                     <pre class="mb-0">{{ $executionOutput }}</pre>
                 @else
                     <p class="mb-0 text-muted">Run the migrations to capture the artisan output.</p>
+                @endif
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card-header">
+                <strong>Seeder log</strong>
+            </div>
+            <div class="card-body">
+                @if ($seederOutput)
+                    <pre class="mb-0">{{ $seederOutput }}</pre>
+                @else
+                    <p class="mb-0 text-muted">Execute the seeder to capture the artisan output.</p>
                 @endif
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -111,6 +111,7 @@ Route::middleware(['auth'])->group(function () {
                 Route::get('migrations', [MigrationCenterController::class, 'index'])->name('migrations.index');
                 Route::post('migrations/preview', [MigrationCenterController::class, 'preview'])->name('migrations.preview');
                 Route::post('migrations/run', [MigrationCenterController::class, 'run'])->name('migrations.run');
+                Route::post('migrations/seed', [MigrationCenterController::class, 'runSeeder'])->name('migrations.seed');
                 Route::get('cron-logs', [CronJobLogController::class, 'index'])->name('cron-logs.index');
                 Route::get('cron-logs/{cronJobLog}', [CronJobLogController::class, 'show'])->name('cron-logs.show');
             });


### PR DESCRIPTION
## Summary
- add a super-admin only POST route to trigger the roles seeder from the migration center
- implement controller and service helpers to run the seeder and capture Artisan output
- surface seeder status messaging, log output, and a toolbar button in the migration center view

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f8d115a0832684a8f07a03381382)