### PR TITLE
Refactor valabilitati module into shared namespaces

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ValabilitateRequest;
+use App\Models\Masini\Masina;
+use App\Models\Valabilitate;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ValabilitateController extends Controller
+{
+    public function __construct()
+    {
+        $this->authorizeResource(Valabilitate::class, 'valabilitate');
+    }
+
+    public function index(): View
+    {
+        /** @var LengthAwarePaginator $valabilitati */
+        $valabilitati = Valabilitate::query()
+            ->with('masina')
+            ->orderByDesc('created_at')
+            ->paginate(20)
+            ->withQueryString();
+
+        return view('valabilitati.index', [
+            'valabilitati' => $valabilitati,
+        ]);
+    }
+
+    public function create(): View
+    {
+        return view('valabilitati.create', [
+            'valabilitate' => new Valabilitate(),
+            'masini' => $this->masinaOptions(),
+        ]);
+    }
+
+    public function store(ValabilitateRequest $request): RedirectResponse
+    {
+        $valabilitate = Valabilitate::create(
+            $request->validated() + ['total_curse' => 0]
+        );
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Valabilitatea a fost creată cu succes.');
+    }
+
+    public function show(Valabilitate $valabilitate): View
+    {
+        $valabilitate->load(['masina', 'curse' => fn ($query) => $query->orderByDesc('plecare_la')->orderByDesc('created_at')]);
+
+        return view('valabilitati.show', [
+            'valabilitate' => $valabilitate,
+        ]);
+    }
+
+    public function edit(Valabilitate $valabilitate): View
+    {
+        return view('valabilitati.edit', [
+            'valabilitate' => $valabilitate,
+            'masini' => $this->masinaOptions(),
+        ]);
+    }
+
+    public function update(ValabilitateRequest $request, Valabilitate $valabilitate): RedirectResponse
+    {
+        $valabilitate->update($request->validated());
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Valabilitatea a fost actualizată cu succes.');
+    }
+
+    public function destroy(Valabilitate $valabilitate): RedirectResponse
+    {
+        $valabilitate->delete();
+
+        return redirect()
+            ->route('valabilitati.index')
+            ->with('status', 'Valabilitatea a fost ștearsă.');
+    }
+
+    protected function resourceAbilityMap(): array
+    {
+        return [
+            'index' => 'viewAny',
+            'show' => 'view',
+            'create' => 'create',
+            'store' => 'create',
+            'edit' => 'update',
+            'update' => 'update',
+            'destroy' => 'delete',
+        ];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function masinaOptions(): array
+    {
+        return Masina::query()
+            ->orderBy('numar_inmatriculare')
+            ->pluck('numar_inmatriculare', 'id')
+            ->map(fn (string $value) => trim($value))
+            ->all();
+    }
+}

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ValabilitateCursaRequest;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ValabilitateCursaController extends Controller
+{
+    public function store(ValabilitateCursaRequest $request, Valabilitate $valabilitate): RedirectResponse
+    {
+        $this->authorize('update', $valabilitate);
+
+        $valabilitate->curse()->create($request->validated());
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost adăugată cu succes.');
+    }
+
+    public function edit(Valabilitate $valabilitate, ValabilitateCursa $cursa): View
+    {
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+
+        $this->authorize('update', $valabilitate);
+
+        return view('valabilitati.curse.edit', [
+            'valabilitate' => $valabilitate,
+            'cursa' => $cursa,
+        ]);
+    }
+
+    public function update(ValabilitateCursaRequest $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): RedirectResponse
+    {
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+
+        $this->authorize('update', $valabilitate);
+
+        $cursa->update($request->validated());
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost actualizată.');
+    }
+
+    public function destroy(Valabilitate $valabilitate, ValabilitateCursa $cursa): RedirectResponse
+    {
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+
+        $this->authorize('update', $valabilitate);
+
+        $cursa->delete();
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost ștearsă.');
+    }
+
+    private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void
+    {
+        if ($cursa->valabilitate_id !== $valabilitate->getKey()) {
+            abort(404);
+        }
+    }
+}

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ValabilitateCursaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        return $valabilitate && $this->user()?->can('update', $valabilitate);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'localitate_plecare' => ['required', 'string', 'max:255'],
+            'localitate_sosire' => ['nullable', 'string', 'max:255'],
+            'plecare_la' => ['nullable', 'date'],
+            'sosire_la' => ['nullable', 'date', 'after_or_equal:plecare_la'],
+            'km_bord' => ['nullable', 'integer', 'min:0'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Http/Requests/ValabilitateRequest.php
+++ b/app/Http/Requests/ValabilitateRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Valabilitate;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ValabilitateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $ability = $this->isMethod('POST') ? 'create' : 'update';
+
+        $subject = $this->route('valabilitate');
+
+        if (! $subject instanceof Valabilitate) {
+            $subject = Valabilitate::class;
+        }
+
+        return $this->user()?->can($ability, $subject) ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'masina_id' => ['nullable', 'integer', 'exists:masini,id'],
+            'referinta' => ['nullable', 'string', 'max:255'],
+            'prima_cursa' => ['nullable', 'date'],
+            'ultima_cursa' => ['nullable', 'date', 'after_or_equal:prima_cursa'],
+        ];
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $data = parent::validated($key, $default);
+
+        if (array_key_exists('masina_id', $data)) {
+            $data['masina_id'] = $data['masina_id'] ? (int) $data['masina_id'] : null;
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -11,6 +11,10 @@ class Valabilitate extends Model
 {
     use HasFactory;
 
+    protected $attributes = [
+        'total_curse' => 0,
+    ];
+
     protected $fillable = [
         'masina_id',
         'referinta',
@@ -33,5 +37,28 @@ class Valabilitate extends Model
     public function curse(): HasMany
     {
         return $this->hasMany(ValabilitateCursa::class);
+    }
+
+    public function syncSummary(): void
+    {
+        $totalCurse = $this->curse()->count();
+
+        $primaCursa = $this->curse()
+            ->orderBy('plecare_la')
+            ->value('plecare_la');
+
+        $ultimaSosire = $this->curse()
+            ->orderByDesc('sosire_la')
+            ->value('sosire_la');
+
+        $ultimaPlecare = $ultimaSosire === null
+            ? $this->curse()->orderByDesc('plecare_la')->value('plecare_la')
+            : null;
+
+        $this->forceFill([
+            'total_curse' => $totalCurse,
+            'prima_cursa' => $primaCursa,
+            'ultima_cursa' => $ultimaSosire ?? $ultimaPlecare,
+        ])->saveQuietly();
     }
 }

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -35,6 +35,17 @@ class ValabilitateCursa extends Model
         return $this->belongsTo(Valabilitate::class);
     }
 
+    protected static function booted(): void
+    {
+        static::saved(function (ValabilitateCursa $cursa): void {
+            $cursa->valabilitate?->syncSummary();
+        });
+
+        static::deleted(function (ValabilitateCursa $cursa): void {
+            $cursa->valabilitate?->syncSummary();
+        });
+    }
+
     public static function suggestLocalitati(string $term = '', int $limit = 10): Collection
     {
         $term = trim($term);

--- a/app/Policies/ValabilitatePolicy.php
+++ b/app/Policies/ValabilitatePolicy.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use App\Models\Valabilitate;
+
+class ValabilitatePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermission('valabilitati');
+    }
+
+    public function view(User $user, Valabilitate $valabilitate): bool
+    {
+        return $user->hasPermission('valabilitati');
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermission('valabilitati');
+    }
+
+    public function update(User $user, Valabilitate $valabilitate): bool
+    {
+        return $user->hasPermission('valabilitati');
+    }
+
+    public function delete(User $user, Valabilitate $valabilitate): bool
+    {
+        return $user->hasPermission('valabilitati');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 
+use App\Models\Valabilitate;
+use App\Policies\ValabilitatePolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 
@@ -15,6 +17,7 @@ class AuthServiceProvider extends ServiceProvider
      */
     protected $policies = [
         \App\Models\DocumentWord::class => \App\Policies\DocumentWordPolicy::class,
+        Valabilitate::class => ValabilitatePolicy::class,
     ];
 
     /**

--- a/app/Support/Navigation/MainNavigation.php
+++ b/app/Support/Navigation/MainNavigation.php
@@ -80,6 +80,13 @@ class MainNavigation
             ],
             ['type' => 'divider'],
             [
+                'permission' => 'valabilitati',
+                'href' => route('valabilitati.index'),
+                'icon' => 'fa-solid fa-calendar-check',
+                'label' => 'Valabilități',
+            ],
+            ['type' => 'divider'],
+            [
                 'permission' => 'comenzi',
                 'href' => '/oferte-curse',
                 'icon' => 'fa-solid fa-truck',

--- a/resources/views/valabilitati/create.blade.php
+++ b/resources/views/valabilitati/create.blade.php
@@ -1,0 +1,30 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-10 col-xl-8">
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <span class="badge bg-primary text-uppercase">
+                        <i class="fa-solid fa-calendar-plus me-1"></i>
+                        Adăugare valabilitate
+                    </span>
+                </div>
+                <div class="card-body">
+                    @include('errors')
+
+                    <form method="POST" action="{{ route('valabilitati.store') }}">
+                        @csrf
+                        @include('valabilitati.form', [
+                            'valabilitate' => $valabilitate,
+                            'masini' => $masini,
+                            'submitLabel' => 'Salvează valabilitatea',
+                        ])
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/valabilitati/curse/_form.blade.php
+++ b/resources/views/valabilitati/curse/_form.blade.php
@@ -1,0 +1,36 @@
+<div class="row g-3">
+    <div class="col-md-6">
+        <label for="localitate_plecare" class="form-label">Localitate plecare</label>
+        <input type="text" class="form-control" id="localitate_plecare" name="localitate_plecare"
+            value="{{ old('localitate_plecare', $cursa->localitate_plecare ?? '') }}" required maxlength="255">
+    </div>
+
+    <div class="col-md-6">
+        <label for="localitate_sosire" class="form-label">Localitate sosire</label>
+        <input type="text" class="form-control" id="localitate_sosire" name="localitate_sosire"
+            value="{{ old('localitate_sosire', $cursa->localitate_sosire ?? '') }}" maxlength="255">
+    </div>
+
+    <div class="col-md-6">
+        <label for="plecare_la" class="form-label">Plecare la</label>
+        <input type="datetime-local" class="form-control" id="plecare_la" name="plecare_la"
+            value="{{ old('plecare_la', optional($cursa->plecare_la ?? null)->format('Y-m-d\TH:i')) }}">
+    </div>
+
+    <div class="col-md-6">
+        <label for="sosire_la" class="form-label">Sosire la</label>
+        <input type="datetime-local" class="form-control" id="sosire_la" name="sosire_la"
+            value="{{ old('sosire_la', optional($cursa->sosire_la ?? null)->format('Y-m-d\TH:i')) }}">
+    </div>
+
+    <div class="col-md-6">
+        <label for="km_bord" class="form-label">Kilometraj bord</label>
+        <input type="number" class="form-control" id="km_bord" name="km_bord" min="0"
+            value="{{ old('km_bord', $cursa->km_bord ?? '') }}">
+    </div>
+
+    <div class="col-12">
+        <label for="observatii" class="form-label">Observații</label>
+        <textarea class="form-control" id="observatii" name="observatii" rows="3">{{ old('observatii', $cursa->observatii ?? '') }}</textarea>
+    </div>
+</div>

--- a/resources/views/valabilitati/curse/edit.blade.php
+++ b/resources/views/valabilitati/curse/edit.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="mb-3">
+        <a href="{{ route('valabilitati.show', $valabilitate) }}" class="btn btn-link px-0">
+            <i class="fa-solid fa-arrow-left me-1"></i> Înapoi la valabilitate
+        </a>
+    </div>
+
+    <div class="row justify-content-center">
+        <div class="col-lg-10 col-xl-8">
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <span class="badge bg-primary text-uppercase">
+                        <i class="fa-solid fa-route me-1"></i>
+                        Modificare cursă
+                    </span>
+                </div>
+                <div class="card-body">
+                    @include('errors')
+
+                    <form method="POST" action="{{ route('valabilitati.curse.update', [$valabilitate, $cursa]) }}">
+                        @csrf
+                        @method('PUT')
+                        @include('valabilitati.curse._form', ['cursa' => $cursa])
+                        <div class="d-flex justify-content-end mt-3">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fa-solid fa-save me-1"></i> Salvează cursa
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/valabilitati/edit.blade.php
+++ b/resources/views/valabilitati/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="row justify-content-center">
+        <div class="col-lg-10 col-xl-8">
+            <div class="card shadow-sm">
+                <div class="card-header">
+                    <span class="badge bg-primary text-uppercase">
+                        <i class="fa-solid fa-pen-to-square me-1"></i>
+                        Modificare valabilitate
+                    </span>
+                </div>
+                <div class="card-body">
+                    @include('errors')
+
+                    <form method="POST" action="{{ route('valabilitati.update', $valabilitate) }}">
+                        @csrf
+                        @method('PUT')
+                        @include('valabilitati.form', [
+                            'valabilitate' => $valabilitate,
+                            'masini' => $masini,
+                            'submitLabel' => 'Actualizează valabilitatea',
+                        ])
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/valabilitati/form.blade.php
+++ b/resources/views/valabilitati/form.blade.php
@@ -1,0 +1,40 @@
+<div class="row g-3">
+    <div class="col-md-6">
+        <label for="masina_id" class="form-label">Mașină</label>
+        <select id="masina_id" name="masina_id" class="form-select">
+            <option value="">— Selectează mașina —</option>
+            @foreach ($masini as $id => $label)
+                <option value="{{ $id }}" @selected((string) old('masina_id', $valabilitate->masina_id) === (string) $id)>
+                    {{ $label }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+
+    <div class="col-md-6">
+        <label for="referinta" class="form-label">Referință</label>
+        <input type="text" class="form-control" id="referinta" name="referinta"
+            value="{{ old('referinta', $valabilitate->referinta) }}" maxlength="255">
+    </div>
+
+    <div class="col-md-6">
+        <label for="prima_cursa" class="form-label">Prima cursă</label>
+        <input type="datetime-local" class="form-control" id="prima_cursa" name="prima_cursa"
+            value="{{ old('prima_cursa', optional($valabilitate->prima_cursa)->format('Y-m-d\TH:i')) }}">
+    </div>
+
+    <div class="col-md-6">
+        <label for="ultima_cursa" class="form-label">Ultima cursă</label>
+        <input type="datetime-local" class="form-control" id="ultima_cursa" name="ultima_cursa"
+            value="{{ old('ultima_cursa', optional($valabilitate->ultima_cursa)->format('Y-m-d\TH:i')) }}">
+    </div>
+</div>
+
+<div class="d-flex justify-content-end mt-4">
+    <a href="{{ route('valabilitati.index') }}" class="btn btn-outline-secondary me-2">
+        Renunță
+    </a>
+    <button type="submit" class="btn btn-primary">
+        {{ $submitLabel }}
+    </button>
+</div>

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -1,0 +1,74 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <span class="badge bg-primary text-uppercase">
+                <i class="fa-solid fa-calendar-check me-1"></i>
+                Valabilități
+            </span>
+            <a class="btn btn-sm btn-success" href="{{ route('valabilitati.create') }}">
+                <i class="fa-solid fa-plus me-1"></i>
+                Adaugă valabilitate
+            </a>
+        </div>
+
+        <div class="card-body">
+            @include('errors')
+
+            @if ($valabilitati->isEmpty())
+                <p class="text-muted mb-0">Nu există valabilități înregistrate în acest moment.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Referință</th>
+                                <th>Mașină</th>
+                                <th>Prima cursă</th>
+                                <th>Ultima cursă</th>
+                                <th class="text-center">Total curse</th>
+                                <th class="text-end">Acțiuni</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($valabilitati as $valabilitate)
+                                <tr>
+                                    <td>{{ $loop->iteration + ($valabilitati->currentPage() - 1) * $valabilitati->perPage() }}</td>
+                                    <td>{{ $valabilitate->referinta ?: '—' }}</td>
+                                    <td>{{ $valabilitate->masina?->numar_inmatriculare ?: '—' }}</td>
+                                    <td>{{ $valabilitate->prima_cursa?->format('d.m.Y H:i') ?: '—' }}</td>
+                                    <td>{{ $valabilitate->ultima_cursa?->format('d.m.Y H:i') ?: '—' }}</td>
+                                    <td class="text-center">{{ $valabilitate->total_curse }}</td>
+                                    <td class="text-end">
+                                        <a class="btn btn-sm btn-outline-primary me-1" href="{{ route('valabilitati.show', $valabilitate) }}">
+                                            <i class="fa-solid fa-eye"></i>
+                                        </a>
+                                        <a class="btn btn-sm btn-outline-secondary me-1" href="{{ route('valabilitati.edit', $valabilitate) }}">
+                                            <i class="fa-solid fa-pen"></i>
+                                        </a>
+                                        <form action="{{ route('valabilitati.destroy', $valabilitate) }}" method="POST" class="d-inline"
+                                            onsubmit="return confirm('Sigur dorești să ștergi această valabilitate?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button class="btn btn-sm btn-outline-danger" type="submit">
+                                                <i class="fa-solid fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="mt-3">
+                    {{ $valabilitati->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -1,0 +1,119 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4">
+    <div class="mb-3">
+        <a href="{{ route('valabilitati.index') }}" class="btn btn-link px-0">
+            <i class="fa-solid fa-arrow-left me-1"></i> Înapoi la listă
+        </a>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <div>
+                <h2 class="h5 mb-0">{{ $valabilitate->referinta ?: 'Valabilitate fără referință' }}</h2>
+                <small class="text-muted">Creată la {{ $valabilitate->created_at?->format('d.m.Y H:i') }}</small>
+            </div>
+            <div>
+                <a href="{{ route('valabilitati.edit', $valabilitate) }}" class="btn btn-sm btn-outline-secondary me-2">
+                    <i class="fa-solid fa-pen"></i> Modifică
+                </a>
+                <form action="{{ route('valabilitati.destroy', $valabilitate) }}" method="POST" class="d-inline"
+                    onsubmit="return confirm('Sigur dorești să ștergi această valabilitate?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-outline-danger">
+                        <i class="fa-solid fa-trash"></i> Șterge
+                    </button>
+                </form>
+            </div>
+        </div>
+        <div class="card-body">
+            @include('errors')
+
+            <dl class="row mb-0">
+                <dt class="col-sm-3">Mașină asociată</dt>
+                <dd class="col-sm-9">{{ $valabilitate->masina?->numar_inmatriculare ?: '—' }}</dd>
+
+                <dt class="col-sm-3">Prima cursă</dt>
+                <dd class="col-sm-9">{{ $valabilitate->prima_cursa?->format('d.m.Y H:i') ?: '—' }}</dd>
+
+                <dt class="col-sm-3">Ultima cursă</dt>
+                <dd class="col-sm-9">{{ $valabilitate->ultima_cursa?->format('d.m.Y H:i') ?: '—' }}</dd>
+
+                <dt class="col-sm-3">Total curse</dt>
+                <dd class="col-sm-9">{{ $valabilitate->total_curse }}</dd>
+            </dl>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-header d-flex justify-content-between align-items-center">
+            <h3 class="h6 mb-0">Curse asociate</h3>
+        </div>
+        <div class="card-body">
+            @if ($valabilitate->curse->isEmpty())
+                <p class="text-muted">Nu există curse asociate acestei valabilități.</p>
+            @else
+                <div class="table-responsive mb-4">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Localitate plecare</th>
+                                <th>Localitate sosire</th>
+                                <th>Plecare</th>
+                                <th>Sosire</th>
+                                <th class="text-center">Km bord</th>
+                                <th>Observații</th>
+                                <th class="text-end">Acțiuni</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($valabilitate->curse as $cursa)
+                                <tr>
+                                    <td>{{ $loop->iteration }}</td>
+                                    <td>{{ $cursa->localitate_plecare }}</td>
+                                    <td>{{ $cursa->localitate_sosire ?: '—' }}</td>
+                                    <td>{{ $cursa->plecare_la?->format('d.m.Y H:i') ?: '—' }}</td>
+                                    <td>{{ $cursa->sosire_la?->format('d.m.Y H:i') ?: '—' }}</td>
+                                    <td class="text-center">{{ $cursa->km_bord ?? '—' }}</td>
+                                    <td>{{ $cursa->observatii ?: '—' }}</td>
+                                    <td class="text-end">
+                                        <a href="{{ route('valabilitati.curse.edit', [$valabilitate, $cursa]) }}"
+                                           class="btn btn-sm btn-outline-secondary me-2">
+                                            <i class="fa-solid fa-pen"></i>
+                                        </a>
+                                        <form action="{{ route('valabilitati.curse.destroy', [$valabilitate, $cursa]) }}"
+                                              method="POST" class="d-inline"
+                                              onsubmit="return confirm('Sigur dorești să ștergi această cursă?');">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger">
+                                                <i class="fa-solid fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+
+            <div class="border rounded p-3">
+                <h4 class="h6 mb-3">Adaugă cursă nouă</h4>
+                <form method="POST" action="{{ route('valabilitati.curse.store', $valabilitate) }}">
+                    @csrf
+                    @include('valabilitati.curse._form', ['cursa' => null])
+                    <div class="d-flex justify-content-end mt-3">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fa-solid fa-plus me-1"></i> Adaugă cursă
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,8 @@ use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\CronJobLogController;
 use App\Http\Controllers\SoferDashboardController;
+use App\Http\Controllers\ValabilitateController;
+use App\Http\Controllers\ValabilitateCursaController;
 
 
 /*
@@ -323,6 +325,22 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware('permission:masini-valabilitati')->group(function () {
         Route::resource('masini-valabilitati', MasinaValabilitatiController::class)
             ->parameters(['masini-valabilitati' => 'masinaValabilitati']);
+    });
+
+    Route::middleware('permission:valabilitati')->group(function () {
+        Route::resource('valabilitati', ValabilitateController::class)
+            ->parameters(['valabilitati' => 'valabilitate']);
+
+        Route::scopeBindings()->group(function () {
+            Route::post('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'store'])
+                ->name('valabilitati.curse.store');
+            Route::get('valabilitati/{valabilitate}/curse/{cursa}/edit', [ValabilitateCursaController::class, 'edit'])
+                ->name('valabilitati.curse.edit');
+            Route::put('valabilitati/{valabilitate}/curse/{cursa}', [ValabilitateCursaController::class, 'update'])
+                ->name('valabilitati.curse.update');
+            Route::delete('valabilitati/{valabilitate}/curse/{cursa}', [ValabilitateCursaController::class, 'destroy'])
+                ->name('valabilitati.curse.destroy');
+        });
     });
 
     Route::middleware('permission:rapoarte')->group(function () {


### PR DESCRIPTION
## Summary
- add first-party Valabilitate controllers, requests, and policy under the App namespace and register the policy mapping
- expose the valabilitati resource routes without the admin prefix and update navigation to the new route names
- publish dedicated Blade screens for listing, editing, and managing Valabilitate entries and their nested curse

## Testing
- php artisan test *(fails: vendor directory is not installed in the sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912fe8f3ef08326a351cbfd586dedf3)