### PR TITLE
Add seeder control center page

### DIFF
--- a/app/Http/Controllers/Tech/MigrationCenterController.php
+++ b/app/Http/Controllers/Tech/MigrationCenterController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Services\MigrationCenterService;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 use Throwable;
 
@@ -20,6 +21,19 @@ class MigrationCenterController extends Controller
             'executionOutput' => $request->session()->get('migration_output'),
             'statusMessage' => $request->session()->get('migration_status'),
             'statusLevel' => $request->session()->get('migration_status_level', 'info'),
+        ]);
+    }
+
+    public function seeders(Request $request, MigrationCenterService $service): View
+    {
+        $availableSeeders = $service->availableSeeders();
+
+        return view('tech.seeders.index', [
+            'seeders' => $availableSeeders,
+            'seederOutput' => $request->session()->get('seeder_output'),
+            'seederStatus' => $request->session()->get('seeder_status'),
+            'seederStatusLevel' => $request->session()->get('seeder_status_level', 'info'),
+            'lastRunSeeder' => $request->session()->get('seeder_last_run'),
         ]);
     }
 
@@ -63,6 +77,50 @@ class MigrationCenterController extends Controller
                 ->with([
                     'migration_status' => 'Migration failed: ' . $exception->getMessage(),
                     'migration_status_level' => 'danger',
+                ]);
+        }
+    }
+
+    public function runSeeder(Request $request, MigrationCenterService $service): RedirectResponse
+    {
+        $availableSeeders = $service->availableSeeders();
+
+        if ($availableSeeders->isEmpty()) {
+            return redirect()
+                ->route('tech.seeders.index')
+                ->with([
+                    'seeder_status' => 'No seeders are currently configured for execution.',
+                    'seeder_status_level' => 'warning',
+                ]);
+        }
+
+        $validated = $request->validate([
+            'seeder' => ['required', Rule::in($availableSeeders->keys())],
+        ]);
+
+        $seederClass = $validated['seeder'];
+        $seederMeta = $availableSeeders->get($seederClass);
+        $seederName = $seederMeta['name'] ?? class_basename($seederClass);
+
+        try {
+            $output = $service->runSeeder($seederClass);
+
+            return redirect()
+                ->route('tech.seeders.index')
+                ->with([
+                    'seeder_output' => $output,
+                    'seeder_status' => sprintf('Seeder "%s" executed successfully. Review the run log below.', $seederName),
+                    'seeder_status_level' => 'success',
+                    'seeder_last_run' => $seederClass,
+                ]);
+        } catch (Throwable $exception) {
+            return redirect()
+                ->route('tech.seeders.index')
+                ->with([
+                    'seeder_output' => $exception->getMessage(),
+                    'seeder_status' => sprintf('Seeder "%s" failed: %s', $seederName, $exception->getMessage()),
+                    'seeder_status_level' => 'danger',
+                    'seeder_last_run' => $seederClass,
                 ]);
         }
     }

--- a/app/Services/MigrationCenterService.php
+++ b/app/Services/MigrationCenterService.php
@@ -54,6 +54,37 @@ class MigrationCenterService
         return Artisan::output();
     }
 
