### PR TITLE
Fix duplicate seeder controller action and adjust seeder page header

### DIFF
--- a/app/Http/Controllers/Tech/MigrationCenterController.php
+++ b/app/Http/Controllers/Tech/MigrationCenterController.php
@@ -40,19 +40,6 @@ class MigrationCenterController extends Controller
         ]);
     }
 
-    public function seeders(Request $request, MigrationCenterService $service): View
-    {
-        $availableSeeders = $service->availableSeeders();
-
-        return view('tech.seeders.index', [
-            'seeders' => $availableSeeders,
-            'seederOutput' => $request->session()->get('seeder_output'),
-            'seederStatus' => $request->session()->get('seeder_status'),
-            'seederStatusLevel' => $request->session()->get('seeder_status_level', 'info'),
-            'lastRunSeeder' => $request->session()->get('seeder_last_run'),
-        ]);
-    }
-
     public function showSeeders(Request $request, MigrationCenterService $service): View
     {
         $availableSeeders = $service->availableSeeders();

--- a/resources/views/tech/seeders/index.blade.php
+++ b/resources/views/tech/seeders/index.blade.php
@@ -7,9 +7,6 @@
                 <h1 class="h3 mb-1">Seeder Control Center</h1>
                 <p class="text-muted mb-0">Review each seeder's responsibilities, impacted tables, and safety notes before executing it.</p>
             </div>
-            <a href="{{ route('tech.migrations.index') }}" class="btn btn-outline-secondary">
-                <i class="fa-solid fa-arrow-left me-1"></i>Back to migrations dashboard
-            </a>
         </div>
 
         @if ($seederStatus)


### PR DESCRIPTION
## Summary
- remove the duplicate seeders action definition from `MigrationCenterController`
- drop the obsolete "Back to migrations dashboard" button from the Seeder Control Center page header

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69130f6ee6188326a8d56089b123f688)