### PR TITLE
Switch curse filters to a range date picker

### DIFF
--- a/resources/js/components/DatePicker.vue
+++ b/resources/js/components/DatePicker.vue
@@ -21,7 +21,9 @@ export default {
     'doarZiuaB',
     'minuteStep',
     'hours',
-    'range'],
+    'range',
+    'rangeStartName',
+    'rangeEndName'],
   computed: {
     latimePrelucrata() {
       if (this.tip === "time") {
@@ -58,6 +60,8 @@ export default {
         // disabledDates: {
         //         weekdays: [1, 7]
         // }
+        rangeStartValue: '',
+        rangeEndValue: '',
     }
   },
     methods: {
@@ -125,6 +129,33 @@ export default {
             }
         },
     },
+    watch: {
+        time: {
+            handler(value) {
+                if (!this.range || (!this.rangeStartName && !this.rangeEndName)) {
+                    this.rangeStartValue = '';
+                    this.rangeEndValue = '';
+                    return;
+                }
+
+                if (Array.isArray(value)) {
+                    this.rangeStartValue = value[0] ?? '';
+                    this.rangeEndValue = value[1] ?? '';
+                    return;
+                }
+
+                if (typeof value === 'string' && value !== '') {
+                    this.rangeStartValue = value;
+                    this.rangeEndValue = '';
+                } else {
+                    this.rangeStartValue = '';
+                    this.rangeEndValue = '';
+                }
+            },
+            deep: true,
+            immediate: true,
+        }
+    },
     created() {
         // if ((typeof this.dataVeche !== 'undefined') && (this.dataVeche !== "")) {
         if (this.dataVeche != null && this.dataVeche !== "") {
@@ -153,7 +184,25 @@ export default {
 
 <template>
   <div>
-    <input type="text" :name=numeCampDb v-model="time" v-show="false">
+    <input
+        v-if="numeCampDb"
+        type="text"
+        :name="numeCampDb"
+        v-model="time"
+        v-show="false"
+    >
+    <input
+        v-if="range && rangeStartName"
+        type="hidden"
+        :name="rangeStartName"
+        :value="rangeStartValue"
+    >
+    <input
+        v-if="range && rangeEndName"
+        type="hidden"
+        :name="rangeEndName"
+        :value="rangeEndValue"
+    >
     <date-picker
         v-model:value="time"
         :type=tip

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -45,33 +45,33 @@
                         >
                     </div>
                 </div>
-                <div class="row custom-search-form justify-content-center align-items-end">
-                    <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
-                        <label for="filter-data-start" class="form-label mb-0 ps-3">Început perioadă</label>
-                        <input
-                            type="date"
-                            class="form-control rounded-3"
-                            id="filter-data-start"
-                            name="data_start"
-                            value="{{ $filters['data_start'] }}"
-                        >
+                @php
+                    $dateRangeFilter = implode(',', array_filter([
+                        $filters['data_start'] ?? null,
+                        $filters['data_end'] ?? null,
+                    ]));
+                @endphp
+                <div class="row custom-search-form justify-content-center align-items-end" id="datePicker">
+                    <div class="col-lg-6 col-md-6 mb-2 mb-lg-0">
+                        <label for="filter-data-interval" class="form-label mb-0 ps-3">Perioadă</label>
+                        <vue-datepicker-next
+                            id="filter-data-interval"
+                            data-veche="{{ $dateRangeFilter }}"
+                            tip="date"
+                            value-type="YYYY-MM-DD"
+                            format="DD.MM.YYYY"
+                            :latime="{ width: '100%' }"
+                            :range="true"
+                            range-start-name="data_start"
+                            range-end-name="data_end"
+                        ></vue-datepicker-next>
                     </div>
-                    <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
-                        <label for="filter-data-end" class="form-label mb-0 ps-3">Sfârșit perioadă</label>
-                        <input
-                            type="date"
-                            class="form-control rounded-3"
-                            id="filter-data-end"
-                            name="data_end"
-                            value="{{ $filters['data_end'] }}"
-                        >
-                    </div>
-                    <div class="col-lg-3 col-md-4 mb-2 mb-md-0">
+                    <div class="col-lg-3 col-md-3 mb-2 mb-md-0">
                         <button class="btn btn-sm w-100 btn-primary text-white border border-dark rounded-3" type="submit">
                             <i class="fas fa-search text-white me-1"></i>Caută
                         </button>
                     </div>
-                    <div class="col-lg-3 col-md-4">
+                    <div class="col-lg-3 col-md-3">
                         <a
                             class="btn btn-sm w-100 btn-secondary text-white border border-dark rounded-3"
                             href="{{ route('valabilitati.curse.index', $valabilitate) }}"


### PR DESCRIPTION
## Summary
- enhance the shared DatePicker component to expose optional range start/end hidden fields when using range mode
- replace the dual curse filter date inputs with a single vue-datepicker-next range picker that maps values back to data_start and data_end

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69144ee40b048326bd7598de936f253c)