### PR TITLE
Add sofer valabilitate interface and enforce trip validation

### DIFF
--- a/app/Http/Controllers/Api/ValabilitateLocalitatiController.php
+++ b/app/Http/Controllers/Api/ValabilitateLocalitatiController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\ValabilitateCursa;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ValabilitateLocalitatiController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $term = (string) $request->query('q', '');
+        $limit = (int) $request->query('limit', 10);
+        $limit = max(1, min($limit, 25));
+
+        $localitati = ValabilitateCursa::suggestLocalitati($term, $limit);
+
+        return response()->json($localitati);
+    }
+}

--- a/app/Http/Controllers/SoferValabilitateController.php
+++ b/app/Http/Controllers/SoferValabilitateController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Valabilitate;
+use App\Support\CountryList;
+use Illuminate\View\View;
+
+class SoferValabilitateController extends Controller
+{
+    public function show(Valabilitate $valabilitate): View
+    {
+        $valabilitate->load(['masina', 'curse' => fn ($query) => $query->orderByDesc('plecare_la')->orderByDesc('created_at')]);
+
+        return view('sofer.valabilitate.show', [
+            'valabilitate' => $valabilitate,
+            'countries' => CountryList::options(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ValabilitateRequest;
 use App\Models\Masini\Masina;
 use App\Models\Valabilitate;
+use App\Support\CountryList;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
@@ -55,6 +56,7 @@ class ValabilitateController extends Controller
 
         return view('valabilitati.show', [
             'valabilitate' => $valabilitate,
+            'countries' => CountryList::options(),
         ]);
     }
 

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Models\ValabilitateCursa;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ValabilitateCursaRequest extends FormRequest
@@ -15,13 +16,54 @@ class ValabilitateCursaRequest extends FormRequest
 
     public function rules(): array
     {
+        $valabilitate = $this->route('valabilitate');
+        $cursa = $this->route('cursa');
+
+        $isFirstTrip = false;
+
+        if ($valabilitate) {
+            $query = $valabilitate->curse();
+
+            if ($cursa instanceof ValabilitateCursa) {
+                $query->whereKeyNot($cursa->getKey());
+            }
+
+            $isFirstTrip = $query->doesntExist();
+        }
+
+        $ultimaCursaRequested = $this->boolean('ultima_cursa');
+
+        $oraRules = ['nullable', 'date_format:H:i'];
+
+        if ($isFirstTrip || $ultimaCursaRequested) {
+            $oraRules[0] = 'required';
+        }
+
         return [
             'localitate_plecare' => ['required', 'string', 'max:255'],
             'localitate_sosire' => ['nullable', 'string', 'max:255'],
+            'descarcare_tara' => ['nullable', 'string', 'size:2'],
             'plecare_la' => ['nullable', 'date'],
             'sosire_la' => ['nullable', 'date', 'after_or_equal:plecare_la'],
+            'ora' => $oraRules,
             'km_bord' => ['nullable', 'integer', 'min:0'],
             'observatii' => ['nullable', 'string'],
+            'ultima_cursa' => ['required', 'boolean'],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $ora = $this->input('ora');
+        $descarcareTara = $this->input('descarcare_tara');
+        $descarcareTara = $descarcareTara === '' ? null : strtoupper((string) $descarcareTara);
+
+        $this->merge([
+            'ultima_cursa' => $this->has('ultima_cursa')
+                ? filter_var($this->input('ultima_cursa'), FILTER_VALIDATE_BOOLEAN)
+                : false,
+            'ora' => $ora === '' ? null : $ora,
+            'descarcare_tara' => $descarcareTara,
+        ]);
     }
 }

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection;
@@ -18,17 +19,28 @@ class ValabilitateCursa extends Model
         'valabilitate_id',
         'localitate_plecare',
         'localitate_sosire',
+        'descarcare_tara',
         'plecare_la',
         'sosire_la',
+        'ora',
         'km_bord',
         'observatii',
+        'ultima_cursa',
     ];
 
     protected $casts = [
         'plecare_la' => 'immutable_datetime',
         'sosire_la' => 'immutable_datetime',
         'km_bord' => 'integer',
+        'ultima_cursa' => 'boolean',
     ];
+
+    protected function descarcareTara(): Attribute
+    {
+        return Attribute::make(
+            set: fn (?string $value) => $value !== null ? strtoupper(trim($value)) : null,
+        );
+    }
 
     public function valabilitate(): BelongsTo
     {

--- a/app/Support/CountryList.php
+++ b/app/Support/CountryList.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Support;
+
+class CountryList
+{
+    /**
+     * @var array<string, string>
+     */
+    private const COUNTRIES = [
+        'AL' => 'Albania',
+        'AT' => 'Austria',
+        'BA' => 'Bosnia și Herțegovina',
+        'BE' => 'Belgia',
+        'BG' => 'Bulgaria',
+        'CH' => 'Elveția',
+        'CY' => 'Cipru',
+        'CZ' => 'Cehia',
+        'DE' => 'Germania',
+        'DK' => 'Danemarca',
+        'EE' => 'Estonia',
+        'ES' => 'Spania',
+        'FI' => 'Finlanda',
+        'FR' => 'Franța',
+        'GB' => 'Regatul Unit',
+        'GR' => 'Grecia',
+        'HR' => 'Croația',
+        'HU' => 'Ungaria',
+        'IE' => 'Irlanda',
+        'IT' => 'Italia',
+        'LT' => 'Lituania',
+        'LU' => 'Luxemburg',
+        'LV' => 'Letonia',
+        'MD' => 'Republica Moldova',
+        'MK' => 'Macedonia de Nord',
+        'MT' => 'Malta',
+        'NL' => 'Țările de Jos',
+        'NO' => 'Norvegia',
+        'PL' => 'Polonia',
+        'PT' => 'Portugalia',
+        'RO' => 'România',
+        'RS' => 'Serbia',
+        'SE' => 'Suedia',
+        'SI' => 'Slovenia',
+        'SK' => 'Slovacia',
+        'TR' => 'Turcia',
+        'UA' => 'Ucraina',
+    ];
+
+    public static function options(): array
+    {
+        return self::COUNTRIES;
+    }
+
+    public static function label(?string $code): ?string
+    {
+        if ($code === null) {
+            return null;
+        }
+
+        $upperCode = strtoupper($code);
+
+        return self::COUNTRIES[$upperCode] ?? $upperCode;
+    }
+}

--- a/database/migrations/2025_03_24_000200_add_trip_fields_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_000200_add_trip_fields_to_valabilitati_curse_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table) {
+            $table->string('descarcare_tara', 2)->nullable()->after('localitate_sosire');
+            $table->time('ora')->nullable()->after('sosire_la');
+            $table->boolean('ultima_cursa')->default(false)->after('ora');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table) {
+            $table->dropColumn(['descarcare_tara', 'ora', 'ultima_cursa']);
+        });
+    }
+};

