### PR TITLE
Add modal-based CRUD management for valabilitati

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -2,15 +2,19 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use App\Models\Valabilitate;
 use App\Support\Valabilitati\ValabilitatiFilterState;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class ValabilitateController extends Controller
 {
@@ -30,6 +34,7 @@ class ValabilitateController extends Controller
             'valabilitati' => $valabilitati,
             'filters' => $filters,
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitati),
+            'soferi' => $this->getSoferOptions(),
         ]);
     }
 
@@ -42,27 +47,68 @@ class ValabilitateController extends Controller
             'rows_html' => view('valabilitati.partials.rows', [
                 'valabilitati' => $valabilitati,
             ])->render(),
+            'modals_html' => view('valabilitati.partials.modals', [
+                'valabilitati' => $valabilitati,
+                'soferi' => $this->getSoferOptions(),
+                'includeCreate' => false,
+            ])->render(),
             'next_url' => $this->buildNextPageUrl($request, $valabilitati),
         ]);
     }
 
+    public function show(Valabilitate $valabilitate): View
+    {
+        $valabilitate->loadMissing(['sofer']);
+
+        return view('valabilitati.show', [
+            'valabilitate' => $valabilitate,
+            'backUrl' => ValabilitatiFilterState::route(),
+            'soferi' => $this->getSoferOptions(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse|JsonResponse
+    {
+        $validated = $this->validateValabilitate($request);
+
+        if ($validated instanceof RedirectResponse) {
+            return $validated;
+        }
+
+        Valabilitate::create($validated);
+
+        return $this->respondAfterMutation($request, 'Valabilitatea a fost adăugată.');
+    }
+
+    public function update(Request $request, Valabilitate $valabilitate): RedirectResponse|JsonResponse
+    {
+        $validated = $this->validateValabilitate($request, $valabilitate);
+
+        if ($validated instanceof RedirectResponse) {
+            return $validated;
+        }
+
+        $valabilitate->update($validated);
+
+        return $this->respondAfterMutation($request, 'Valabilitatea a fost actualizată.');
+    }
+
+    public function destroy(Request $request, Valabilitate $valabilitate): RedirectResponse|JsonResponse
+    {
+        $valabilitate->delete();
+
+        return $this->respondAfterMutation($request, 'Valabilitatea a fost ștearsă.');
+    }
+
     private function validateFilters(Request $request): array
     {
-        $validated = $request->validate([
-            'numar_auto' => ['nullable', 'string', 'max:255'],
-            'sofer' => ['nullable', 'string', 'max:255'],
-            'denumire' => ['nullable', 'string', 'max:255'],
-            'interval_start' => ['nullable', 'date'],
-            'interval_end' => ['nullable', 'date', 'after_or_equal:interval_start'],
-        ]);
-
-        return [
-            'numar_auto' => trim((string) ($validated['numar_auto'] ?? '')),
-            'sofer' => trim((string) ($validated['sofer'] ?? '')),
-            'denumire' => trim((string) ($validated['denumire'] ?? '')),
-            'interval_start' => $validated['interval_start'] ?? null,
-            'interval_end' => $validated['interval_end'] ?? null,
-        ];
+        return $this->parseFilters($request->only([
+            'numar_auto',
+            'sofer',
+            'denumire',
+            'interval_start',
+            'interval_end',
+        ]));
     }
 
     /**
@@ -113,13 +159,18 @@ class ValabilitateController extends Controller
     /**
      * @param array<string, mixed> $filters
      */
-    private function paginateValabilitati(Request $request, array $filters): LengthAwarePaginator
+    private function paginateValabilitati(Request $request, array $filters, ?array $query = null): LengthAwarePaginator
     {
-        return $this->buildFilteredQuery($filters)
+        $paginator = $this->buildFilteredQuery($filters)
             ->orderByDesc('data_inceput')
             ->orderBy('denumire')
-            ->paginate(self::PER_PAGE)
-            ->withQueryString();
+            ->paginate(self::PER_PAGE);
+
+        if ($query !== null) {
+            return $paginator->appends($query);
+        }
+
+        return $paginator->withQueryString();
     }
 
     private function buildNextPageUrl(Request $request, LengthAwarePaginator $paginator): ?string
@@ -132,5 +183,112 @@ class ValabilitateController extends Controller
         $nextPage = $paginator->currentPage() + 1;
 
         return route('valabilitati.paginate', array_merge($queryParameters, ['page' => $nextPage]));
+    }
+
+    /**
+     * @param array<string, mixed> $input
+     */
+    private function parseFilters(array $input): array
+    {
+        $validator = Validator::make($input, [
+            'numar_auto' => ['nullable', 'string', 'max:255'],
+            'sofer' => ['nullable', 'string', 'max:255'],
+            'denumire' => ['nullable', 'string', 'max:255'],
+            'interval_start' => ['nullable', 'date'],
+            'interval_end' => ['nullable', 'date', 'after_or_equal:interval_start'],
+        ]);
+
+        $validated = $validator->validate();
+
+        return [
+            'numar_auto' => trim((string) ($validated['numar_auto'] ?? '')),
+            'sofer' => trim((string) ($validated['sofer'] ?? '')),
+            'denumire' => trim((string) ($validated['denumire'] ?? '')),
+            'interval_start' => $validated['interval_start'] ?? null,
+            'interval_end' => $validated['interval_end'] ?? null,
+        ];
+    }
+
+    private function getSoferOptions(): array
+    {
+        return User::query()
+            ->where('activ', 1)
+            ->orderBy('name')
+            ->pluck('name', 'id')
+            ->toArray();
+    }
+
+    /**
+     * @return array<string, mixed>|RedirectResponse
+     */
+    private function validateValabilitate(Request $request, ?Valabilitate $valabilitate = null)
+    {
+        $validator = Validator::make($request->all(), [
+            'numar_auto' => ['required', 'string', 'max:255'],
+            'sofer_id' => ['required', 'integer', 'exists:users,id'],
+            'denumire' => ['required', 'string', 'max:255'],
+            'data_inceput' => ['required', 'date'],
+            'data_sfarsit' => ['nullable', 'date', 'after_or_equal:data_inceput'],
+        ], [], [
+            'numar_auto' => 'număr auto',
+            'sofer_id' => 'șofer',
+            'denumire' => 'denumire',
+            'data_inceput' => 'data de început',
+            'data_sfarsit' => 'data de sfârșit',
+        ]);
+
+        if ($validator->fails() && ! $request->expectsJson()) {
+            $modalKey = $valabilitate ? 'edit:' . $valabilitate->id : 'create';
+
+            return redirect(ValabilitatiFilterState::route())
+                ->withErrors($validator)
+                ->withInput()
+                ->with('valabilitati.modal', $modalKey);
+        }
+
+        try {
+            return $validator->validate();
+        } catch (ValidationException $exception) {
+            if ($request->expectsJson()) {
+                throw $exception;
+            }
+
+            $modalKey = $valabilitate ? 'edit:' . $valabilitate->id : 'create';
+
+            return redirect(ValabilitatiFilterState::route())
+                ->withErrors($exception->validator)
+                ->withInput()
+                ->with('valabilitati.modal', $modalKey);
+        }
+    }
+
+    private function respondAfterMutation(Request $request, string $message): RedirectResponse|JsonResponse
+    {
+        if ($request->expectsJson()) {
+            return $this->listingJsonResponse($message);
+        }
+
+        return redirect(ValabilitatiFilterState::route())->with('status', $message);
+    }
+
+    private function listingJsonResponse(string $message): JsonResponse
+    {
+        $query = ValabilitatiFilterState::get();
+        $filtersRequest = Request::create('', 'GET', $query);
+        $filters = $this->parseFilters($query);
+        $valabilitati = $this->paginateValabilitati($filtersRequest, $filters, $query);
+
+        return response()->json([
+            'message' => $message,
+            'table_html' => view('valabilitati.partials.rows', [
+                'valabilitati' => $valabilitati,
+            ])->render(),
+            'modals_html' => view('valabilitati.partials.modals', [
+                'valabilitati' => $valabilitati,
+                'soferi' => $this->getSoferOptions(),
+                'includeCreate' => true,
+            ])->render(),
+            'next_url' => $this->buildNextPageUrl($filtersRequest, $valabilitati),
+        ]);
     }
 }

--- a/resources/views/valabilitati/partials/modals.blade.php
+++ b/resources/views/valabilitati/partials/modals.blade.php
@@ -1,0 +1,248 @@
+@php
+    $currentFormType = $formType ?? old('form_type');
+    $currentFormId = (int) ($formId ?? old('form_id'));
+    $driverOptions = $soferi ?? [];
+@endphp
+
+@if (($includeCreate ?? false) === true)
+    @php($isCreateActive = $currentFormType === 'create')
+    <div class="modal fade text-dark" id="valabilitateCreateModal" tabindex="-1" role="dialog" aria-labelledby="valabilitateCreateModalLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header bg-success text-white">
+                    <h5 class="modal-title" id="valabilitateCreateModalLabel">Adaugă valabilitate</h5>
+                    <button type="button" class="btn-close bg-white" data-bs-dismiss="modal" aria-label="Închide"></button>
+                </div>
+                <form action="{{ route('valabilitati.store') }}" method="POST" class="valabilitati-modal-form" novalidate>
+                    @csrf
+                    <input type="hidden" name="form_type" value="create">
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label for="valabilitate-create-denumire" class="form-label">Denumire<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="denumire"
+                                id="valabilitate-create-denumire"
+                                class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('denumire') ? 'is-invalid' : '' }}"
+                                value="{{ $isCreateActive ? old('denumire', '') : '' }}"
+                                autocomplete="off"
+                                required
+                            >
+                            <div class="invalid-feedback {{ $isCreateActive && $errors->has('denumire') ? 'd-block' : '' }}" data-error-for="denumire">
+                                {{ $isCreateActive ? $errors->first('denumire') : '' }}
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="valabilitate-create-numar-auto" class="form-label">Număr auto<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="numar_auto"
+                                id="valabilitate-create-numar-auto"
+                                class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('numar_auto') ? 'is-invalid' : '' }}"
+                                value="{{ $isCreateActive ? old('numar_auto', '') : '' }}"
+                                autocomplete="off"
+                                required
+                            >
+                            <div class="invalid-feedback {{ $isCreateActive && $errors->has('numar_auto') ? 'd-block' : '' }}" data-error-for="numar_auto">
+                                {{ $isCreateActive ? $errors->first('numar_auto') : '' }}
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="valabilitate-create-sofer" class="form-label">Șofer<span class="text-danger">*</span></label>
+                            <select
+                                name="sofer_id"
+                                id="valabilitate-create-sofer"
+                                class="form-select bg-white rounded-3 {{ $isCreateActive && $errors->has('sofer_id') ? 'is-invalid' : '' }}"
+                                required
+                            >
+                                <option value="">Selectează șofer</option>
+                                @foreach ($driverOptions as $driverId => $driverName)
+                                    <option value="{{ $driverId }}" {{ $isCreateActive && (int) old('sofer_id') === (int) $driverId ? 'selected' : '' }}>
+                                        {{ $driverName }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            <div class="invalid-feedback {{ $isCreateActive && $errors->has('sofer_id') ? 'd-block' : '' }}" data-error-for="sofer_id">
+                                {{ $isCreateActive ? $errors->first('sofer_id') : '' }}
+                            </div>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label for="valabilitate-create-data-inceput" class="form-label">Data început<span class="text-danger">*</span></label>
+                                <input
+                                    type="date"
+                                    name="data_inceput"
+                                    id="valabilitate-create-data-inceput"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('data_inceput') ? 'is-invalid' : '' }}"
+                                    value="{{ $isCreateActive ? old('data_inceput', '') : '' }}"
+                                    required
+                                >
+                                <div class="invalid-feedback {{ $isCreateActive && $errors->has('data_inceput') ? 'd-block' : '' }}" data-error-for="data_inceput">
+                                    {{ $isCreateActive ? $errors->first('data_inceput') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="valabilitate-create-data-sfarsit" class="form-label">Data sfârșit</label>
+                                <input
+                                    type="date"
+                                    name="data_sfarsit"
+                                    id="valabilitate-create-data-sfarsit"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('data_sfarsit') ? 'is-invalid' : '' }}"
+                                    value="{{ $isCreateActive ? old('data_sfarsit', '') : '' }}"
+                                >
+                                <div class="invalid-feedback {{ $isCreateActive && $errors->has('data_sfarsit') ? 'd-block' : '' }}" data-error-for="data_sfarsit">
+                                    {{ $isCreateActive ? $errors->first('data_sfarsit') : '' }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                        <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
+                            <i class="fa-solid fa-floppy-disk me-1"></i>Salvează
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endif
+
+@foreach ($valabilitati as $valabilitate)
+    @php
+        $isEditing = $currentFormType === 'edit' && $currentFormId === (int) $valabilitate->id;
+        $editPrefix = 'valabilitate-edit-' . $valabilitate->id . '-';
+    @endphp
+    <div class="modal fade text-dark" id="valabilitateEditModal{{ $valabilitate->id }}" tabindex="-1" role="dialog" aria-labelledby="valabilitateEditModalLabel{{ $valabilitate->id }}" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header bg-primary text-white">
+                    <h5 class="modal-title" id="valabilitateEditModalLabel{{ $valabilitate->id }}">Modifică valabilitate</h5>
+                    <button type="button" class="btn-close bg-white" data-bs-dismiss="modal" aria-label="Închide"></button>
+                </div>
+                <form action="{{ route('valabilitati.update', $valabilitate) }}" method="POST" class="valabilitati-modal-form" novalidate>
+                    @csrf
+                    @method('PUT')
+                    <input type="hidden" name="form_type" value="edit">
+                    <input type="hidden" name="form_id" value="{{ $valabilitate->id }}">
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label for="{{ $editPrefix }}denumire" class="form-label">Denumire<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="denumire"
+                                id="{{ $editPrefix }}denumire"
+                                class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('denumire') ? 'is-invalid' : '' }}"
+                                value="{{ $isEditing ? old('denumire', $valabilitate->denumire) : $valabilitate->denumire }}"
+                                autocomplete="off"
+                                required
+                            >
+                            <div class="invalid-feedback {{ $isEditing && $errors->has('denumire') ? 'd-block' : '' }}" data-error-for="denumire">
+                                {{ $isEditing ? $errors->first('denumire') : '' }}
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="{{ $editPrefix }}numar-auto" class="form-label">Număr auto<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="numar_auto"
+                                id="{{ $editPrefix }}numar-auto"
+                                class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('numar_auto') ? 'is-invalid' : '' }}"
+                                value="{{ $isEditing ? old('numar_auto', $valabilitate->numar_auto) : $valabilitate->numar_auto }}"
+                                autocomplete="off"
+                                required
+                            >
+                            <div class="invalid-feedback {{ $isEditing && $errors->has('numar_auto') ? 'd-block' : '' }}" data-error-for="numar_auto">
+                                {{ $isEditing ? $errors->first('numar_auto') : '' }}
+                            </div>
+                        </div>
+                        <div class="mb-3">
+                            <label for="{{ $editPrefix }}sofer" class="form-label">Șofer<span class="text-danger">*</span></label>
+                            <select
+                                name="sofer_id"
+                                id="{{ $editPrefix }}sofer"
+                                class="form-select bg-white rounded-3 {{ $isEditing && $errors->has('sofer_id') ? 'is-invalid' : '' }}"
+                                required
+                            >
+                                <option value="">Selectează șofer</option>
+                                @foreach ($driverOptions as $driverId => $driverName)
+                                    <option value="{{ $driverId }}"
+                                        @if (($isEditing ? (int) old('sofer_id', $valabilitate->sofer_id) : (int) $valabilitate->sofer_id) === (int) $driverId) selected @endif>
+                                        {{ $driverName }}
+                                    </option>
+                                @endforeach
+                                @if ($valabilitate->sofer && ! array_key_exists($valabilitate->sofer_id, $driverOptions))
+                                    <option value="{{ $valabilitate->sofer_id }}" selected>
+                                        {{ $valabilitate->sofer->name }}
+                                    </option>
+                                @endif
+                            </select>
+                            <div class="invalid-feedback {{ $isEditing && $errors->has('sofer_id') ? 'd-block' : '' }}" data-error-for="sofer_id">
+                                {{ $isEditing ? $errors->first('sofer_id') : '' }}
+                            </div>
+                        </div>
+                        <div class="row g-3">
+                            <div class="col-md-6">
+                                <label for="{{ $editPrefix }}data-inceput" class="form-label">Data început<span class="text-danger">*</span></label>
+                                <input
+                                    type="date"
+                                    name="data_inceput"
+                                    id="{{ $editPrefix }}data-inceput"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('data_inceput') ? 'is-invalid' : '' }}"
+                                    value="{{ $isEditing ? old('data_inceput', optional($valabilitate->data_inceput)->format('Y-m-d')) : optional($valabilitate->data_inceput)->format('Y-m-d') }}"
+                                    required
+                                >
+                                <div class="invalid-feedback {{ $isEditing && $errors->has('data_inceput') ? 'd-block' : '' }}" data-error-for="data_inceput">
+                                    {{ $isEditing ? $errors->first('data_inceput') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="{{ $editPrefix }}data-sfarsit" class="form-label">Data sfârșit</label>
+                                <input
+                                    type="date"
+                                    name="data_sfarsit"
+                                    id="{{ $editPrefix }}data-sfarsit"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('data_sfarsit') ? 'is-invalid' : '' }}"
+                                    value="{{ $isEditing ? old('data_sfarsit', optional($valabilitate->data_sfarsit)->format('Y-m-d')) : optional($valabilitate->data_sfarsit)->format('Y-m-d') }}"
+                                >
+                                <div class="invalid-feedback {{ $isEditing && $errors->has('data_sfarsit') ? 'd-block' : '' }}" data-error-for="data_sfarsit">
+                                    {{ $isEditing ? $errors->first('data_sfarsit') : '' }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                        <button type="submit" class="btn btn-primary text-white border border-dark rounded-3">
+                            <i class="fa-solid fa-floppy-disk me-1"></i>Salvează modificările
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade text-dark" id="valabilitateDeleteModal{{ $valabilitate->id }}" tabindex="-1" role="dialog" aria-labelledby="valabilitateDeleteModalLabel{{ $valabilitate->id }}" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header bg-danger text-white">
+                    <h5 class="modal-title" id="valabilitateDeleteModalLabel{{ $valabilitate->id }}">Șterge valabilitate</h5>
+                    <button type="button" class="btn-close bg-white" data-bs-dismiss="modal" aria-label="Închide"></button>
+                </div>
+                <div class="modal-body text-start">
+                    Sigur ștergi valabilitatea <strong>{{ $valabilitate->denumire }}</strong> pentru <strong>{{ $valabilitate->numar_auto }}</strong>?
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                    <form action="{{ route('valabilitati.destroy', $valabilitate) }}" method="POST" class="valabilitati-modal-form" novalidate>
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-danger text-white border border-dark rounded-3">
+                            <i class="fa-solid fa-trash-can me-1"></i>Șterge
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+@endforeach

--- a/resources/views/valabilitati/partials/rows.blade.php
+++ b/resources/views/valabilitati/partials/rows.blade.php
@@ -29,5 +29,36 @@
                 Expirat de {{ abs($zileRamase) }} zile
             @endif
         </td>
+        <td class="text-end">
+            <div class="d-flex flex-wrap justify-content-end">
+                <div class="ms-1">
+                    <a href="{{ route('valabilitati.show', $valabilitate) }}" class="flex">
+                        <span class="badge bg-success">Vezi</span>
+                    </a>
+                </div>
+                <div class="ms-1">
+                    <a
+                        href="#"
+                        data-bs-toggle="modal"
+                        data-bs-target="#valabilitateEditModal{{ $valabilitate->id }}"
+                        class="flex"
+                        title="Modifică valabilitatea"
+                    >
+                        <span class="badge bg-primary">Modifică</span>
+                    </a>
+                </div>
+                <div class="ms-1">
+                    <a
+                        href="#"
+                        data-bs-toggle="modal"
+                        data-bs-target="#valabilitateDeleteModal{{ $valabilitate->id }}"
+                        class="flex"
+                        title="Șterge valabilitatea"
+                    >
+                        <span class="badge bg-danger">Șterge</span>
+                    </a>
+                </div>
+            </div>
+        </td>
     </tr>
 @endforeach

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -1,0 +1,150 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-6">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-calendar-check me-1"></i>Valabilitate
+            </span>
+        </div>
+        <div class="col-lg-6 text-lg-end mt-3 mt-lg-0">
+            <div class="d-flex flex-column flex-lg-row justify-content-lg-end align-items-stretch align-items-lg-center gap-2">
+                <a href="{{ $backUrl }}" class="btn btn-sm btn-secondary text-white border border-dark rounded-3">
+                    <i class="fas fa-arrow-left text-white me-1"></i>Înapoi
+                </a>
+                <button
+                    type="button"
+                    class="btn btn-sm btn-primary text-white border border-dark rounded-3"
+                    data-bs-toggle="modal"
+                    data-bs-target="#valabilitateEditModal{{ $valabilitate->id }}"
+                >
+                    <i class="fa-solid fa-pen-to-square text-white me-1"></i>Modifică
+                </button>
+                <button
+                    type="button"
+                    class="btn btn-sm btn-danger text-white border border-dark rounded-3"
+                    data-bs-toggle="modal"
+                    data-bs-target="#valabilitateDeleteModal{{ $valabilitate->id }}"
+                >
+                    <i class="fa-solid fa-trash-can text-white me-1"></i>Șterge
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div class="card-body py-4">
+        <div class="row g-4">
+            <div class="col-md-6">
+                <div class="border rounded-3 p-3 h-100">
+                    <h6 class="text-muted text-uppercase mb-2">Informații generale</h6>
+                    <p class="mb-1"><strong>Denumire:</strong> {{ $valabilitate->denumire }}</p>
+                    <p class="mb-1"><strong>Număr auto:</strong> {{ $valabilitate->numar_auto }}</p>
+                    <p class="mb-0"><strong>Șofer:</strong> {{ $valabilitate->sofer->name ?? '—' }}</p>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="border rounded-3 p-3 h-100">
+                    <h6 class="text-muted text-uppercase mb-2">Perioadă</h6>
+                    <p class="mb-1">
+                        <strong>Început:</strong>
+                        {{ optional($valabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
+                    </p>
+                    <p class="mb-1">
+                        <strong>Sfârșit:</strong>
+                        {{ optional($valabilitate->data_sfarsit)->format('d.m.Y') ?? '—' }}
+                    </p>
+                    @php($azi = now()->startOfDay())
+                    @php($zileRamase = optional($valabilitate->data_sfarsit)?->diffInDays($azi, false))
+                    @php($isActive = is_null($valabilitate->data_sfarsit) || optional($valabilitate->data_sfarsit)->greaterThanOrEqualTo($azi))
+                    <p class="mb-0">
+                        <strong>Status:</strong>
+                        <span class="badge {{ $isActive ? 'bg-success' : 'bg-secondary' }}">
+                            {{ $isActive ? 'Activă' : 'Expirată' }}
+                        </span>
+                        @if (! is_null($zileRamase))
+                            <span class="ms-2 text-muted">
+                                @if ($zileRamase >= 0)
+                                    {{ $zileRamase }} zile rămase
+                                @else
+                                    Expirată de {{ abs($zileRamase) }} zile
+                                @endif
+                            </span>
+                        @endif
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div
+    id="valabilitati-modals"
+    data-active-modal="{{ session('valabilitati.modal') }}"
+>
+    @include('valabilitati.partials.modals', [
+        'valabilitati' => collect([$valabilitate]),
+        'soferi' => $soferi,
+        'includeCreate' => false,
+        'formType' => old('form_type'),
+        'formId' => old('form_id'),
+    ])
+</div>
+
+@push('page-scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const container = document.getElementById('valabilitati-modals');
+            if (!container) {
+                return;
+            }
+
+            const activeModal = container.dataset.activeModal;
+            if (!activeModal) {
+                return;
+            }
+
+            let modalId = null;
+
+            if (activeModal === 'create') {
+                modalId = 'valabilitateCreateModal';
+            } else if (activeModal.startsWith('edit:')) {
+                const parts = activeModal.split(':');
+                if (parts.length === 2 && parts[1]) {
+                    modalId = `valabilitateEditModal${parts[1]}`;
+                }
+            }
+
+            if (!modalId) {
+                return;
+            }
+
+            const modalElement = document.getElementById(modalId);
+            if (!modalElement) {
+                return;
+            }
+
+            const bootstrap = window.bootstrap;
+            const bootstrapModal = bootstrap && bootstrap.Modal ? bootstrap.Modal : null;
+
+            if (bootstrapModal) {
+                const instance =
+                    typeof bootstrapModal.getOrCreateInstance === 'function'
+                        ? bootstrapModal.getOrCreateInstance(modalElement)
+                        : new bootstrapModal(modalElement);
+                instance.show();
+                return;
+            }
+
+            const $ = window.jQuery || window.$;
+            if (typeof $ === 'function' && typeof $(modalElement).modal === 'function') {
+                $(modalElement).modal('show');
+                return;
+            }
+
+            modalElement.classList.add('show');
+            modalElement.removeAttribute('aria-hidden');
+        });
+    </script>
+@endpush
+@endsection


### PR DESCRIPTION
## Summary
- implement store, update, and destroy logic with JSON refresh handling in the `ValabilitateController`
- add modal partials, per-row action badges, and front-end scripting for the valabilități index to mirror the facturi pattern
- create a dedicated show page that reuses the modal controls for edit and delete operations

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691378831664832680ca33bf4cb122f6)