### PR TITLE
Adjust valabilitati UI and driver selection

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -213,6 +213,9 @@ class ValabilitateController extends Controller
     {
         return User::query()
             ->where('activ', 1)
+            ->whereHas('roles', function (Builder $query): void {
+                $query->where('slug', 'sofer');
+            })
             ->orderBy('name')
             ->pluck('name', 'id')
             ->toArray();

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -7,7 +7,6 @@
             <span class="badge culoare1 fs-5">
                 <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
                     <span><i class="fa-solid fa-calendar-check me-1"></i>Valabilități</span>
-                    <span class="ms-4">flotă</span>
                 </span>
             </span>
         </div>
@@ -26,9 +25,11 @@
                 </div>
                 <div class="row mb-1 custom-search-form justify-content-center">
                     <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
+                        <label for="filter-interval-start" class="form-label mb-1">Început</label>
                         <input type="date" class="form-control rounded-3" id="filter-interval-start" name="interval_start" value="{{ $filters['interval_start'] }}">
                     </div>
                     <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
+                        <label for="filter-interval-end" class="form-label mb-1">Sfârșit</label>
                         <input type="date" class="form-control rounded-3" id="filter-interval-end" name="interval_end" value="{{ $filters['interval_end'] }}">
                     </div>
                 </div>
@@ -56,7 +57,6 @@
                 >
                     <i class="fas fa-plus-square text-white me-1"></i>Adaugă valabilitate
                 </button>
-                @include('partials.operations-navigation')
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- rename the Valabilități badge and remove the unrelated quick links from the listing
- label the date filters so the interval start and end are obvious
- restrict the selectable drivers in the create/edit modals to users with the șofer role

## Testing
- php artisan test *(fails: vendor directory missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138594cdd8832691a648604c2693d2)