### PR TITLE
Add valabilitati curse reporting dashboard

### DIFF
--- a/app/Http/Controllers/Admin/ValabilitatiReportController.php
+++ b/app/Http/Controllers/Admin/ValabilitatiReportController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Valabilitati\ValabilitatiReportService;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ValabilitatiReportController extends Controller
+{
+    public function index(Request $request, ValabilitatiReportService $service)
+    {
+        $filters = $this->resolveFilters($request);
+        $options = $service->filterOptions();
+        $report = $service->buildReport($filters);
+
+        return view('admin.valabilitati.report', [
+            'filters' => $filters,
+            'options' => $options,
+            'report' => $report,
+        ]);
+    }
+
+    public function export(Request $request, ValabilitatiReportService $service, string $format): StreamedResponse
+    {
+        $filters = $this->resolveFilters($request);
+
+        return $service->export($filters, $format);
+    }
+
+    /**
+     * @return array{driver: string|null, vehicle: string|null, date_from: string|null, date_to: string|null}
+     */
+    private function resolveFilters(Request $request): array
+    {
+        $driver = $request->input('driver');
+        if (is_string($driver)) {
+            $driver = trim($driver);
+        }
+
+        $vehicle = $request->input('vehicle');
+        if (is_string($vehicle)) {
+            $vehicle = trim($vehicle);
+        }
+
+        $dateFrom = $this->sanitizeDate($request->input('date_from'));
+        $dateTo = $this->sanitizeDate($request->input('date_to'));
+
+        if ($dateFrom === null && $dateTo === null) {
+            $today = CarbonImmutable::now();
+            $dateTo = $today->format('Y-m-d');
+            $dateFrom = $today->subDays(30)->format('Y-m-d');
+        }
+
+        if ($dateFrom !== null && $dateTo !== null && $dateFrom > $dateTo) {
+            [$dateFrom, $dateTo] = [$dateTo, $dateFrom];
+        }
+
+        return [
+            'driver' => $driver !== '' ? $driver : null,
+            'vehicle' => $vehicle !== '' ? $vehicle : null,
+            'date_from' => $dateFrom,
+            'date_to' => $dateTo,
+        ];
+    }
+
+    private function sanitizeDate(?string $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::createFromFormat('Y-m-d', $value)->format('Y-m-d');
+        } catch (\Throwable $exception) {
+            return null;
+        }
+    }
+}

