### PR TITLE
Align impersonation redirects with login flow

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Providers\RouteServiceProvider;
-use App\Support\Navigation\MainNavigation;
+use App\Support\Auth\UserRedirector;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 use Illuminate\Http\Request;
@@ -38,25 +38,7 @@ class LoginController extends Controller
 
     protected function redirectTo()
     {
-        $user = Auth::user();
-
-        if ($user && $user->hasRole('sofer')) {
-            return route('sofer.dashboard');
-        }
-
-        if ($user && $user->hasPermission('dashboard')) {
-            return route('dashboard');
-        }
-
-        if ($user) {
-            $menuUrl = MainNavigation::firstAccessibleUrlFor($user);
-
-            if ($menuUrl) {
-                return $menuUrl;
-            }
-        }
-
-        return $this->redirectTo;
+        return UserRedirector::redirectPathFor(Auth::user(), $this->redirectTo);
     }
 
     /**

--- a/app/Http/Controllers/Tech/ImpersonationController.php
+++ b/app/Http/Controllers/Tech/ImpersonationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Tech;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Support\Auth\UserRedirector;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -72,11 +73,9 @@ class ImpersonationController extends Controller
 
         Auth::login($targetUser);
 
-        if ($targetUser->hasRole('mecanic')) {
-            return redirect()->route('service-masini.index');
-        }
+        $redirectUrl = UserRedirector::redirectPathFor($targetUser);
 
-        return redirect('/');
+        return redirect()->to($redirectUrl);
     }
 
     public function destroy(Request $request): RedirectResponse

--- a/app/Support/Auth/UserRedirector.php
+++ b/app/Support/Auth/UserRedirector.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Support\Auth;
+
+use App\Models\User;
+use App\Support\Navigation\MainNavigation;
+
+class UserRedirector
+{
+    public static function redirectPathFor(?User $user, string $fallback = '/'): string
+    {
+        if (! $user) {
+            return $fallback;
+        }
+
+        if ($user->hasRole('sofer')) {
+            return route('sofer.dashboard');
+        }
+
+        if ($user->hasRole('mecanic')) {
+            return route('service-masini.index');
+        }
+
+        if ($user->hasPermission('dashboard')) {
+            return route('dashboard');
+        }
+
+        $menuUrl = MainNavigation::firstAccessibleUrlFor($user);
+
+        if ($menuUrl) {
+            return $menuUrl;
+        }
+
+        return $fallback;
+    }
+}

--- a/tests/Feature/ImpersonationTest.php
+++ b/tests/Feature/ImpersonationTest.php
@@ -129,6 +129,30 @@ class ImpersonationTest extends TestCase
         $this->assertSame($superAdmin->name, session('impersonated_by_name'));
     }
 
+    public function test_impersonating_sofer_redirects_to_sofer_dashboard(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+        $soferRole = Role::firstOrCreate(
+            ['slug' => 'sofer'],
+            [
+                'name' => 'Șofer',
+                'description' => 'Acces restrâns la cursele unei valabilități.',
+            ]
+        );
+
+        $soferUser = User::factory()->create();
+        $soferUser->assignRole($soferRole);
+
+        $response = $this->actingAs($superAdmin)->post(route('tech.impersonation.start'), [
+            'user_id' => $soferUser->id,
+        ]);
+
+        $response->assertRedirect(route('sofer.dashboard'));
+        $this->assertAuthenticatedAs($soferUser);
+        $this->assertSame($superAdmin->id, session('impersonated_by'));
+        $this->assertSame($superAdmin->name, session('impersonated_by_name'));
+    }
+
     public function test_impersonation_index_orders_by_primary_role_then_name(): void
     {
         $superAdminRole = Role::firstOrCreate(


### PR DESCRIPTION
## Summary
- add an App\Support\Auth\UserRedirector helper that encapsulates the post-authentication redirect logic for role-based accounts
- update the login and impersonation controllers to rely on the shared redirector so impersonated users land on the same destinations as direct logins
- extend the impersonation feature tests with a scenario that asserts șofer accounts are redirected to their dashboard

## Testing
- php artisan test --filter=ImpersonationTest *(fails: missing Composer dependencies and GitHub authentication prevented installation)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69143edb363c8326ac840ade3947634a)