### PR TITLE
Add valabilitate curse management with split location fields

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -58,7 +58,12 @@ class ValabilitateController extends Controller
 
     public function show(Valabilitate $valabilitate): View
     {
-        $valabilitate->loadMissing(['sofer']);
+        $valabilitate->loadMissing([
+            'sofer',
+            'curse' => fn ($query) => $query
+                ->orderByDesc('data_cursa')
+                ->orderByDesc('created_at'),
+        ]);
 
         return view('valabilitati.show', [
             'valabilitate' => $valabilitate,

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ValabilitateCursaRequest;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+
+class ValabilitateCursaController extends Controller
+{
+    public function store(ValabilitateCursaRequest $request, Valabilitate $valabilitate): RedirectResponse
+    {
+        $this->authorize('update', $valabilitate);
+
+        $valabilitate->curse()->create($request->validated());
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost adăugată cu succes.');
+    }
+
+    public function edit(Valabilitate $valabilitate, ValabilitateCursa $cursa): View
+    {
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+
+        $this->authorize('update', $valabilitate);
+
+        return view('valabilitati.curse.edit', [
+            'valabilitate' => $valabilitate,
+            'cursa' => $cursa,
+        ]);
+    }
+
+    public function update(ValabilitateCursaRequest $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): RedirectResponse
+    {
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+
+        $this->authorize('update', $valabilitate);
+
+        $cursa->update($request->validated());
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost actualizată.');
+    }
+
+    public function destroy(Valabilitate $valabilitate, ValabilitateCursa $cursa): RedirectResponse
+    {
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+
+        $this->authorize('update', $valabilitate);
+
+        $cursa->delete();
+
+        return redirect()
+            ->route('valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost ștearsă.');
+    }
+
+    private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void
+    {
+        if ($cursa->valabilitate_id !== $valabilitate->getKey()) {
+            abort(404);
+        }
+    }
+}

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ValabilitateCursaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        return $valabilitate && $this->user()?->can('update', $valabilitate);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'incarcare_localitate' => ['nullable', 'string', 'max:255'],
+            'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'descarcare_localitate' => ['nullable', 'string', 'max:255'],
+            'descarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'data_cursa' => ['nullable', 'date'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\User;
 
 class Valabilitate extends Model
@@ -29,6 +30,11 @@ class Valabilitate extends Model
     public function sofer(): BelongsTo
     {
         return $this->belongsTo(User::class, 'sofer_id');
+    }
+
+    public function curse(): HasMany
+    {
+        return $this->hasMany(ValabilitateCursa::class);
     }
 
     public function syncSummary(): void

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ValabilitateCursa extends Model
+{
+    use HasFactory;
+
+    protected $table = 'valabilitati_curse';
+
+    protected $fillable = [
+        'valabilitate_id',
+        'incarcare_localitate',
+        'incarcare_cod_postal',
+        'descarcare_localitate',
+        'descarcare_cod_postal',
+        'data_cursa',
+        'observatii',
+    ];
+
+    protected $casts = [
+        'data_cursa' => 'datetime',
+    ];
+
+    public function valabilitate(): BelongsTo
+    {
+        return $this->belongsTo(Valabilitate::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(static function (ValabilitateCursa $cursa): void {
+            $cursa->valabilitate?->syncSummary();
+        });
+
+        static::deleted(static function (ValabilitateCursa $cursa): void {
+            $cursa->valabilitate?->syncSummary();
+        });
+    }
+}

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\ValabilitateCursa>
+ */
+class ValabilitateCursaFactory extends Factory
+{
+    protected $model = ValabilitateCursa::class;
+
+    public function definition(): array
+    {
+        return [
+            'valabilitate_id' => Valabilitate::factory(),
+            'incarcare_localitate' => fake()->city(),
+            'incarcare_cod_postal' => fake()->postcode(),
+            'descarcare_localitate' => fake()->city(),
+            'descarcare_cod_postal' => fake()->postcode(),
+            'data_cursa' => fake()->dateTimeBetween('-1 week', '+1 week'),
+            'observatii' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/ValabilitateFactory.php
+++ b/database/factories/ValabilitateFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Valabilitate;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Valabilitate>
+ */
+class ValabilitateFactory extends Factory
+{
+    protected $model = Valabilitate::class;
+
+    public function definition(): array
+    {
+        $startDate = fake()->dateTimeBetween('-1 month', '+1 week');
+
+        return [
+            'numar_auto' => strtoupper(fake()->bothify('??##???')),
+            'sofer_id' => User::factory(),
+            'denumire' => fake()->words(3, true),
+            'data_inceput' => $startDate->format('Y-m-d'),
+            'data_sfarsit' => fake()->boolean(40)
+                ? fake()->dateTimeBetween($startDate, '+2 months')->format('Y-m-d')
+                : null,
+        ];
+    }
+}

--- a/database/migrations/2025_03_24_040800_create_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_040800_create_valabilitati_curse_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('valabilitati_curse', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('valabilitate_id')->constrained('valabilitati')->cascadeOnDelete();
+            $table->string('incarcare_localitate')->nullable();
+            $table->string('incarcare_cod_postal')->nullable();
+            $table->string('descarcare_localitate')->nullable();
+            $table->string('descarcare_cod_postal')->nullable();
+            $table->dateTime('data_cursa')->nullable();
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+
+            $table->index('data_cursa');
+            $table->index('incarcare_localitate');
+            $table->index('descarcare_localitate');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('valabilitati_curse');
+    }
+};

--- a/resources/views/valabilitati/curse/_form.blade.php
+++ b/resources/views/valabilitati/curse/_form.blade.php
@@ -1,0 +1,70 @@
+<div class="row g-3">
+    <div class="col-md-6">
+        <label for="incarcare_localitate" class="form-label">Localitate încărcare</label>
+        <input
+            type="text"
+            class="form-control"
+            id="incarcare_localitate"
+            name="incarcare_localitate"
+            value="{{ old('incarcare_localitate', optional($cursa)->incarcare_localitate ?? '') }}"
+            maxlength="255"
+        >
+    </div>
+
+    <div class="col-md-6">
+        <label for="incarcare_cod_postal" class="form-label">Cod poștal încărcare</label>
+        <input
+            type="text"
+            class="form-control"
+            id="incarcare_cod_postal"
+            name="incarcare_cod_postal"
+            value="{{ old('incarcare_cod_postal', optional($cursa)->incarcare_cod_postal ?? '') }}"
+            maxlength="255"
+        >
+    </div>
+
+    <div class="col-md-6">
+        <label for="descarcare_localitate" class="form-label">Localitate descărcare</label>
+        <input
+            type="text"
+            class="form-control"
+            id="descarcare_localitate"
+            name="descarcare_localitate"
+            value="{{ old('descarcare_localitate', optional($cursa)->descarcare_localitate ?? '') }}"
+            maxlength="255"
+        >
+    </div>
+
+    <div class="col-md-6">
+        <label for="descarcare_cod_postal" class="form-label">Cod poștal descărcare</label>
+        <input
+            type="text"
+            class="form-control"
+            id="descarcare_cod_postal"
+            name="descarcare_cod_postal"
+            value="{{ old('descarcare_cod_postal', optional($cursa)->descarcare_cod_postal ?? '') }}"
+            maxlength="255"
+        >
+    </div>
+
+    <div class="col-md-6">
+        <label for="data_cursa" class="form-label">Data și ora cursei</label>
+        <input
+            type="datetime-local"
+            class="form-control"
+            id="data_cursa"
+            name="data_cursa"
+            value="{{ old('data_cursa', optional($cursa)->data_cursa?->format('Y-m-d\\TH:i')) }}"
+        >
+    </div>
+
+    <div class="col-12">
+        <label for="observatii" class="form-label">Observații</label>
+        <textarea
+            class="form-control"
+            id="observatii"
+            name="observatii"
+            rows="3"
+        >{{ old('observatii', optional($cursa)->observatii ?? '') }}</textarea>
+    </div>
+</div>

--- a/resources/views/valabilitati/curse/edit.blade.php
+++ b/resources/views/valabilitati/curse/edit.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-6">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-truck-fast me-1"></i>Modifică cursă
+            </span>
+        </div>
+        <div class="col-lg-6 text-lg-end mt-3 mt-lg-0">
+            <a href="{{ route('valabilitati.show', $valabilitate) }}" class="btn btn-sm btn-secondary text-white border border-dark rounded-3">
+                <i class="fas fa-arrow-left text-white me-1"></i>Înapoi
+            </a>
+        </div>
+    </div>
+
+    <div class="card-body py-4">
+        @include('errors')
+
+        <form method="POST" action="{{ route('valabilitati.curse.update', [$valabilitate, $cursa]) }}" class="needs-validation" novalidate>
+            @csrf
+            @method('PUT')
+
+            @include('valabilitati.curse._form', ['cursa' => $cursa])
+
+            <div class="d-flex justify-content-end mt-4">
+                <a href="{{ route('valabilitati.show', $valabilitate) }}" class="btn btn-secondary me-2">Renunță</a>
+                <button type="submit" class="btn btn-primary text-white border border-dark rounded-3">
+                    <i class="fa-solid fa-floppy-disk me-1"></i>Salvează cursa
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -34,6 +34,14 @@
     </div>
 
     <div class="card-body py-4">
+        @include('errors')
+
+        @if (session('status'))
+            <div class="alert alert-success" role="alert">
+                {{ session('status') }}
+            </div>
+        @endif
+
         <div class="row g-4">
             <div class="col-md-6">
                 <div class="border rounded-3 p-3 h-100">
@@ -74,6 +82,84 @@
                     </p>
                 </div>
             </div>
+        </div>
+    </div>
+</div>
+
+<div class="mx-3 px-3 mt-4 card" style="border-radius: 40px;">
+    <div class="card-header d-flex justify-content-between align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <h6 class="mb-0 text-uppercase">Curse asociate</h6>
+        <span class="badge bg-primary text-white">{{ $valabilitate->curse->count() }} înregistrări</span>
+    </div>
+    <div class="card-body">
+        @if ($valabilitate->curse->isEmpty())
+            <p class="text-muted mb-4">Nu există curse asociate acestei valabilități.</p>
+        @else
+            <div class="table-responsive mb-4">
+                <table class="table table-striped align-middle">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Încărcare - localitate</th>
+                            <th>Încărcare - cod poștal</th>
+                            <th>Descărcare - localitate</th>
+                            <th>Descărcare - cod poștal</th>
+                            <th>Data cursă</th>
+                            <th>Observații</th>
+                            <th class="text-end">Acțiuni</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach ($valabilitate->curse as $cursa)
+                            <tr>
+                                <td>{{ $loop->iteration }}</td>
+                                <td>{{ $cursa->incarcare_localitate ?: '—' }}</td>
+                                <td>{{ $cursa->incarcare_cod_postal ?: '—' }}</td>
+                                <td>{{ $cursa->descarcare_localitate ?: '—' }}</td>
+                                <td>{{ $cursa->descarcare_cod_postal ?: '—' }}</td>
+                                <td>{{ $cursa->data_cursa?->format('d.m.Y H:i') ?: '—' }}</td>
+                                <td>{{ $cursa->observatii ?: '—' }}</td>
+                                <td class="text-end">
+                                    <a
+                                        href="{{ route('valabilitati.curse.edit', [$valabilitate, $cursa]) }}"
+                                        class="btn btn-sm btn-outline-secondary me-2"
+                                        title="Modifică cursa"
+                                    >
+                                        <i class="fa-solid fa-pen"></i>
+                                    </a>
+                                    <form
+                                        action="{{ route('valabilitati.curse.destroy', [$valabilitate, $cursa]) }}"
+                                        method="POST"
+                                        class="d-inline"
+                                        onsubmit="return confirm('Sigur dorești să ștergi această cursă?');"
+                                    >
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Șterge cursa">
+                                            <i class="fa-solid fa-trash"></i>
+                                        </button>
+                                    </form>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endif
+
+        <div class="border rounded-3 p-3">
+            <h6 class="text-muted text-uppercase mb-3">Adaugă cursă</h6>
+            <form method="POST" action="{{ route('valabilitati.curse.store', $valabilitate) }}" class="needs-validation" novalidate>
+                @csrf
+
+                @include('valabilitati.curse._form', ['cursa' => null])
+
+                <div class="d-flex justify-content-end mt-4">
+                    <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
+                        <i class="fa-solid fa-plus me-1"></i>Adaugă cursă
+                    </button>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Tests\Feature\Valabilitati;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class ValabilitateCursaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_store_cursa_with_split_fields(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('valabilitati.curse.store', $valabilitate), [
+            'incarcare_localitate' => 'Cluj-Napoca',
+            'incarcare_cod_postal' => '400000',
+            'descarcare_localitate' => 'Oradea',
+            'descarcare_cod_postal' => '410001',
+            'data_cursa' => '2025-05-01T08:30',
+            'observatii' => 'Livrare completă',
+        ]);
+
+        $response->assertRedirect(route('valabilitati.show', $valabilitate));
+
+        $this->assertDatabaseHas('valabilitati_curse', [
+            'valabilitate_id' => $valabilitate->id,
+            'incarcare_localitate' => 'Cluj-Napoca',
+            'incarcare_cod_postal' => '400000',
+            'descarcare_localitate' => 'Oradea',
+            'descarcare_cod_postal' => '410001',
+            'data_cursa' => '2025-05-01 08:30:00',
+            'observatii' => 'Livrare completă',
+        ]);
+
+        $cursa = ValabilitateCursa::firstOrFail();
+        $this->assertInstanceOf(Carbon::class, $cursa->data_cursa);
+        $this->assertSame('2025-05-01 08:30:00', $cursa->data_cursa->format('Y-m-d H:i:s'));
+    }
+
+    public function test_user_can_update_cursa_fields(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $cursa = ValabilitateCursa::factory()->create([
+            'incarcare_localitate' => 'Brașov',
+            'incarcare_cod_postal' => '500100',
+            'descarcare_localitate' => 'Sibiu',
+            'descarcare_cod_postal' => '550200',
+            'data_cursa' => '2025-05-03 10:00:00',
+        ]);
+
+        $response = $this->actingAs($user)->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
+            'incarcare_localitate' => 'Iași',
+            'incarcare_cod_postal' => '700505',
+            'descarcare_localitate' => 'Galați',
+            'descarcare_cod_postal' => '800010',
+            'data_cursa' => '2025-05-05T14:45',
+            'observatii' => 'Actualizare detalii',
+        ]);
+
+        $response->assertRedirect(route('valabilitati.show', $cursa->valabilitate));
+
+        $this->assertDatabaseHas('valabilitati_curse', [
+            'id' => $cursa->id,
+            'incarcare_localitate' => 'Iași',
+            'incarcare_cod_postal' => '700505',
+            'descarcare_localitate' => 'Galați',
+            'descarcare_cod_postal' => '800010',
+            'data_cursa' => '2025-05-05 14:45:00',
+            'observatii' => 'Actualizare detalii',
+        ]);
+    }
+
+    public function test_user_can_delete_cursa(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $cursa = ValabilitateCursa::factory()->create();
+
+        $response = $this->actingAs($user)->delete(route('valabilitati.curse.destroy', [$cursa->valabilitate, $cursa]));
+
+        $response->assertRedirect(route('valabilitati.show', $cursa->valabilitate));
+        $this->assertDatabaseMissing('valabilitati_curse', ['id' => $cursa->id]);
+    }
+
+    public function test_show_view_displays_split_fields_and_datetime(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create();
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
+            'incarcare_localitate' => 'Timișoara',
+            'incarcare_cod_postal' => '300001',
+            'descarcare_localitate' => 'Arad',
+            'descarcare_cod_postal' => '310002',
+            'data_cursa' => '2025-06-10 16:20:00',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.show', $valabilitate));
+
+        $response->assertOk();
+        $response->assertSeeText('Timișoara');
+        $response->assertSeeText('300001');
+        $response->assertSeeText('Arad');
+        $response->assertSeeText('310002');
+        $response->assertSeeText('10.06.2025 16:20');
+    }
+
+    private function createValabilitatiUser(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::create([
+            'name' => 'Valabilități',
+            'slug' => 'access-valabilitati',
+            'module' => 'valabilitati',
+        ]);
+
+        $role = Role::create([
+            'name' => 'Administrator',
+            'slug' => 'admin',
+        ]);
+
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- create a valabilitati_curse migration with separate localitate/cod poștal columns and a datetime data_cursa field
- add the ValabilitateCursa model, request, controller, and Blade forms to manage the new fields
- extend the valabilitate detail page plus factories and feature tests to cover storing, updating, and displaying trips

## Testing
- `php artisan test --filter=ValabilitateCursaTest` *(fails: vendor autoload missing; composer install cannot run because package downloads are blocked in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691439d9e5b483269974272bb51f9a3a)