--- a/app/Services/Valabilitati/ValabilitatiReportService.php
+++ b/app/Services/Valabilitati/ValabilitatiReportService.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace App\Services\Valabilitati;
+
+use App\Models\Masini\Masina;
+use App\Models\ValabilitateCursa;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Csv as CsvWriter;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ValabilitatiReportService
+{
+    /**
+     * @return array{drivers: array<int, string>, vehicles: array<int|string, string>}
+     */
+    public function filterOptions(): array
+    {
+        $drivers = Masina::query()
+            ->selectRaw('DISTINCT TRIM(descriere) AS driver')
+            ->whereNotNull('descriere')
+            ->whereRaw("TRIM(descriere) <> ''")
+            ->orderBy('driver')
+            ->pluck('driver')
+            ->all();
+
+        $vehicles = Masina::query()
+            ->orderBy('numar_inmatriculare')
+            ->pluck('numar_inmatriculare', 'id')
+            ->map(fn (string $value) => trim($value))
+            ->all();
+
+        return [
+            'drivers' => $drivers,
+            'vehicles' => $vehicles,
+        ];
+    }
+
+    /**
+     * @param  array{driver?: string|null, vehicle?: string|null, date_from?: string|null, date_to?: string|null}  $filters
+     * @return array{
+     *     summary: array<string, mixed>,
+     *     drivers: Collection<int, array<string, mixed>>,
+     *     vehicles: Collection<int, array<string, mixed>>,
+     *     dates: Collection<int, array<string, mixed>>,
+     *     charts: array<string, array<string, array<int, string>|array<int, int>>>
+     * }
+     */
+    public function buildReport(array $filters): array
+    {
+        $baseQuery = $this->applyFilters($filters);
+
+        $totalTrips = (clone $baseQuery)->count();
+
+        $uniqueDriverCount = (clone $baseQuery)
+            ->selectRaw("COUNT(DISTINCT COALESCE(NULLIF(TRIM(m.descriere), ''), '__missing')) AS aggregate")
+            ->value('aggregate') ?? 0;
+
+        $uniqueVehicleCount = (clone $baseQuery)
+            ->selectRaw('COUNT(DISTINCT m.id) AS aggregate')
+            ->value('aggregate') ?? 0;
+
+        $drivers = $this->driversBreakdown(clone $baseQuery);
+        $vehicles = $this->vehiclesBreakdown(clone $baseQuery);
+        $dates = $this->datesBreakdown(clone $baseQuery);
+
+        return [
+            'summary' => [
+                'total_trips' => (int) $totalTrips,
+                'unique_drivers' => (int) $uniqueDriverCount,
+                'unique_vehicles' => (int) $uniqueVehicleCount,
+                'date_from' => $filters['date_from'] ?? null,
+                'date_to' => $filters['date_to'] ?? null,
+            ],
+            'drivers' => $drivers,
+            'vehicles' => $vehicles,
+            'dates' => $dates,
+            'charts' => [
+                'drivers' => [
+                    'labels' => $drivers->pluck('driver_name')->all(),
+                    'data' => $drivers->pluck('trip_count')->all(),
+                ],
+                'vehicles' => [
+                    'labels' => $vehicles->pluck('vehicle_label')->all(),
+                    'data' => $vehicles->pluck('trip_count')->all(),
+                ],
+                'dates' => [
+                    'labels' => $dates->pluck('trip_date')->all(),
+                    'data' => $dates->pluck('trip_count')->all(),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array{driver?: string|null, vehicle?: string|null, date_from?: string|null, date_to?: string|null}  $filters
+     */
+    public function export(array $filters, string $format = 'csv'): StreamedResponse
+    {
+        $format = strtolower($format);
+
+        if (! in_array($format, ['csv', 'xlsx'], true)) {
+            $format = 'csv';
+        }
+
+        $rows = $this->detailedRows($filters);
+
+        $headers = [
+            'ID',
+            'Referință',
+            'Șofer',
+            'Mașină',
+            'Plecare la',
+            'Sosire la',
+            'Ora (locală)',
+            'Localitate plecare',
+            'Localitate sosire',
+            'Țara descărcare',
+            'Km bord',
+            'Ultima cursă',
+            'Observații',
+        ];
+
+        $spreadsheet = new Spreadsheet();
+        $worksheet = $spreadsheet->getActiveSheet();
+        $worksheet->fromArray($headers, null, 'A1');
+
+        $worksheet->fromArray($rows->map(fn (array $row) => array_values($row))->all(), null, 'A2', true);
+
+        $timestamp = CarbonImmutable::now()->format('Ymd_His');
+
+        if ($format === 'xlsx') {
+            $writer = new XlsxWriter($spreadsheet);
+            $filename = "valabilitati_curse_{$timestamp}.xlsx";
+            $contentType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+        } else {
+            $writer = new CsvWriter($spreadsheet);
+            $writer->setDelimiter(';');
+            $writer->setEnclosure('"');
+            $writer->setSheetIndex(0);
+            $filename = "valabilitati_curse_{$timestamp}.csv";
+            $contentType = 'text/csv';
+        }
+
+        return response()->streamDownload(static function () use ($writer): void {
+            $writer->save('php://output');
+        }, $filename, [
+            'Content-Type' => $contentType,
+        ]);
+    }
+
+    /**
+     * @param  array{driver?: string|null, vehicle?: string|null, date_from?: string|null, date_to?: string|null}  $filters
+     */
+    private function applyFilters(array $filters): Builder
+    {
+        $query = ValabilitateCursa::query()
+            ->from('valabilitati_curse as vc')
+            ->join('valabilitati as v', 'v.id', '=', 'vc.valabilitate_id')
+            ->leftJoin('masini as m', 'm.id', '=', 'v.masina_id');
+
+        $driverFilter = $filters['driver'] ?? null;
+        if ($driverFilter === '__missing') {
+            $query->where(function (Builder $subQuery): void {
+                $subQuery->whereNull('m.descriere')->orWhereRaw("TRIM(m.descriere) = ''");
+            });
+        } elseif (is_string($driverFilter) && $driverFilter !== '') {
+            $query->whereRaw('TRIM(m.descriere) = ?', [$driverFilter]);
+        }
+
+        $vehicleFilter = $filters['vehicle'] ?? null;
+        if ($vehicleFilter === '__missing') {
+            $query->whereNull('m.id');
+        } elseif (is_string($vehicleFilter) && $vehicleFilter !== '') {
+            $query->where('m.id', (int) $vehicleFilter);
+        }
+
+        if (! empty($filters['date_from'])) {
+            $query->whereDate('vc.plecare_la', '>=', $filters['date_from']);
+        }
+
+        if (! empty($filters['date_to'])) {
+            $query->whereDate('vc.plecare_la', '<=', $filters['date_to']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function driversBreakdown(Builder $query): Collection
+    {
+        return $query
+            ->selectRaw("COALESCE(NULLIF(TRIM(m.descriere), ''), 'Fără șofer asociat') AS driver_name")
+            ->selectRaw('COUNT(*) AS trip_count')
+            ->selectRaw('COUNT(DISTINCT m.id) AS vehicle_count')
+            ->selectRaw('MIN(vc.plecare_la) AS first_trip_at')
+            ->selectRaw('MAX(vc.plecare_la) AS last_trip_at')
+            ->groupBy('driver_name')
+            ->orderByDesc('trip_count')
+            ->get()
+            ->map(fn ($row): array => [
+                'driver_name' => (string) $row->driver_name,
+                'trip_count' => (int) $row->trip_count,
+                'vehicle_count' => (int) $row->vehicle_count,
+                'first_trip_at' => $this->formatDateTime($row->first_trip_at ?? null),
+                'last_trip_at' => $this->formatDateTime($row->last_trip_at ?? null),
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function vehiclesBreakdown(Builder $query): Collection
+    {
+        return $query
+            ->selectRaw("COALESCE(NULLIF(TRIM(m.numar_inmatriculare), ''), 'Fără mașină asociată') AS vehicle_label")
+            ->selectRaw("COALESCE(NULLIF(TRIM(m.descriere), ''), 'Fără șofer asociat') AS driver_placeholder")
+            ->selectRaw('COUNT(*) AS trip_count')
+            ->selectRaw("COUNT(DISTINCT COALESCE(NULLIF(TRIM(m.descriere), ''), '__missing')) AS driver_count")
+            ->selectRaw('MIN(vc.plecare_la) AS first_trip_at')
+            ->selectRaw('MAX(vc.plecare_la) AS last_trip_at')
+            ->groupBy('vehicle_label')
+            ->orderByDesc('trip_count')
+            ->get()
+            ->map(fn ($row): array => [
+                'vehicle_label' => (string) $row->vehicle_label,
+                'trip_count' => (int) $row->trip_count,
+                'driver_count' => (int) $row->driver_count,
+                'first_trip_at' => $this->formatDateTime($row->first_trip_at ?? null),
+                'last_trip_at' => $this->formatDateTime($row->last_trip_at ?? null),
+            ]);
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function datesBreakdown(Builder $query): Collection
+    {
+        return $query
+            ->selectRaw("COALESCE(DATE(vc.plecare_la), 'Fără dată') AS trip_date")
+            ->selectRaw('COUNT(*) AS trip_count')
+            ->selectRaw("COUNT(DISTINCT COALESCE(NULLIF(TRIM(m.descriere), ''), '__missing')) AS driver_count")
+            ->selectRaw('COUNT(DISTINCT m.id) AS vehicle_count')
+            ->groupBy('trip_date')
+            ->orderBy('trip_date')
+            ->get()
+            ->map(fn ($row): array => [
+                'trip_date' => (string) $row->trip_date,
+                'trip_count' => (int) $row->trip_count,
+                'driver_count' => (int) $row->driver_count,
+                'vehicle_count' => (int) $row->vehicle_count,
+            ]);
+    }
+
+    /**
+     * @param  array{driver?: string|null, vehicle?: string|null, date_from?: string|null, date_to?: string|null}  $filters
+     * @return Collection<int, array<string, string|int|null>>
+     */
+    private function detailedRows(array $filters): Collection
+    {
+        $query = $this->applyFilters($filters)
+            ->select([
+                'vc.id',
+                'v.referinta as reference',
+                'vc.localitate_plecare',
+                'vc.localitate_sosire',
+                'vc.descarcare_tara',
+                'vc.plecare_la',
+                'vc.sosire_la',
+                'vc.ora',
+                'vc.km_bord',
+                'vc.observatii',
+                'vc.ultima_cursa',
+                'm.numar_inmatriculare',
+                'm.descriere as driver_name',
+            ])
+            ->orderBy('vc.plecare_la')
+            ->orderBy('vc.created_at');
+
+        return $query->get()->map(function ($row): array {
+            $driverName = trim((string) ($row->driver_name ?? ''));
+            $vehicleLabel = trim((string) ($row->numar_inmatriculare ?? ''));
+
+            return [
+                'id' => (int) $row->id,
+                'reference' => $row->reference ?? '',
+                'driver' => $driverName !== '' ? $driverName : 'Fără șofer asociat',
+                'vehicle' => $vehicleLabel !== '' ? $vehicleLabel : 'Fără mașină asociată',
+                'plecare_la' => $this->formatDateTime($row->plecare_la ?? null),
+                'sosire_la' => $this->formatDateTime($row->sosire_la ?? null),
+                'ora' => $this->formatTime($row->ora ?? null),
+                'localitate_plecare' => $row->localitate_plecare ?? '',
+                'localitate_sosire' => $row->localitate_sosire ?? '',
+                'descarcare_tara' => $row->descarcare_tara ?? '',
+                'km_bord' => $row->km_bord !== null ? (int) $row->km_bord : null,
+                'ultima_cursa' => $row->ultima_cursa ? 'Da' : 'Nu',
+                'observatii' => $row->observatii ?? '',
+            ];
+        });
+    }
+
+    private function formatDateTime(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value)->format('d.m.Y H:i');
+        } catch (\Throwable $exception) {
+            return null;
+        }
+    }
+
+    private function formatTime(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return substr((string) $value, 0, 5);
+    }
+}

--- a/app/Support/Navigation/MainNavigation.php
+++ b/app/Support/Navigation/MainNavigation.php
@@ -128,6 +128,13 @@ class MainNavigation
         return [
             [
                 'permission' => 'rapoarte',
+                'href' => route('rapoarte.valabilitati'),
+                'icon' => 'fa-solid fa-route',
+                'label' => 'Curse valabilități',
+            ],
+            ['type' => 'divider'],
+            [
+                'permission' => 'rapoarte',
                 'href' => '/rapoarte/documente-transportatori',
                 'icon' => 'fa-solid fa-file',
                 'label' => 'Documente transportatori',

--- a/resources/views/admin/valabilitati/report.blade.php
+++ b/resources/views/admin/valabilitati/report.blade.php
@@ -1,0 +1,313 @@
+@extends('layouts.app')
+
+@php
+    $exportQuery = collect($filters)
+        ->reject(fn ($value) => $value === null || $value === '')
+        ->all();
+@endphp
+
+@section('content')
+<div class="container py-4">
+    <div class="card shadow-sm mb-4">
+        <div class="card-header d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3">
+            <div>
+                <span class="badge bg-primary text-uppercase mb-2 mb-lg-1">
+                    <i class="fa-solid fa-chart-simple me-1"></i>
+                    Raport curse valabilități
+                </span>
+                <h1 class="h5 mb-0">Analiză pe șoferi, mașini și date calendaristice</h1>
+            </div>
+            <div class="btn-group" role="group" aria-label="Export">
+                <a class="btn btn-outline-secondary btn-sm" href="{{ route('rapoarte.valabilitati.export', array_merge(['format' => 'csv'], $exportQuery)) }}">
+                    <i class="fa-solid fa-file-csv me-1"></i>
+                    Export CSV
+                </a>
+                <a class="btn btn-outline-secondary btn-sm" href="{{ route('rapoarte.valabilitati.export', array_merge(['format' => 'xlsx'], $exportQuery)) }}">
+                    <i class="fa-solid fa-file-excel me-1"></i>
+                    Export Excel
+                </a>
+            </div>
+        </div>
+        <div class="card-body">
+            <form method="GET" class="row g-3 align-items-end">
+                <div class="col-md-4">
+                    <label for="driver" class="form-label">Șofer</label>
+                    <select id="driver" name="driver" class="form-select">
+                        <option value="">Toți șoferii</option>
+                        <option value="__missing" @selected(($filters['driver'] ?? null) === '__missing')>Fără șofer asociat</option>
+                        @foreach ($options['drivers'] as $driverOption)
+                            <option value="{{ $driverOption }}" @selected(($filters['driver'] ?? null) === $driverOption)>
+                                {{ $driverOption }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label for="vehicle" class="form-label">Mașină</label>
+                    <select id="vehicle" name="vehicle" class="form-select">
+                        <option value="">Toate mașinile</option>
+                        <option value="__missing" @selected(($filters['vehicle'] ?? null) === '__missing')>Fără mașină asociată</option>
+                        @foreach ($options['vehicles'] as $vehicleId => $vehicleLabel)
+                            <option value="{{ $vehicleId }}" @selected(($filters['vehicle'] ?? null) === (string) $vehicleId)>
+                                {{ $vehicleLabel }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <label for="date_from" class="form-label">De la</label>
+                    <input type="date" id="date_from" name="date_from" class="form-control" value="{{ $filters['date_from'] ?? '' }}">
+                </div>
+                <div class="col-md-2">
+                    <label for="date_to" class="form-label">Până la</label>
+                    <input type="date" id="date_to" name="date_to" class="form-control" value="{{ $filters['date_to'] ?? '' }}">
+                </div>
+                <div class="col-12 d-flex justify-content-end gap-2">
+                    <a href="{{ route('rapoarte.valabilitati') }}" class="btn btn-outline-secondary">
+                        Resetare
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa-solid fa-filter me-1"></i>
+                        Aplică filtrele
+                    </button>
+                </div>
+            </form>
+
+            <div class="row g-3 mt-4">
+                <div class="col-md-3">
+                    <div class="border rounded p-3 h-100 text-center">
+                        <p class="text-muted mb-1">Total curse</p>
+                        <p class="fs-3 fw-semibold mb-0">{{ number_format($report['summary']['total_trips']) }}</p>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="border rounded p-3 h-100 text-center">
+                        <p class="text-muted mb-1">Șoferi unici</p>
+                        <p class="fs-3 fw-semibold mb-0">{{ number_format($report['summary']['unique_drivers']) }}</p>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="border rounded p-3 h-100 text-center">
+                        <p class="text-muted mb-1">Mașini unice</p>
+                        <p class="fs-3 fw-semibold mb-0">{{ number_format($report['summary']['unique_vehicles']) }}</p>
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <div class="border rounded p-3 h-100 text-center">
+                        <p class="text-muted mb-1">Interval analizat</p>
+                        <p class="fs-6 fw-semibold mb-0">
+                            {{ $report['summary']['date_from'] ? \Carbon\CarbonImmutable::parse($report['summary']['date_from'])->format('d.m.Y') : '—' }}
+                            –
+                            {{ $report['summary']['date_to'] ? \Carbon\CarbonImmutable::parse($report['summary']['date_to'])->format('d.m.Y') : '—' }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h2 class="h6 mb-0">Distribuție curse pe șoferi</h2>
+        </div>
+        <div class="card-body">
+            <div class="mb-4">
+                <canvas id="driversChart" height="200"></canvas>
+            </div>
+            @if ($report['drivers']->isEmpty())
+                <p class="text-muted mb-0">Nu există curse pentru criteriile selectate.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>Șofer</th>
+                                <th class="text-center">Total curse</th>
+                                <th class="text-center">Mașini distincte</th>
+                                <th>Prima cursă</th>
+                                <th>Ultima cursă</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($report['drivers'] as $driver)
+                                <tr>
+                                    <td>{{ $driver['driver_name'] }}</td>
+                                    <td class="text-center">{{ number_format($driver['trip_count']) }}</td>
+                                    <td class="text-center">{{ number_format($driver['vehicle_count']) }}</td>
+                                    <td>{{ $driver['first_trip_at'] ?? '—' }}</td>
+                                    <td>{{ $driver['last_trip_at'] ?? '—' }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header">
+            <h2 class="h6 mb-0">Distribuție curse pe mașini</h2>
+        </div>
+        <div class="card-body">
+            <div class="mb-4">
+                <canvas id="vehiclesChart" height="200"></canvas>
+            </div>
+            @if ($report['vehicles']->isEmpty())
+                <p class="text-muted mb-0">Nu există curse pentru criteriile selectate.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>Mașină</th>
+                                <th class="text-center">Total curse</th>
+                                <th class="text-center">Șoferi distinct</th>
+                                <th>Prima cursă</th>
+                                <th>Ultima cursă</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($report['vehicles'] as $vehicle)
+                                <tr>
+                                    <td>{{ $vehicle['vehicle_label'] }}</td>
+                                    <td class="text-center">{{ number_format($vehicle['trip_count']) }}</td>
+                                    <td class="text-center">{{ number_format($vehicle['driver_count']) }}</td>
+                                    <td>{{ $vehicle['first_trip_at'] ?? '—' }}</td>
+                                    <td>{{ $vehicle['last_trip_at'] ?? '—' }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-header">
+            <h2 class="h6 mb-0">Distribuție curse pe zile</h2>
+        </div>
+        <div class="card-body">
+            <div class="mb-4">
+                <canvas id="datesChart" height="200"></canvas>
+            </div>
+            @if ($report['dates']->isEmpty())
+                <p class="text-muted mb-0">Nu există curse pentru criteriile selectate.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>Dată</th>
+                                <th class="text-center">Total curse</th>
+                                <th class="text-center">Șoferi distinct</th>
+                                <th class="text-center">Mașini distincte</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($report['dates'] as $date)
+                                <tr>
+                                    <td>{{ $date['trip_date'] }}</td>
+                                    <td class="text-center">{{ number_format($date['trip_count']) }}</td>
+                                    <td class="text-center">{{ number_format($date['driver_count']) }}</td>
+                                    <td class="text-center">{{ number_format($date['vehicle_count']) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('page-scripts')
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const charts = @json($report['charts']);
+
+            const createBarChart = (canvasId, labels, data, label, color) => {
+                const canvas = document.getElementById(canvasId);
+
+                if (!canvas || !Array.isArray(labels) || labels.length === 0) {
+                    return;
+                }
+
+                const ctx = canvas.getContext('2d');
+
+                return new window.Chart(ctx, {
+                    type: 'bar',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                label,
+                                data,
+                                backgroundColor: color,
+                                borderColor: color,
+                                borderWidth: 1,
+                            },
+                        ],
+                    },
+                    options: {
+                        maintainAspectRatio: false,
+                        scales: {
+                            y: {
+                                beginAtZero: true,
+                                ticks: {
+                                    precision: 0,
+                                },
+                            },
+                        },
+                    },
+                });
+            };
+
+            const createLineChart = (canvasId, labels, data, label, color) => {
+                const canvas = document.getElementById(canvasId);
+
+                if (!canvas || !Array.isArray(labels) || labels.length === 0) {
+                    return;
+                }
+
+                const ctx = canvas.getContext('2d');
+
+                return new window.Chart(ctx, {
+                    type: 'line',
+                    data: {
+                        labels,
+                        datasets: [
+                            {
+                                label,
+                                data,
+                                borderColor: color,
+                                backgroundColor: color,
+                                fill: false,
+                                tension: 0.3,
+                                pointRadius: 3,
+                            },
+                        ],
+                    },
+                    options: {
+                        maintainAspectRatio: false,
+                        scales: {
+                            y: {
+                                beginAtZero: true,
+                                ticks: {
+                                    precision: 0,
+                                },
+                            },
+                        },
+                    },
+                });
+            };
+
+            createBarChart('driversChart', charts.drivers.labels, charts.drivers.data, 'Curse', 'rgba(54, 162, 235, 0.6)');
+            createBarChart('vehiclesChart', charts.vehicles.labels, charts.vehicles.data, 'Curse', 'rgba(75, 192, 192, 0.6)');
+            createLineChart('datesChart', charts.dates.labels, charts.dates.data, 'Curse pe zi', 'rgba(255, 99, 132, 0.7)');
+        });
+    </script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\FacturaController;
 use App\Http\Controllers\FacturaScadentaController;
 use App\Http\Controllers\UserController;
 use App\Http\Controllers\RaportController;
+use App\Http\Controllers\Admin\ValabilitatiReportController;
 use App\Http\Controllers\DiverseTesteController;
 use App\Http\Controllers\ComandaFisierInternController;
 use App\Http\Controllers\ComandaIncarcareDocumenteDeCatreTransportatorController;
@@ -347,6 +348,11 @@ Route::middleware(['auth'])->group(function () {
     });
 
     Route::middleware('permission:rapoarte')->group(function () {
+        Route::get('/rapoarte/valabilitati-curse', [ValabilitatiReportController::class, 'index'])
+            ->name('rapoarte.valabilitati');
+        Route::get('/rapoarte/valabilitati-curse/export/{format}', [ValabilitatiReportController::class, 'export'])
+            ->whereIn('format', ['csv', 'xlsx'])
+            ->name('rapoarte.valabilitati.export');
         Route::get('/rapoarte/incasari-utilizatori', [RaportController::class, 'incasariUtilizatori']);
         Route::get('/rapoarte/documente-transportatori', [RaportController::class, 'documenteTransportatori']);
 


### PR DESCRIPTION
## Summary
- add an admin controller and reporting service for valabilitati_curse with filtering and export helpers
- create the admin valabilitati report page with filter UI, summary metrics, charts, and grouped tables
- register new routes and navigation entry so the report is accessible from the rapoarte menu

## Testing
- php -l app/Http/Controllers/Admin/ValabilitatiReportController.php
- php -l app/Services/Valabilitati/ValabilitatiReportService.php
- php artisan test *(fails: vendor dependencies are not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913090cc2908326a1a3de68ed87d332)