--- a/resources/views/sofer/valabilitate/show.blade.php
+++ b/resources/views/sofer/valabilitate/show.blade.php
@@ -1,0 +1,181 @@
+@extends('layouts.app')
+
+@php
+    use App\Support\CountryList;
+
+    $firstTrip = $valabilitate->curse->sortBy('plecare_la')->first();
+@endphp
+
+@section('content')
+    <div class="container py-4 py-md-5">
+        <div class="mb-3">
+            <a href="{{ route('sofer.dashboard') }}" class="btn btn-link px-0">
+                <i class="fa-solid fa-arrow-left me-1"></i> Înapoi la panou
+            </a>
+        </div>
+
+        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3 mb-4">
+            <div>
+                <span class="badge bg-primary-subtle text-primary fw-semibold text-uppercase px-3 py-2 rounded-pill">
+                    Valabilitate activă
+                </span>
+                <h1 class="h4 fw-bold mt-3 mb-0">{{ $valabilitate->referinta ?: 'Fără referință' }}</h1>
+                <p class="text-muted small mb-0">Actualizat la {{ $valabilitate->updated_at?->format('d.m.Y H:i') ?? '—' }}</p>
+            </div>
+            @if ($valabilitate->masina)
+                <div class="text-md-end">
+                    <p class="text-muted text-uppercase small mb-1">Vehicul</p>
+                    <p class="h5 fw-semibold mb-0">{{ $valabilitate->masina->numar_inmatriculare }}</p>
+                </div>
+            @endif
+        </div>
+
+        @if (session('status'))
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                {{ session('status') }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Închide"></button>
+            </div>
+        @endif
+
+        @include('errors')
+
+        <section class="card border-0 shadow-sm mb-4">
+            <div class="card-body">
+                <div class="row g-3 g-md-4">
+                    <div class="col-6 col-md-3">
+                        <p class="text-muted text-uppercase small mb-1">Prima cursă</p>
+                        <p class="fw-semibold mb-0">{{ $valabilitate->prima_cursa?->format('d.m.Y H:i') ?? '—' }}</p>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <p class="text-muted text-uppercase small mb-1">Ultima cursă</p>
+                        <p class="fw-semibold mb-0">{{ $valabilitate->ultima_cursa?->format('d.m.Y H:i') ?? '—' }}</p>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <p class="text-muted text-uppercase small mb-1">Total curse</p>
+                        <p class="fw-semibold mb-0">{{ $valabilitate->total_curse }}</p>
+                    </div>
+                    <div class="col-6 col-md-3">
+                        <p class="text-muted text-uppercase small mb-1">Prima locație</p>
+                        <p class="fw-semibold mb-0">{{ $firstTrip?->localitate_plecare ?? '—' }}</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="mb-5">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-3">
+                <div>
+                    <h2 class="h5 fw-bold mb-1">Curse înregistrate</h2>
+                    <p class="text-muted small mb-0">Actualizați cursele rapid direct din cardurile de mai jos.</p>
+                </div>
+            </div>
+
+            <div class="d-flex flex-column gap-3">
+                @forelse ($valabilitate->curse as $cursa)
+                    <article class="card border-0 shadow-sm">
+                        <div class="card-body p-4">
+                            <div class="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                                <div>
+                                    <div class="d-flex align-items-center gap-2 mb-2 flex-wrap">
+                                        <span class="badge bg-primary-subtle text-primary fw-semibold">
+                                            {{ $cursa->localitate_plecare }} → {{ $cursa->localitate_sosire ?? '—' }}
+                                        </span>
+                                        @if ($cursa->descarcare_tara)
+                                            <span class="badge bg-light text-muted border">
+                                                {{ CountryList::label($cursa->descarcare_tara) }}
+                                            </span>
+                                        @endif
+                                        @if ($cursa->ultima_cursa)
+                                            <span class="badge bg-success text-uppercase">Ultima cursă</span>
+                                        @endif
+                                    </div>
+                                    <dl class="row mb-0 small text-muted">
+                                        <dt class="col-sm-4">Plecare</dt>
+                                        <dd class="col-sm-8 mb-1">
+                                            {{ $cursa->plecare_la?->format('d.m.Y H:i') ?? '—' }}
+                                        </dd>
+                                        <dt class="col-sm-4">Sosire</dt>
+                                        <dd class="col-sm-8 mb-1">
+                                            {{ $cursa->sosire_la?->format('d.m.Y H:i') ?? '—' }}
+                                        </dd>
+                                        <dt class="col-sm-4">Ora</dt>
+                                        <dd class="col-sm-8 mb-1">
+                                            {{ $cursa->ora ? substr($cursa->ora, 0, 5) : '—' }}
+                                        </dd>
+                                        <dt class="col-sm-4">Km bord</dt>
+                                        <dd class="col-sm-8 mb-1">
+                                            {{ $cursa->km_bord ?? '—' }}
+                                        </dd>
+                                        <dt class="col-sm-4">Observații</dt>
+                                        <dd class="col-sm-8">
+                                            {{ $cursa->observatii ?: '—' }}
+                                        </dd>
+                                    </dl>
+                                </div>
+                                <form method="POST" action="{{ route('valabilitati.curse.destroy', [$valabilitate, $cursa]) }}"
+                                      class="ms-auto" onsubmit="return confirm('Ștergi această cursă?');">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-outline-danger btn-sm">
+                                        <i class="fa-solid fa-trash"></i>
+                                    </button>
+                                </form>
+                            </div>
+
+                            <details class="mt-3">
+                                <summary class="btn btn-sm btn-outline-secondary">
+                                    <i class="fa-solid fa-pen me-1"></i> Editează cursa
+                                </summary>
+                                <div class="mt-3 border-top pt-3">
+                                    <form method="POST" action="{{ route('valabilitati.curse.update', [$valabilitate, $cursa]) }}">
+                                        @csrf
+                                        @method('PUT')
+                                        @include('valabilitati.curse._form', [
+                                            'cursa' => $cursa,
+                                            'countries' => $countries,
+                                            'isFirstTrip' => $valabilitate->curse->count() === 1,
+                                            'formId' => 'sofer-edit-' . $loop->index,
+                                        ])
+                                        <div class="d-flex justify-content-end gap-2 mt-3">
+                                            <button type="submit" class="btn btn-primary btn-sm">
+                                                <i class="fa-solid fa-save me-1"></i> Salvează
+                                            </button>
+                                        </div>
+                                    </form>
+                                </div>
+                            </details>
+                        </div>
+                    </article>
+                @empty
+                    <div class="card border-0 shadow-sm">
+                        <div class="card-body text-center py-5">
+                            <i class="fa-solid fa-route fa-2x text-muted mb-3"></i>
+                            <p class="fw-semibold mb-1">Nu există încă nicio cursă înregistrată.</p>
+                            <p class="text-muted small mb-0">Folosește formularul de mai jos pentru a adăuga prima cursă.</p>
+                        </div>
+                    </div>
+                @endforelse
+            </div>
+        </section>
+
+        <section class="card border-0 shadow-sm">
+            <div class="card-body p-4">
+                <h2 class="h5 fw-bold mb-3">Adaugă cursă nouă</h2>
+                <form method="POST" action="{{ route('valabilitati.curse.store', $valabilitate) }}">
+                    @csrf
+                    @include('valabilitati.curse._form', [
+                        'cursa' => null,
+                        'countries' => $countries,
+                        'isFirstTrip' => $valabilitate->curse->isEmpty(),
+                        'formId' => 'sofer-create',
+                    ])
+                    <div class="d-flex justify-content-end mt-3">
+                        <button type="submit" class="btn btn-primary">
+                            <i class="fa-solid fa-plus me-1"></i> Adaugă cursă
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </section>
+    </div>
+@endsection

--- a/resources/views/valabilitati/curse/_form.blade.php
+++ b/resources/views/valabilitati/curse/_form.blade.php
@@ -1,36 +1,219 @@
+@php
+    use App\Support\CountryList;
+
+    $formId ??= 'valabilitate-cursa-' . uniqid();
+    $countries = $countries ?? CountryList::options();
+    $isFirstTrip = $isFirstTrip ?? false;
+    $ultimaCursaDefault = old('ultima_cursa', $cursa->ultima_cursa ?? false);
+@endphp
+
 <div class="row g-3">
     <div class="col-md-6">
-        <label for="localitate_plecare" class="form-label">Localitate plecare</label>
-        <input type="text" class="form-control" id="localitate_plecare" name="localitate_plecare"
-            value="{{ old('localitate_plecare', $cursa->localitate_plecare ?? '') }}" required maxlength="255">
+        <label for="{{ $formId }}-localitate-plecare" class="form-label">Localitate plecare</label>
+        <input type="text" class="form-control" id="{{ $formId }}-localitate-plecare" name="localitate_plecare"
+            value="{{ old('localitate_plecare', $cursa->localitate_plecare ?? '') }}" required maxlength="255"
+            list="{{ $formId }}-plecare-suggestions" data-localitate-autocomplete
+            data-autocomplete-target="{{ $formId }}-plecare-suggestions">
+        <datalist id="{{ $formId }}-plecare-suggestions"></datalist>
     </div>
 
     <div class="col-md-6">
-        <label for="localitate_sosire" class="form-label">Localitate sosire</label>
-        <input type="text" class="form-control" id="localitate_sosire" name="localitate_sosire"
-            value="{{ old('localitate_sosire', $cursa->localitate_sosire ?? '') }}" maxlength="255">
+        <label for="{{ $formId }}-localitate-sosire" class="form-label">Localitate sosire</label>
+        <input type="text" class="form-control" id="{{ $formId }}-localitate-sosire" name="localitate_sosire"
+            value="{{ old('localitate_sosire', $cursa->localitate_sosire ?? '') }}" maxlength="255"
+            list="{{ $formId }}-sosire-suggestions" data-localitate-autocomplete
+            data-autocomplete-target="{{ $formId }}-sosire-suggestions">
+        <datalist id="{{ $formId }}-sosire-suggestions"></datalist>
     </div>
 
-    <div class="col-md-6">
-        <label for="plecare_la" class="form-label">Plecare la</label>
-        <input type="datetime-local" class="form-control" id="plecare_la" name="plecare_la"
+    <div class="col-md-6 col-lg-4">
+        <label for="{{ $formId }}-descarcare-tara" class="form-label">Țara descărcare</label>
+        <select class="form-select" id="{{ $formId }}-descarcare-tara" name="descarcare_tara"
+            data-descarcare-tara>
+            <option value="">Alege țara</option>
+            @foreach ($countries as $code => $label)
+                <option value="{{ $code }}" @selected(old('descarcare_tara', $cursa->descarcare_tara ?? '') === $code)>
+                    {{ $label }}
+                </option>
+            @endforeach
+        </select>
+    </div>
+
+    <div class="col-md-6 col-lg-4">
+        <label for="{{ $formId }}-plecare" class="form-label">Plecare la</label>
+        <input type="datetime-local" class="form-control" id="{{ $formId }}-plecare" name="plecare_la"
             value="{{ old('plecare_la', optional($cursa->plecare_la ?? null)->format('Y-m-d\TH:i')) }}">
     </div>
 
-    <div class="col-md-6">
-        <label for="sosire_la" class="form-label">Sosire la</label>
-        <input type="datetime-local" class="form-control" id="sosire_la" name="sosire_la"
+    <div class="col-md-6 col-lg-4">
+        <label for="{{ $formId }}-sosire" class="form-label">Sosire la</label>
+        <input type="datetime-local" class="form-control" id="{{ $formId }}-sosire" name="sosire_la"
             value="{{ old('sosire_la', optional($cursa->sosire_la ?? null)->format('Y-m-d\TH:i')) }}">
     </div>
 
-    <div class="col-md-6">
-        <label for="km_bord" class="form-label">Kilometraj bord</label>
-        <input type="number" class="form-control" id="km_bord" name="km_bord" min="0"
+    <div class="col-md-6 col-lg-4">
+        <label for="{{ $formId }}-ora" class="form-label">Ora</label>
+        <input type="time" class="form-control" id="{{ $formId }}-ora" name="ora"
+            value="{{ old('ora', $cursa->ora ? substr($cursa->ora, 0, 5) : '') }}"
+            @if ($isFirstTrip || $ultimaCursaDefault) required @endif
+            data-ora-input data-first-trip="{{ $isFirstTrip ? '1' : '0' }}">
+        <small class="text-muted" data-ora-hint>Ora este obligatorie pentru prima cursă și pentru ultima cursă.</small>
+    </div>
+
+    <div class="col-md-6 col-lg-4">
+        <label for="{{ $formId }}-km" class="form-label">Kilometraj bord</label>
+        <input type="number" class="form-control" id="{{ $formId }}-km" name="km_bord" min="0"
             value="{{ old('km_bord', $cursa->km_bord ?? '') }}">
     </div>
 
+    <div class="col-md-6 col-lg-4 d-flex align-items-end">
+        <div class="form-check form-switch">
+            <input type="hidden" name="ultima_cursa" value="0">
+            <input class="form-check-input" type="checkbox" role="switch"
+                id="{{ $formId }}-ultima-cursa" name="ultima_cursa" value="1"
+                @checked((bool) $ultimaCursaDefault) data-ultima-checkbox>
+            <label class="form-check-label" for="{{ $formId }}-ultima-cursa">Ultima cursă</label>
+        </div>
+    </div>
+
     <div class="col-12">
-        <label for="observatii" class="form-label">Observații</label>
-        <textarea class="form-control" id="observatii" name="observatii" rows="3">{{ old('observatii', $cursa->observatii ?? '') }}</textarea>
+        <label for="{{ $formId }}-observatii" class="form-label">Observații</label>
+        <textarea class="form-control" id="{{ $formId }}-observatii" name="observatii" rows="3">{{ old('observatii', $cursa->observatii ?? '') }}</textarea>
     </div>
 </div>
+
+@once
+    @push('scripts')
+        <script>
+            (function () {
+                const attachAutocomplete = (input) => {
+                    if (input.dataset.enhanced === '1') {
+                        return;
+                    }
+
+                    input.dataset.enhanced = '1';
+
+                    const datalistId = input.getAttribute('data-autocomplete-target');
+                    const datalist = document.getElementById(datalistId);
+                    if (!datalist) {
+                        return;
+                    }
+
+                    let controller;
+
+                    input.addEventListener('input', () => {
+                        const query = input.value.trim();
+
+                        if (query.length < 2) {
+                            datalist.innerHTML = '';
+                            if (controller) {
+                                controller.abort();
+                                controller = undefined;
+                            }
+                            return;
+                        }
+
+                        if (controller) {
+                            controller.abort();
+                        }
+
+                        controller = new AbortController();
+
+                        fetch(`/api/valabilitati/localitati?q=${encodeURIComponent(query)}`, {
+                            signal: controller.signal,
+                            credentials: 'same-origin',
+                        })
+                            .then((response) => {
+                                if (!response.ok) {
+                                    throw new Error('Request failed');
+                                }
+
+                                return response.json();
+                            })
+                            .then((items) => {
+                                datalist.innerHTML = '';
+
+                                items.forEach((item) => {
+                                    const option = document.createElement('option');
+                                    option.value = item;
+                                    datalist.appendChild(option);
+                                });
+                            })
+                            .catch(() => {
+                                datalist.innerHTML = '';
+                            });
+                    });
+                };
+
+                const updateOraRequirement = (form) => {
+                    const oraInput = form.querySelector('[data-ora-input]');
+                    if (!oraInput) {
+                        return;
+                    }
+
+                    const ultimaCheckbox = form.querySelector('[data-ultima-checkbox]');
+                    const firstTrip = oraInput.dataset.firstTrip === '1';
+                    const requireOra = (ultimaCheckbox && ultimaCheckbox.checked) || firstTrip;
+
+                    oraInput.required = requireOra;
+                };
+
+                const enhanceForm = (form) => {
+                    if (!form || form.dataset.valabilitateEnhanced === '1') {
+                        return;
+                    }
+
+                    form.dataset.valabilitateEnhanced = '1';
+
+                    form.querySelectorAll('[data-localitate-autocomplete]').forEach(attachAutocomplete);
+
+                    const ultimaCheckbox = form.querySelector('[data-ultima-checkbox]');
+                    const oraInput = form.querySelector('[data-ora-input]');
+                    const taraSelect = form.querySelector('[data-descarcare-tara]');
+
+                    if (ultimaCheckbox && oraInput) {
+                        ultimaCheckbox.addEventListener('change', () => {
+                            updateOraRequirement(form);
+                        });
+                    }
+
+                    if (taraSelect && ultimaCheckbox) {
+                        taraSelect.addEventListener('change', () => {
+                            if (taraSelect.value === 'RO') {
+                                const confirmed = window.confirm('Cursa se încheie în România și va fi marcată ca ultima cursă?');
+                                ultimaCheckbox.checked = confirmed;
+                                ultimaCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
+                            }
+                        });
+                    }
+
+                    updateOraRequirement(form);
+                };
+
+                document.querySelectorAll('form').forEach(enhanceForm);
+
+                document.addEventListener('DOMContentLoaded', () => {
+                    document.querySelectorAll('form').forEach(enhanceForm);
+                });
+
+                const observer = new MutationObserver((mutations) => {
+                    for (const mutation of mutations) {
+                        mutation.addedNodes.forEach((node) => {
+                            if (!(node instanceof HTMLElement)) {
+                                return;
+                            }
+
+                            if (node.tagName === 'FORM') {
+                                enhanceForm(node);
+                            } else {
+                                node.querySelectorAll?.('form').forEach(enhanceForm);
+                            }
+                        });
+                    }
+                });
+
+                observer.observe(document.body, { childList: true, subtree: true });
+            })();
+        </script>
+    @endpush
+@endonce

--- a/resources/views/valabilitati/curse/edit.blade.php
+++ b/resources/views/valabilitati/curse/edit.blade.php
@@ -23,7 +23,12 @@
                     <form method="POST" action="{{ route('valabilitati.curse.update', [$valabilitate, $cursa]) }}">
                         @csrf
                         @method('PUT')
-                        @include('valabilitati.curse._form', ['cursa' => $cursa])
+                        @include('valabilitati.curse._form', [
+                            'cursa' => $cursa,
+                            'countries' => $countries,
+                            'isFirstTrip' => $isFirstTrip,
+                            'formId' => 'valabilitate-cursa-edit',
+                        ])
                         <div class="d-flex justify-content-end mt-3">
                             <button type="submit" class="btn btn-primary">
                                 <i class="fa-solid fa-save me-1"></i> Salvează cursa

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -1,5 +1,11 @@
 @extends('layouts.app')
 
+@php
+    use App\Support\CountryList;
+
+    $isFirstTrip = $valabilitate->curse->isEmpty();
+@endphp
+
 @section('content')
 <div class="container py-4">
     <div class="mb-3">
@@ -62,9 +68,12 @@
                                 <th>#</th>
                                 <th>Localitate plecare</th>
                                 <th>Localitate sosire</th>
+                                <th>Țara descărcare</th>
                                 <th>Plecare</th>
                                 <th>Sosire</th>
+                                <th>Ora</th>
                                 <th class="text-center">Km bord</th>
+                                <th class="text-center">Ultima cursă</th>
                                 <th>Observații</th>
                                 <th class="text-end">Acțiuni</th>
                             </tr>
@@ -75,9 +84,18 @@
                                     <td>{{ $loop->iteration }}</td>
                                     <td>{{ $cursa->localitate_plecare }}</td>
                                     <td>{{ $cursa->localitate_sosire ?: '—' }}</td>
+                                    <td>{{ CountryList::label($cursa->descarcare_tara) ?? '—' }}</td>
                                     <td>{{ $cursa->plecare_la?->format('d.m.Y H:i') ?: '—' }}</td>
                                     <td>{{ $cursa->sosire_la?->format('d.m.Y H:i') ?: '—' }}</td>
+                                    <td>{{ $cursa->ora ? substr($cursa->ora, 0, 5) : '—' }}</td>
                                     <td class="text-center">{{ $cursa->km_bord ?? '—' }}</td>
+                                    <td class="text-center">
+                                        @if ($cursa->ultima_cursa)
+                                            <span class="badge bg-success">Da</span>
+                                        @else
+                                            <span class="badge bg-secondary">Nu</span>
+                                        @endif
+                                    </td>
                                     <td>{{ $cursa->observatii ?: '—' }}</td>
                                     <td class="text-end">
                                         <a href="{{ route('valabilitati.curse.edit', [$valabilitate, $cursa]) }}"
@@ -105,7 +123,12 @@
                 <h4 class="h6 mb-3">Adaugă cursă nouă</h4>
                 <form method="POST" action="{{ route('valabilitati.curse.store', $valabilitate) }}">
                     @csrf
-                    @include('valabilitati.curse._form', ['cursa' => null])
+                    @include('valabilitati.curse._form', [
+                        'cursa' => null,
+                        'countries' => $countries,
+                        'isFirstTrip' => $isFirstTrip,
+                        'formId' => 'valabilitate-cursa-create',
+                    ])
                     <div class="d-flex justify-content-end mt-3">
                         <button type="submit" class="btn btn-primary">
                             <i class="fa-solid fa-plus me-1"></i> Adaugă cursă

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,8 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
+use App\Http\Controllers\Api\ValabilitateLocalitatiController;
+
 /*
 |--------------------------------------------------------------------------
 | API Routes
@@ -17,3 +19,6 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::middleware('auth:sanctum')->get('/valabilitati/localitati', ValabilitateLocalitatiController::class)
+    ->name('api.valabilitati.localitati');

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,7 @@ use App\Http\Controllers\Tech\ImpersonationController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\CronJobLogController;
 use App\Http\Controllers\SoferDashboardController;
+use App\Http\Controllers\SoferValabilitateController;
 use App\Http\Controllers\ValabilitateController;
 use App\Http\Controllers\ValabilitateCursaController;
 
@@ -91,6 +92,8 @@ Route::redirect('/', '/acasa');
 Route::middleware(['auth'])->group(function () {
     Route::middleware('role:sofer')->group(function () {
         Route::get('sofer/dashboard', SoferDashboardController::class)->name('sofer.dashboard');
+        Route::get('sofer/valabilitati/{valabilitate}', [SoferValabilitateController::class, 'show'])
+            ->name('sofer.valabilitati.show');
     });
 
     Route::middleware('permission:dashboard')->group(function () {


### PR DESCRIPTION
## Summary
- add a dedicated sofer valabilitate screen with inline trip cards and mobile friendly styling, wired to a new controller and route
- extend valabilitate trip data with descarcare_tara, ora, and ultima_cursa, enforcing the rules in validation, persistence, and admin views via a new migration and updated forms
- expose a localitate autocomplete API backed by historical trips and centralize country labels for the new UI interactions

## Testing
- php -l app/Http/Controllers/ValabilitateCursaController.php
- php -l app/Http/Requests/ValabilitateCursaRequest.php
- php -l app/Http/Controllers/Api/ValabilitateLocalitatiController.php
- php -l app/Http/Controllers/SoferValabilitateController.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691304bb75488326b17735562459c463)