+    public function availableSeeders(): Collection
+    {
+        $configured = config('tech-seeders.seeders', []);
+
+        return collect($configured)
+            ->map(function (array $metadata, string $class) {
+                return array_merge([
+                    'class' => $class,
+                    'name' => $metadata['name'] ?? class_basename($class),
+                    'description' => $metadata['description'] ?? null,
+                    'tables' => $metadata['tables'] ?? [],
+                    'operations' => $metadata['operations'] ?? [],
+                    'safety' => $metadata['safety'] ?? null,
+                    'recommended' => $metadata['recommended'] ?? null,
+                    'impact' => $metadata['impact'] ?? null,
+                    'estimated_runtime' => $metadata['estimated_runtime'] ?? null,
+                    'notes' => $metadata['notes'] ?? [],
+                ], $metadata);
+            });
+    }
+
+    public function runSeeder(string $seederClass): string
+    {
+        Artisan::call('db:seed', [
+            '--class' => $seederClass,
+            '--force' => true,
+        ]);
+
+        return Artisan::output();
+    }
+
     private function discoverMigrationNames(): array
     {
         $paths = array_merge([database_path('migrations')], $this->additionalMigrationPaths());

--- a/config/tech-seeders.php
+++ b/config/tech-seeders.php
@@ -1,0 +1,33 @@
+<?php
+
+use Database\Seeders\RolesTableSeeder;
+
+return [
+    'seeders' => [
+        RolesTableSeeder::class => [
+            'name' => 'Roles & Permissions baseline',
+            'description' => 'Ensures the platform has the expected roles, permissions, and pivot assignments synchronised for new and existing users.',
+            'impact' => 'Security & access control',
+            'estimated_runtime' => 'Under 1 second',
+            'recommended' => 'Run after deploying permission changes or when onboarding new role definitions.',
+            'tables' => [
+                'roles' => 'Upserts the canonical set of application roles.',
+                'permissions' => 'Seeds permissions required by each role (without removing custom additions).',
+                'role_has_permissions' => 'Synchronises the mapping between roles and permissions.',
+                'model_has_roles' => 'Re-attaches default roles to the Super Admin to guarantee access.',
+            ],
+            'operations' => [
+                'Creates any missing roles defined by the platform specification.',
+                'Updates the human-readable labels for existing roles to keep them in sync.',
+                'Links each role to the curated permission set expected by the product team.',
+                'Confirms that at least one Super Admin retains the Super Admin role.',
+            ],
+            'safety' => 'Idempotent: existing records are updated in-place without truncating the tables, so rerunning keeps data in sync.',
+            'notes' => [
+                'Custom roles or permissions added manually remain untouched.',
+                'Users with bespoke role assignments are not altered unless they rely solely on the default roles.',
+                'Database transactions ensure partial failures are rolled back before changes persist.',
+            ],
+        ],
+    ],
+];

--- a/resources/views/tech/migrations/index.blade.php
+++ b/resources/views/tech/migrations/index.blade.php
@@ -17,6 +17,9 @@
                         <i class="fa-solid fa-triangle-exclamation me-1"></i>Run migrations
                     </button>
                 </form>
+                <a href="{{ route('tech.seeders.index') }}" class="btn btn-outline-success">
+                    <i class="fa-solid fa-seedling me-1"></i>Open seeder control
+                </a>
             </div>
         </div>
 

--- a/resources/views/tech/seeders/index.blade.php
+++ b/resources/views/tech/seeders/index.blade.php
@@ -1,0 +1,128 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container py-4">
+        <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-start mb-4 gap-3">
+            <div>
+                <h1 class="h3 mb-1">Seeder Control Center</h1>
+                <p class="text-muted mb-0">Review each seeder's responsibilities, impacted tables, and safety notes before executing it.</p>
+            </div>
+            <a href="{{ route('tech.migrations.index') }}" class="btn btn-outline-secondary">
+                <i class="fa-solid fa-arrow-left me-1"></i>Back to migrations dashboard
+            </a>
+        </div>
+
+        @if ($seederStatus)
+            <div class="alert alert-{{ $seederStatusLevel }}">
+                {{ $seederStatus }}
+            </div>
+        @endif
+
+        @if ($errors->has('seeder'))
+            <div class="alert alert-danger">
+                {{ $errors->first('seeder') }}
+            </div>
+        @endif
+
+        @if ($seeders->isEmpty())
+            <div class="alert alert-warning">
+                No seeders are currently configured. Add entries to <code>config/tech-seeders.php</code> to expose them here.
+            </div>
+        @else
+            <div class="row g-4">
+                @foreach ($seeders as $seeder)
+                    <div class="col-12">
+                        <div class="card shadow-sm {{ $lastRunSeeder === $seeder['class'] ? 'border-success' : '' }}">
+                            <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+                                <div>
+                                    <h2 class="h5 mb-1">{{ $seeder['name'] }}</h2>
+                                    <p class="text-muted mb-0"><code>{{ $seeder['class'] }}</code></p>
+                                </div>
+                                <div class="text-lg-end">
+                                    @if (!empty($seeder['impact']))
+                                        <span class="badge bg-info text-dark me-2">{{ $seeder['impact'] }}</span>
+                                    @endif
+                                    @if (!empty($seeder['estimated_runtime']))
+                                        <span class="badge bg-light text-muted border">{{ $seeder['estimated_runtime'] }}</span>
+                                    @endif
+                                </div>
+                                <form action="{{ route('tech.seeders.run') }}" method="post" onsubmit="return confirm('Run the {{ $seeder['name'] }} seeder now?');" class="ms-lg-auto">
+                                    @csrf
+                                    <input type="hidden" name="seeder" value="{{ $seeder['class'] }}">
+                                    <button class="btn btn-success" type="submit">
+                                        <i class="fa-solid fa-seedling me-1"></i>{{ $lastRunSeeder === $seeder['class'] ? 'Re-run seeder' : 'Run seeder' }}
+                                    </button>
+                                </form>
+                            </div>
+                            <div class="card-body">
+                                @if (!empty($seeder['description']))
+                                    <p>{{ $seeder['description'] }}</p>
+                                @endif
+
+                                <div class="row gy-4">
+                                    @if (!empty($seeder['operations']))
+                                        <div class="col-md-6 col-lg-4">
+                                            <h3 class="h6 text-uppercase text-muted">Key operations</h3>
+                                            <ul class="mb-0">
+                                                @foreach ($seeder['operations'] as $operation)
+                                                    <li>{{ $operation }}</li>
+                                                @endforeach
+                                            </ul>
+                                        </div>
+                                    @endif
+
+                                    @if (!empty($seeder['tables']))
+                                        <div class="col-md-6 col-lg-4">
+                                            <h3 class="h6 text-uppercase text-muted">Tables touched</h3>
+                                            <ul class="mb-0">
+                                                @foreach ($seeder['tables'] as $table => $explanation)
+                                                    <li><strong>{{ is_string($table) ? $table : $explanation }}</strong>@if(is_string($table))<span class="d-block text-muted small">{{ $explanation }}</span>@endif</li>
+                                                @endforeach
+                                            </ul>
+                                        </div>
+                                    @endif
+
+                                    @if (!empty($seeder['recommended']) || !empty($seeder['safety']))
+                                        <div class="col-md-6 col-lg-4">
+                                            @if (!empty($seeder['recommended']))
+                                                <h3 class="h6 text-uppercase text-muted">When to run</h3>
+                                                <p class="mb-3">{{ $seeder['recommended'] }}</p>
+                                            @endif
+                                            @if (!empty($seeder['safety']))
+                                                <h3 class="h6 text-uppercase text-muted">Safety notes</h3>
+                                                <p class="mb-0">{{ $seeder['safety'] }}</p>
+                                            @endif
+                                        </div>
+                                    @endif
+                                </div>
+
+                                @if (!empty($seeder['notes']))
+                                    <hr>
+                                    <h3 class="h6 text-uppercase text-muted">Additional considerations</h3>
+                                    <ul class="mb-0">
+                                        @foreach ($seeder['notes'] as $note)
+                                            <li>{{ $note }}</li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        <div class="card mt-4">
+            <div class="card-header">
+                <strong>Seeder run log</strong>
+            </div>
+            <div class="card-body">
+                @if ($seederOutput)
+                    <pre class="mb-0">{{ $seederOutput }}</pre>
+                @else
+                    <p class="mb-0 text-muted">Execute a seeder to capture the artisan output here.</p>
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -111,6 +111,8 @@ Route::middleware(['auth'])->group(function () {
                 Route::get('migrations', [MigrationCenterController::class, 'index'])->name('migrations.index');
                 Route::post('migrations/preview', [MigrationCenterController::class, 'preview'])->name('migrations.preview');
                 Route::post('migrations/run', [MigrationCenterController::class, 'run'])->name('migrations.run');
+                Route::get('seeders', [MigrationCenterController::class, 'seeders'])->name('seeders.index');
+                Route::post('seeders/run', [MigrationCenterController::class, 'runSeeder'])->name('seeders.run');
                 Route::get('cron-logs', [CronJobLogController::class, 'index'])->name('cron-logs.index');
                 Route::get('cron-logs/{cronJobLog}', [CronJobLogController::class, 'show'])->name('cron-logs.show');
             });


### PR DESCRIPTION
## Summary
- expose configured seeders through a dedicated super-admin control center with detailed context and execution logging
- drive seeder metadata from a new config file and service helper for validation and presentation
- update routes and migration dashboard links to point to the new seeder experience

## Testing
- php artisan test *(fails: vendor/autoload.php missing in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f8d115a0832684a8f07a03381382)