### PR TITLE
Refine valabilitati views and add dedicated curses page

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -60,9 +60,6 @@ class ValabilitateController extends Controller
     {
         $valabilitate->loadMissing([
             'sofer',
-            'curse' => fn ($query) => $query
-                ->orderByDesc('data_cursa')
-                ->orderByDesc('created_at'),
         ]);
 
         return view('valabilitati.show', [

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -5,11 +5,29 @@ namespace App\Http\Controllers;
 use App\Http\Requests\ValabilitateCursaRequest;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
+use App\Support\Valabilitati\ValabilitatiFilterState;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
 class ValabilitateCursaController extends Controller
 {
+    public function index(Valabilitate $valabilitate): View
+    {
+        $this->authorize('view', $valabilitate);
+
+        $valabilitate->loadMissing([
+            'sofer',
+            'curse' => fn ($query) => $query
+                ->orderByDesc('data_cursa')
+                ->orderByDesc('created_at'),
+        ]);
+
+        return view('valabilitati.curse.index', [
+            'valabilitate' => $valabilitate,
+            'backUrl' => ValabilitatiFilterState::route(),
+        ]);
+    }
+
     public function store(ValabilitateCursaRequest $request, Valabilitate $valabilitate): RedirectResponse
     {
         $this->authorize('update', $valabilitate);
@@ -17,7 +35,7 @@ class ValabilitateCursaController extends Controller
         $valabilitate->curse()->create($request->validated());
 
         return redirect()
-            ->route('valabilitati.show', $valabilitate)
+            ->route('valabilitati.curse.index', $valabilitate)
             ->with('status', 'Cursa a fost adăugată cu succes.');
     }
 
@@ -42,7 +60,7 @@ class ValabilitateCursaController extends Controller
         $cursa->update($request->validated());
 
         return redirect()
-            ->route('valabilitati.show', $valabilitate)
+            ->route('valabilitati.curse.index', $valabilitate)
             ->with('status', 'Cursa a fost actualizată.');
     }
 
@@ -55,7 +73,7 @@ class ValabilitateCursaController extends Controller
         $cursa->delete();
 
         return redirect()
-            ->route('valabilitati.show', $valabilitate)
+            ->route('valabilitati.curse.index', $valabilitate)
             ->with('status', 'Cursa a fost ștearsă.');
     }
 

--- a/resources/views/valabilitati/curse/edit.blade.php
+++ b/resources/views/valabilitati/curse/edit.blade.php
@@ -9,7 +9,7 @@
             </span>
         </div>
         <div class="col-lg-6 text-lg-end mt-3 mt-lg-0">
-            <a href="{{ route('valabilitati.show', $valabilitate) }}" class="btn btn-sm btn-secondary text-white border border-dark rounded-3">
+            <a href="{{ route('valabilitati.curse.index', $valabilitate) }}" class="btn btn-sm btn-secondary text-white border border-dark rounded-3">
                 <i class="fas fa-arrow-left text-white me-1"></i>Înapoi
             </a>
         </div>
@@ -25,7 +25,7 @@
             @include('valabilitati.curse._form', ['cursa' => $cursa])
 
             <div class="d-flex justify-content-end mt-4">
-                <a href="{{ route('valabilitati.show', $valabilitate) }}" class="btn btn-secondary me-2">Renunță</a>
+                <a href="{{ route('valabilitati.curse.index', $valabilitate) }}" class="btn btn-secondary me-2">Renunță</a>
                 <button type="submit" class="btn btn-primary text-white border border-dark rounded-3">
                     <i class="fa-solid fa-floppy-disk me-1"></i>Salvează cursa
                 </button>

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -1,0 +1,132 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+    <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
+        <div class="col-lg-6">
+            <span class="badge culoare1 fs-5">
+                <i class="fa-solid fa-route me-1"></i>Curse asociate
+            </span>
+        </div>
+        <div class="col-lg-6 text-lg-end mt-3 mt-lg-0">
+            <div class="d-flex flex-column flex-lg-row justify-content-lg-end align-items-stretch align-items-lg-center gap-2">
+                <a href="{{ route('valabilitati.show', $valabilitate) }}" class="btn btn-sm btn-secondary text-white border border-dark rounded-3">
+                    <i class="fas fa-arrow-left text-white me-1"></i>Înapoi la valabilitate
+                </a>
+                <a href="{{ $backUrl }}" class="btn btn-sm btn-outline-secondary border border-dark rounded-3">
+                    <i class="fa-solid fa-list me-1"></i>Înapoi la listă
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <div class="card-body py-4">
+        @include('errors')
+
+        @if (session('status'))
+            <div class="alert alert-success" role="alert">
+                {{ session('status') }}
+            </div>
+        @endif
+
+        <div class="row g-4 mb-4">
+            <div class="col-md-6">
+                <div class="border rounded-3 p-3 h-100">
+                    <h6 class="text-muted text-uppercase mb-2">Informații generale</h6>
+                    <p class="mb-1"><strong>Denumire:</strong> {{ $valabilitate->denumire }}</p>
+                    <p class="mb-1"><strong>Număr auto:</strong> {{ $valabilitate->numar_auto }}</p>
+                    <p class="mb-0"><strong>Șofer:</strong> {{ $valabilitate->sofer->name ?? '—' }}</p>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="border rounded-3 p-3 h-100">
+                    <h6 class="text-muted text-uppercase mb-2">Perioadă</h6>
+                    <p class="mb-1">
+                        <strong>Început:</strong>
+                        {{ optional($valabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
+                    </p>
+                    <p class="mb-0">
+                        <strong>Sfârșit:</strong>
+                        {{ optional($valabilitate->data_sfarsit)->format('d.m.Y') ?? '—' }}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="border rounded-3 p-3">
+            <div class="d-flex justify-content-between align-items-center mb-3">
+                <h6 class="mb-0 text-uppercase">Curse asociate</h6>
+                <span class="badge bg-primary text-white">{{ $valabilitate->curse->count() }} înregistrări</span>
+            </div>
+
+            @if ($valabilitate->curse->isEmpty())
+                <p class="text-muted mb-4">Nu există curse asociate acestei valabilități.</p>
+            @else
+                <div class="table-responsive mb-4">
+                    <table class="table table-striped align-middle">
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>Încărcare - localitate</th>
+                                <th>Încărcare - cod poștal</th>
+                                <th>Descărcare - localitate</th>
+                                <th>Descărcare - cod poștal</th>
+                                <th>Data cursă</th>
+                                <th>Observații</th>
+                                <th class="text-end">Acțiuni</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($valabilitate->curse as $cursa)
+                                <tr>
+                                    <td>{{ $loop->iteration }}</td>
+                                    <td>{{ $cursa->incarcare_localitate ?: '—' }}</td>
+                                    <td>{{ $cursa->incarcare_cod_postal ?: '—' }}</td>
+                                    <td>{{ $cursa->descarcare_localitate ?: '—' }}</td>
+                                    <td>{{ $cursa->descarcare_cod_postal ?: '—' }}</td>
+                                    <td>{{ $cursa->data_cursa?->format('d.m.Y H:i') ?: '—' }}</td>
+                                    <td>{{ $cursa->observatii ?: '—' }}</td>
+                                    <td class="text-end">
+                                        <a
+                                            href="{{ route('valabilitati.curse.edit', [$valabilitate, $cursa]) }}"
+                                            class="btn btn-sm btn-outline-secondary me-2"
+                                            title="Modifică cursa"
+                                        >
+                                            <i class="fa-solid fa-pen"></i>
+                                        </a>
+                                        <form
+                                            action="{{ route('valabilitati.curse.destroy', [$valabilitate, $cursa]) }}"
+                                            method="POST"
+                                            class="d-inline"
+                                            onsubmit="return confirm('Sigur dorești să ștergi această cursă?');"
+                                        >
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger" title="Șterge cursa">
+                                                <i class="fa-solid fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+
+            <h6 class="text-muted text-uppercase mb-3">Adaugă cursă</h6>
+            <form method="POST" action="{{ route('valabilitati.curse.store', $valabilitate) }}" class="needs-validation" novalidate>
+                @csrf
+
+                @include('valabilitati.curse._form', ['cursa' => null])
+
+                <div class="d-flex justify-content-end mt-4">
+                    <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
+                        <i class="fa-solid fa-plus me-1"></i>Adaugă cursă
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -73,7 +73,6 @@
                         <th>Început</th>
                         <th>Sfârșit</th>
                         <th>Status</th>
-                        <th class="text-end">Zile rămase</th>
                         <th class="text-end">Acțiuni</th>
                     </tr>
                 </thead>
@@ -82,7 +81,7 @@
                         @include('valabilitati.partials.rows', ['valabilitati' => $valabilitati])
                     @else
                         <tr>
-                            <td colspan="8" class="text-center py-4">Nu există valabilități care să respecte criteriile selectate.</td>
+                            <td colspan="7" class="text-center py-4">Nu există valabilități care să respecte criteriile selectate.</td>
                         </tr>
                     @endif
                 </tbody>

--- a/resources/views/valabilitati/partials/rows.blade.php
+++ b/resources/views/valabilitati/partials/rows.blade.php
@@ -9,9 +9,6 @@
         $isActive = is_null($dataSfarsit) || $dataSfarsit->greaterThanOrEqualTo($azi);
         $statusLabel = $isActive ? 'Activă' : 'Expirată';
         $statusClass = $isActive ? 'bg-success' : 'bg-secondary';
-        $zileRamase = is_null($dataSfarsit)
-            ? null
-            : $azi->diffInDays($dataSfarsit, false);
     @endphp
     <tr>
         <td class="fw-semibold">{{ $valabilitate->denumire }}</td>
@@ -23,16 +20,12 @@
             <span class="badge {{ $statusClass }} text-white">{{ $statusLabel }}</span>
         </td>
         <td class="text-end">
-            @if (is_null($zileRamase))
-                Nelimitat
-            @elseif ($zileRamase >= 0)
-                {{ $zileRamase }} zile
-            @else
-                Expirat de {{ abs($zileRamase) }} zile
-            @endif
-        </td>
-        <td class="text-end">
             <div class="d-flex flex-wrap justify-content-end">
+                <div class="ms-1">
+                    <a href="{{ route('valabilitati.curse.index', $valabilitate) }}" class="flex">
+                        <span class="badge bg-info text-dark">Curse</span>
+                    </a>
+                </div>
                 <div class="ms-1">
                     <a href="{{ route('valabilitati.show', $valabilitate) }}" class="flex">
                         <span class="badge bg-success">Vezi</span>

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -63,103 +63,15 @@
                         {{ optional($valabilitate->data_sfarsit)->format('d.m.Y') ?? '—' }}
                     </p>
                     @php($azi = now()->startOfDay())
-                    @php($zileRamase = optional($valabilitate->data_sfarsit)?->diffInDays($azi, false))
                     @php($isActive = is_null($valabilitate->data_sfarsit) || optional($valabilitate->data_sfarsit)->greaterThanOrEqualTo($azi))
                     <p class="mb-0">
                         <strong>Status:</strong>
                         <span class="badge {{ $isActive ? 'bg-success' : 'bg-secondary' }}">
                             {{ $isActive ? 'Activă' : 'Expirată' }}
                         </span>
-                        @if (! is_null($zileRamase))
-                            <span class="ms-2 text-muted">
-                                @if ($zileRamase >= 0)
-                                    {{ $zileRamase }} zile rămase
-                                @else
-                                    Expirată de {{ abs($zileRamase) }} zile
-                                @endif
-                            </span>
-                        @endif
                     </p>
                 </div>
             </div>
-        </div>
-    </div>
-</div>
-
-<div class="mx-3 px-3 mt-4 card" style="border-radius: 40px;">
-    <div class="card-header d-flex justify-content-between align-items-center" style="border-radius: 40px 40px 0px 0px;">
-        <h6 class="mb-0 text-uppercase">Curse asociate</h6>
-        <span class="badge bg-primary text-white">{{ $valabilitate->curse->count() }} înregistrări</span>
-    </div>
-    <div class="card-body">
-        @if ($valabilitate->curse->isEmpty())
-            <p class="text-muted mb-4">Nu există curse asociate acestei valabilități.</p>
-        @else
-            <div class="table-responsive mb-4">
-                <table class="table table-striped align-middle">
-                    <thead>
-                        <tr>
-                            <th>#</th>
-                            <th>Încărcare - localitate</th>
-                            <th>Încărcare - cod poștal</th>
-                            <th>Descărcare - localitate</th>
-                            <th>Descărcare - cod poștal</th>
-                            <th>Data cursă</th>
-                            <th>Observații</th>
-                            <th class="text-end">Acțiuni</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach ($valabilitate->curse as $cursa)
-                            <tr>
-                                <td>{{ $loop->iteration }}</td>
-                                <td>{{ $cursa->incarcare_localitate ?: '—' }}</td>
-                                <td>{{ $cursa->incarcare_cod_postal ?: '—' }}</td>
-                                <td>{{ $cursa->descarcare_localitate ?: '—' }}</td>
-                                <td>{{ $cursa->descarcare_cod_postal ?: '—' }}</td>
-                                <td>{{ $cursa->data_cursa?->format('d.m.Y H:i') ?: '—' }}</td>
-                                <td>{{ $cursa->observatii ?: '—' }}</td>
-                                <td class="text-end">
-                                    <a
-                                        href="{{ route('valabilitati.curse.edit', [$valabilitate, $cursa]) }}"
-                                        class="btn btn-sm btn-outline-secondary me-2"
-                                        title="Modifică cursa"
-                                    >
-                                        <i class="fa-solid fa-pen"></i>
-                                    </a>
-                                    <form
-                                        action="{{ route('valabilitati.curse.destroy', [$valabilitate, $cursa]) }}"
-                                        method="POST"
-                                        class="d-inline"
-                                        onsubmit="return confirm('Sigur dorești să ștergi această cursă?');"
-                                    >
-                                        @csrf
-                                        @method('DELETE')
-                                        <button type="submit" class="btn btn-sm btn-outline-danger" title="Șterge cursa">
-                                            <i class="fa-solid fa-trash"></i>
-                                        </button>
-                                    </form>
-                                </td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </div>
-        @endif
-
-        <div class="border rounded-3 p-3">
-            <h6 class="text-muted text-uppercase mb-3">Adaugă cursă</h6>
-            <form method="POST" action="{{ route('valabilitati.curse.store', $valabilitate) }}" class="needs-validation" novalidate>
-                @csrf
-
-                @include('valabilitati.curse._form', ['cursa' => null])
-
-                <div class="d-flex justify-content-end mt-4">
-                    <button type="submit" class="btn btn-success text-white border border-dark rounded-3">
-                        <i class="fa-solid fa-plus me-1"></i>Adaugă cursă
-                    </button>
-                </div>
-            </form>
         </div>
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -336,6 +336,8 @@ Route::middleware(['auth'])->group(function () {
             ->parameters(['valabilitati' => 'valabilitate']);
 
         Route::scopeBindings()->group(function () {
+            Route::get('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'index'])
+                ->name('valabilitati.curse.index');
             Route::post('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'store'])
                 ->name('valabilitati.curse.store');
             Route::get('valabilitati/{valabilitate}/curse/{cursa}/edit', [ValabilitateCursaController::class, 'edit'])


### PR DESCRIPTION
## Summary
- remove the "Zile rămase" column from the valabilități table and add a button that opens the dedicated curses view
- trim the valabilitate detail page down to only the general information and period sections
- add a standalone "Curse asociate" page with routing/controller updates so that course management happens outside of the detail view

## Testing
- php artisan test *(fails: missing vendor/autoload.php because Composer dependencies are not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914446056108326948c93d7b9eb4e30)