### PR TITLE
Add valabilitati index view and controller

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use App\Models\Valabilitate;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class ValabilitateController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): View
+    {
+        $filters = [
+            'status' => $request->input('status', 'toate'),
+            'denumire' => trim((string) $request->input('denumire', '')),
+            'sofer' => trim((string) $request->input('sofer', '')),
+            'numar_auto' => trim((string) $request->input('numar_auto', '')),
+            'inceput_de_la' => $request->input('inceput_de_la', ''),
+            'inceput_pana_la' => $request->input('inceput_pana_la', ''),
+            'sfarsit_de_la' => $request->input('sfarsit_de_la', ''),
+            'sfarsit_pana_la' => $request->input('sfarsit_pana_la', ''),
+            'fara_sfarsit' => $request->boolean('fara_sfarsit'),
+        ];
+
+        $query = Valabilitate::query()->with('sofer');
+
+        if ($filters['denumire'] !== '') {
+            $query->where('denumire', 'like', '%' . $filters['denumire'] . '%');
+        }
+
+        if ($filters['sofer'] !== '') {
+            $query->whereHas('sofer', function ($query) use ($filters): void {
+                $query->where('name', 'like', '%' . $filters['sofer'] . '%');
+            });
+        }
+
+        if ($filters['numar_auto'] !== '') {
+            $query->where('numar_auto', 'like', '%' . $filters['numar_auto'] . '%');
+        }
+
+        if ($filters['inceput_de_la'] !== '') {
+            $query->whereDate('data_inceput', '>=', $filters['inceput_de_la']);
+        }
+
+        if ($filters['inceput_pana_la'] !== '') {
+            $query->whereDate('data_inceput', '<=', $filters['inceput_pana_la']);
+        }
+
+        if ($filters['sfarsit_de_la'] !== '') {
+            $query->whereDate('data_sfarsit', '>=', $filters['sfarsit_de_la']);
+        }
+
+        if ($filters['sfarsit_pana_la'] !== '') {
+            $query->whereDate('data_sfarsit', '<=', $filters['sfarsit_pana_la']);
+        }
+
+        if ($filters['fara_sfarsit']) {
+            $query->whereNull('data_sfarsit');
+        }
+
+        $today = now()->startOfDay();
+        $statusFilter = $filters['status'];
+
+        if ($statusFilter === 'active') {
+            $query->where(function ($subQuery) use ($today): void {
+                $subQuery
+                    ->whereNull('data_sfarsit')
+                    ->orWhereDate('data_sfarsit', '>=', $today);
+            });
+        } elseif ($statusFilter === 'expirate') {
+            $query->whereNotNull('data_sfarsit')->whereDate('data_sfarsit', '<', $today);
+        }
+
+        $valabilitati = $query
+            ->orderByDesc('data_inceput')
+            ->orderBy('denumire')
+            ->paginate(20)
+            ->withQueryString();
+
+        $statusCounts = [
+            'active' => Valabilitate::query()
+                ->where(function ($subQuery) use ($today): void {
+                    $subQuery
+                        ->whereNull('data_sfarsit')
+                        ->orWhereDate('data_sfarsit', '>=', $today);
+                })
+                ->count(),
+            'expirate' => Valabilitate::query()
+                ->whereNotNull('data_sfarsit')
+                ->whereDate('data_sfarsit', '<', $today)
+                ->count(),
+        ];
+
+        $denumiri = Valabilitate::query()
+            ->select('denumire')
+            ->distinct()
+            ->orderBy('denumire')
+            ->pluck('denumire');
+
+        $numereAuto = Valabilitate::query()
+            ->select('numar_auto')
+            ->distinct()
+            ->orderBy('numar_auto')
+            ->pluck('numar_auto');
+
+        $soferi = User::query()
+            ->select('name')
+            ->whereHas('valabilitati')
+            ->orderBy('name')
+            ->pluck('name');
+
+        return view('valabilitati.index', [
+            'valabilitati' => $valabilitati,
+            'filters' => $filters,
+            'statusCounts' => $statusCounts,
+            'denumiri' => $denumiri,
+            'numereAuto' => $numereAuto,
+            'soferi' => $soferi,
+        ]);
+    }
+}

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -1,0 +1,190 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-1 mb-2">
+            <span class="badge culoare1 fs-5">
+                <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
+                    <span><i class="fa-solid fa-calendar-check me-1"></i>Valabilități</span>
+                    <span class="ms-4">flotă</span>
+                </span>
+            </span>
+        </div>
+        <div class="col-lg-8 mb-0" id="formularValabilitati">
+            <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ url()->current() }}">
+                <div class="row gy-1 gx-4 mb-2 custom-search-form d-flex justify-content-center align-items-end">
+                    <div class="col-lg-2 col-md-6">
+                        <select name="status" id="filter-status" class="form-select bg-white rounded-3">
+                            <option value="toate" @selected($filters['status'] === 'toate')>Toate</option>
+                            <option value="active" @selected($filters['status'] === 'active')>Active ({{ $statusCounts['active'] ?? 0 }})</option>
+                            <option value="expirate" @selected($filters['status'] === 'expirate')>Expirate ({{ $statusCounts['expirate'] ?? 0 }})</option>
+                        </select>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-book text-muted" title="Caută după denumire"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-denumire"
+                                name="denumire"
+                                placeholder="Denumire valabilitate"
+                                value="{{ $filters['denumire'] }}"
+                                list="filter-denumire-suggestions"
+                                autocomplete="off"
+                            >
+                        </div>
+                        <datalist id="filter-denumire-suggestions">
+                            @foreach ($denumiri as $denumire)
+                                <option value="{{ $denumire }}"></option>
+                            @endforeach
+                        </datalist>
+                    </div>
+                    <div class="col-lg-3 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-user text-muted" title="Caută după șofer"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-sofer"
+                                name="sofer"
+                                placeholder="Șofer"
+                                value="{{ $filters['sofer'] }}"
+                                list="filter-sofer-suggestions"
+                                autocomplete="off"
+                            >
+                        </div>
+                        <datalist id="filter-sofer-suggestions">
+                            @foreach ($soferi as $sofer)
+                                <option value="{{ $sofer }}"></option>
+                            @endforeach
+                        </datalist>
+                    </div>
+                    <div class="col-lg-2 col-md-6">
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="fa-solid fa-truck text-muted" title="Caută după număr auto"></i>
+                            <input
+                                type="text"
+                                class="form-control rounded-3 flex-grow-1"
+                                id="filter-numar-auto"
+                                name="numar_auto"
+                                placeholder="Număr auto"
+                                value="{{ $filters['numar_auto'] }}"
+                                list="filter-numar-auto-suggestions"
+                                autocomplete="off"
+                            >
+                        </div>
+                        <datalist id="filter-numar-auto-suggestions">
+                            @foreach ($numereAuto as $numarAuto)
+                                <option value="{{ $numarAuto }}"></option>
+                            @endforeach
+                        </datalist>
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
+                        <label for="filter-inceput-de-la" class="form-label ps-2 small text-muted mb-0">Început de la</label>
+                        <input type="date" class="form-control rounded-3" id="filter-inceput-de-la" name="inceput_de_la" value="{{ $filters['inceput_de_la'] }}">
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
+                        <label for="filter-inceput-pana" class="form-label ps-2 small text-muted mb-0">Început până la</label>
+                        <input type="date" class="form-control rounded-3" id="filter-inceput-pana" name="inceput_pana_la" value="{{ $filters['inceput_pana_la'] }}">
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
+                        <label for="filter-sfarsit-de-la" class="form-label ps-2 small text-muted mb-0">Sfârșit de la</label>
+                        <input type="date" class="form-control rounded-3" id="filter-sfarsit-de-la" name="sfarsit_de_la" value="{{ $filters['sfarsit_de_la'] }}">
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
+                        <label for="filter-sfarsit-pana" class="form-label ps-2 small text-muted mb-0">Sfârșit până la</label>
+                        <input type="date" class="form-control rounded-3" id="filter-sfarsit-pana" name="sfarsit_pana_la" value="{{ $filters['sfarsit_pana_la'] }}">
+                    </div>
+                    <div class="col-12 col-sm-6 col-lg-2">
+                        <div class="form-check ps-0 ms-1">
+                            <input class="form-check-input ms-2" type="checkbox" value="1" id="filter-fara-sfarsit" name="fara_sfarsit" @checked($filters['fara_sfarsit'])>
+                            <label class="form-check-label ms-4" for="filter-fara-sfarsit">
+                                Doar fără sfârșit
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <div class="row custom-search-form justify-content-center">
+                    <button class="btn btn-sm btn-primary text-white col-md-4 me-3 border border-dark rounded-3" type="submit">
+                        <i class="fas fa-search text-white me-1"></i>Caută
+                    </button>
+                    <a class="btn btn-sm btn-secondary text-white col-md-4 border border-dark rounded-3" href="{{ route('valabilitati.index') }}" role="button">
+                        <i class="far fa-trash-alt text-white me-1"></i>Resetează
+                    </a>
+                </div>
+            </form>
+        </div>
+        <div class="col-lg-3 text-lg-end mt-3 mt-lg-0">
+            <div class="d-flex flex-column align-items-stretch align-items-lg-end gap-2">
+                @include('partials.operations-navigation')
+            </div>
+        </div>
+    </div>
+
+    <div class="card-body px-0 py-3">
+        @include('errors')
+
+        <div class="table-responsive rounded">
+            <table class="table table-sm table-striped table-hover rounded align-middle">
+                <thead class="text-white rounded culoare2">
+                    <tr>
+                        <th>Denumire</th>
+                        <th>Număr auto</th>
+                        <th>Șofer</th>
+                        <th>Început</th>
+                        <th>Sfârșit</th>
+                        <th>Status</th>
+                        <th class="text-end">Zile rămase</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @php($azi = now()->startOfDay())
+                    @forelse ($valabilitati as $valabilitate)
+                        @php
+                            $dataInceput = $valabilitate->data_inceput;
+                            $dataSfarsit = $valabilitate->data_sfarsit;
+                            $isActive = is_null($dataSfarsit) || $dataSfarsit->greaterThanOrEqualTo($azi);
+                            $statusLabel = $isActive ? 'Activă' : 'Expirată';
+                            $statusClass = $isActive ? 'bg-success' : 'bg-secondary';
+                            $zileRamase = is_null($dataSfarsit)
+                                ? null
+                                : $azi->diffInDays($dataSfarsit, false);
+                        @endphp
+                        <tr>
+                            <td class="fw-semibold">{{ $valabilitate->denumire }}</td>
+                            <td class="text-nowrap">{{ $valabilitate->numar_auto }}</td>
+                            <td>{{ $valabilitate->sofer->name ?? '—' }}</td>
+                            <td class="text-nowrap">{{ optional($dataInceput)->format('d.m.Y') ?? '—' }}</td>
+                            <td class="text-nowrap">{{ optional($dataSfarsit)->format('d.m.Y') ?? '—' }}</td>
+                            <td>
+                                <span class="badge {{ $statusClass }} text-white">{{ $statusLabel }}</span>
+                            </td>
+                            <td class="text-end">
+                                @if (is_null($zileRamase))
+                                    Nelimitat
+                                @elseif ($zileRamase >= 0)
+                                    {{ $zileRamase }} zile
+                                @else
+                                    Expirat de {{ abs($zileRamase) }} zile
+                                @endif
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="text-center py-4">Nu există valabilități care să respecte criteriile selectate.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        @if ($valabilitati instanceof \Illuminate\Contracts\Pagination\Paginator || $valabilitati instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator)
+            <div class="mt-3 px-3">
+                {{ $valabilitati->onEachSide(1)->links() }}
+            </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -328,7 +328,7 @@ Route::middleware(['auth'])->group(function () {
             ->parameters(['masini-valabilitati' => 'masinaValabilitati']);
     });
 
-    Route::middleware('permission:valabilitati')->group(function () {
+    Route::middleware(['permission:valabilitati', 'role:super-admin,admin'])->group(function () {
         Route::resource('valabilitati', ValabilitateController::class)
             ->parameters(['valabilitati' => 'valabilitate']);
 


### PR DESCRIPTION
## Summary
- add a dedicated `ValabilitateController@index` to handle filtering and pagination for the valabilități module
- introduce a valabilități index blade modeled on the existing supplier invoice layout while keeping the same card structure and styling
- tighten the valabilități routes by requiring both the permission and super-admin/admin roles

## Testing
- php artisan test *(fails: vendor dependencies missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69136d7649e48326aa261aa39221b6ea)