### PR TITLE
Add country selection and odometer tracking to valabilitati curse

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ValabilitateCursaRequest;
+use App\Models\Tara;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
 use App\Support\Valabilitati\ValabilitatiCurseFilterState;
@@ -37,6 +38,7 @@ class ValabilitateCursaController extends Controller
             'filters' => $filters,
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitate, $curse),
             'backUrl' => ValabilitatiFilterState::route(),
+            'tari' => $this->loadTari(),
         ]);
     }
 
@@ -58,6 +60,7 @@ class ValabilitateCursaController extends Controller
                 'valabilitate' => $valabilitate,
                 'curse' => $curse,
                 'includeCreate' => false,
+                'tari' => $this->loadTari(),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($request, $valabilitate, $curse),
         ]);
@@ -133,7 +136,10 @@ class ValabilitateCursaController extends Controller
 
     private function buildFilteredQuery(Valabilitate $valabilitate, array $filters): Builder
     {
-        $query = $valabilitate->curse()->getQuery();
+        $query = $valabilitate->curse()->with([
+            'incarcareTara',
+            'descarcareTara',
+        ]);
 
         if ($filters['localitate'] !== '') {
             $term = Str::lower($filters['localitate']);
@@ -223,6 +229,7 @@ class ValabilitateCursaController extends Controller
                 'valabilitate' => $valabilitate,
                 'curse' => $curse,
                 'includeCreate' => true,
+                'tari' => $this->loadTari(),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($filtersRequest, $valabilitate, $curse),
         ]);
@@ -233,5 +240,10 @@ class ValabilitateCursaController extends Controller
         if ($cursa->valabilitate_id !== $valabilitate->getKey()) {
             abort(404);
         }
+    }
+
+    private function loadTari()
+    {
+        return Tara::orderBy('nume')->get(['id', 'nume']);
     }
 }

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -22,10 +22,13 @@ class ValabilitateCursaRequest extends FormRequest
         return [
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'incarcare_tara_id' => ['nullable', 'exists:tari,id'],
             'descarcare_localitate' => ['nullable', 'string', 'max:255'],
             'descarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'descarcare_tara_id' => ['nullable', 'exists:tari,id'],
             'data_cursa' => ['nullable', 'date'],
             'observatii' => ['nullable', 'string'],
+            'km_bord' => ['nullable', 'integer', 'min:0'],
         ];
     }
 

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -16,15 +16,29 @@ class ValabilitateCursa extends Model
         'valabilitate_id',
         'incarcare_localitate',
         'incarcare_cod_postal',
+        'incarcare_tara_id',
         'descarcare_localitate',
         'descarcare_cod_postal',
+        'descarcare_tara_id',
         'data_cursa',
         'observatii',
+        'km_bord',
     ];
 
     protected $casts = [
         'data_cursa' => 'datetime',
+        'km_bord' => 'integer',
     ];
+
+    public function incarcareTara(): BelongsTo
+    {
+        return $this->belongsTo(Tara::class, 'incarcare_tara_id');
+    }
+
+    public function descarcareTara(): BelongsTo
+    {
+        return $this->belongsTo(Tara::class, 'descarcare_tara_id');
+    }
 
     public function valabilitate(): BelongsTo
     {

--- a/database/factories/TaraFactory.php
+++ b/database/factories/TaraFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tara;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Tara>
+ */
+class TaraFactory extends Factory
+{
+    protected $model = Tara::class;
+
+    public function definition(): array
+    {
+        return [
+            'nume' => fake()->unique()->country(),
+            'gmt_offset' => fake()->numberBetween(-12, 14),
+        ];
+    }
+}

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Tara;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -19,10 +20,13 @@ class ValabilitateCursaFactory extends Factory
             'valabilitate_id' => Valabilitate::factory(),
             'incarcare_localitate' => fake()->city(),
             'incarcare_cod_postal' => fake()->postcode(),
+            'incarcare_tara_id' => Tara::factory(),
             'descarcare_localitate' => fake()->city(),
             'descarcare_cod_postal' => fake()->postcode(),
+            'descarcare_tara_id' => Tara::factory(),
             'data_cursa' => fake()->dateTimeBetween('-1 week', '+1 week'),
             'observatii' => fake()->optional()->sentence(),
+            'km_bord' => fake()->numberBetween(0, 500000),
         ];
     }
 }

--- a/database/migrations/2025_03_24_040900_add_tari_and_km_bord_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_040900_add_tari_and_km_bord_to_valabilitati_curse_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->foreignId('incarcare_tara_id')->nullable()->after('incarcare_cod_postal')->constrained('tari');
+            $table->foreignId('descarcare_tara_id')->nullable()->after('descarcare_cod_postal')->constrained('tari');
+            $table->unsignedInteger('km_bord')->nullable()->after('observatii');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn('km_bord');
+            $table->dropConstrainedForeignId('descarcare_tara_id');
+            $table->dropConstrainedForeignId('incarcare_tara_id');
+        });
+    }
+};

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -1,7 +1,25 @@
 @php
     $currentFormType = $formType ?? old('form_type');
     $currentFormId = (int) ($formId ?? old('form_id'));
+    $tariCollection = collect($tari ?? [])->keyBy('id');
+    $resolveTaraName = static function ($id) use ($tariCollection) {
+        if ($id === null || $id === '') {
+            return '';
+        }
+
+        $id = (int) $id;
+
+        return optional($tariCollection->get($id))->nume ?? '';
+    };
 @endphp
+
+@if (($includeCreate ?? false) === true)
+    <datalist id="valabilitati-curse-tari">
+        @foreach ($tariCollection as $tara)
+            <option value="{{ $tara->nume }}" data-id="{{ $tara->id }}"></option>
+        @endforeach
+    </datalist>
+@endif
 
 @if (($includeCreate ?? false) === true)
     @php
@@ -30,6 +48,21 @@
                     @csrf
                     <input type="hidden" name="form_type" value="create">
                     <div class="modal-body">
+                        @php
+                            $createIncarcareTaraId = $isCreateActive ? old('incarcare_tara_id', '') : '';
+                            $createIncarcareTaraText = $isCreateActive ? old('incarcare_tara_text', '') : '';
+                            if ($createIncarcareTaraText === '' && $createIncarcareTaraId !== '') {
+                                $createIncarcareTaraText = $resolveTaraName($createIncarcareTaraId);
+                            }
+
+                            $createDescarcareTaraId = $isCreateActive ? old('descarcare_tara_id', '') : '';
+                            $createDescarcareTaraText = $isCreateActive ? old('descarcare_tara_text', '') : '';
+                            if ($createDescarcareTaraText === '' && $createDescarcareTaraId !== '') {
+                                $createDescarcareTaraText = $resolveTaraName($createDescarcareTaraId);
+                            }
+
+                            $createKmBord = $isCreateActive ? old('km_bord', '') : '';
+                        @endphp
                         <div class="row g-3">
                             <div class="col-md-6">
                                 <label for="cursa-create-incarcare-localitate" class="form-label">Localitate încărcare</label>
@@ -63,6 +96,27 @@
                                     data-error-for="incarcare_cod_postal"
                                 >
                                     {{ $isCreateActive ? $errors->first('incarcare_cod_postal') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-6" data-country-field>
+                                <label for="cursa-create-incarcare-tara" class="form-label">Țară încărcare</label>
+                                <input type="hidden" name="incarcare_tara_id" value="{{ $createIncarcareTaraId }}" data-country-hidden="true">
+                                <input
+                                    type="text"
+                                    name="incarcare_tara_text"
+                                    id="cursa-create-incarcare-tara"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('incarcare_tara_id') ? 'is-invalid' : '' }}"
+                                    value="{{ $createIncarcareTaraText }}"
+                                    maxlength="255"
+                                    autocomplete="off"
+                                    list="valabilitati-curse-tari"
+                                    data-country-input
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('incarcare_tara_id') ? 'd-block' : '' }}"
+                                    data-error-for="incarcare_tara_id"
+                                >
+                                    {{ $isCreateActive ? $errors->first('incarcare_tara_id') : '' }}
                                 </div>
                             </div>
                             <div class="col-md-6">
@@ -99,6 +153,27 @@
                                     {{ $isCreateActive ? $errors->first('descarcare_cod_postal') : '' }}
                                 </div>
                             </div>
+                            <div class="col-md-6" data-country-field>
+                                <label for="cursa-create-descarcare-tara" class="form-label">Țară descărcare</label>
+                                <input type="hidden" name="descarcare_tara_id" value="{{ $createDescarcareTaraId }}" data-country-hidden="true">
+                                <input
+                                    type="text"
+                                    name="descarcare_tara_text"
+                                    id="cursa-create-descarcare-tara"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('descarcare_tara_id') ? 'is-invalid' : '' }}"
+                                    value="{{ $createDescarcareTaraText }}"
+                                    maxlength="255"
+                                    autocomplete="off"
+                                    list="valabilitati-curse-tari"
+                                    data-country-input
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('descarcare_tara_id') ? 'd-block' : '' }}"
+                                    data-error-for="descarcare_tara_id"
+                                >
+                                    {{ $isCreateActive ? $errors->first('descarcare_tara_id') : '' }}
+                                </div>
+                            </div>
                             <div class="col-md-6">
                                 <label for="cursa-create-data" class="form-label">Data și ora cursei</label>
                                 <input
@@ -113,6 +188,24 @@
                                     data-error-for="data_cursa"
                                 >
                                     {{ $isCreateActive ? $errors->first('data_cursa') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="cursa-create-km-bord" class="form-label">Km bord</label>
+                                <input
+                                    type="number"
+                                    name="km_bord"
+                                    id="cursa-create-km-bord"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmBord }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_bord') : '' }}
                                 </div>
                             </div>
                             <div class="col-12">
@@ -151,6 +244,24 @@
         $editDataValue = $isEditing
             ? old('data_cursa', optional($cursa->data_cursa)->format('Y-m-d\TH:i'))
             : optional($cursa->data_cursa)->format('Y-m-d\TH:i');
+        $baseIncarcareTaraId = $cursa->incarcare_tara_id;
+        $editIncarcareTaraId = $isEditing ? old('incarcare_tara_id', $baseIncarcareTaraId) : $baseIncarcareTaraId;
+        $editIncarcareTaraText = $isEditing ? old('incarcare_tara_text', '') : optional($cursa->incarcareTara)->nume;
+        if ($editIncarcareTaraText === '' && $editIncarcareTaraId !== null && $editIncarcareTaraId !== '') {
+            $editIncarcareTaraText = $resolveTaraName($editIncarcareTaraId) ?: optional($cursa->incarcareTara)->nume;
+        }
+
+        $baseDescarcareTaraId = $cursa->descarcare_tara_id;
+        $editDescarcareTaraId = $isEditing ? old('descarcare_tara_id', $baseDescarcareTaraId) : $baseDescarcareTaraId;
+        $editDescarcareTaraText = $isEditing ? old('descarcare_tara_text', '') : optional($cursa->descarcareTara)->nume;
+        if ($editDescarcareTaraText === '' && $editDescarcareTaraId !== null && $editDescarcareTaraId !== '') {
+            $editDescarcareTaraText = $resolveTaraName($editDescarcareTaraId) ?: optional($cursa->descarcareTara)->nume;
+        }
+
+        $editKmBordValue = $isEditing ? old('km_bord', $cursa->km_bord) : $cursa->km_bord;
+        if ($editKmBordValue === null) {
+            $editKmBordValue = '';
+        }
     @endphp
     <div
         class="modal fade text-dark"
@@ -212,6 +323,27 @@
                                     {{ $isEditing ? $errors->first('incarcare_cod_postal') : '' }}
                                 </div>
                             </div>
+                            <div class="col-md-6" data-country-field>
+                                <label for="{{ $editPrefix }}incarcare-tara" class="form-label">Țară încărcare</label>
+                                <input type="hidden" name="incarcare_tara_id" value="{{ $editIncarcareTaraId }}" data-country-hidden="true">
+                                <input
+                                    type="text"
+                                    name="incarcare_tara_text"
+                                    id="{{ $editPrefix }}incarcare-tara"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('incarcare_tara_id') ? 'is-invalid' : '' }}"
+                                    value="{{ $editIncarcareTaraText }}"
+                                    maxlength="255"
+                                    autocomplete="off"
+                                    list="valabilitati-curse-tari"
+                                    data-country-input
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('incarcare_tara_id') ? 'd-block' : '' }}"
+                                    data-error-for="incarcare_tara_id"
+                                >
+                                    {{ $isEditing ? $errors->first('incarcare_tara_id') : '' }}
+                                </div>
+                            </div>
                             <div class="col-md-6">
                                 <label for="{{ $editPrefix }}descarcare-localitate" class="form-label">Localitate descărcare</label>
                                 <input
@@ -246,6 +378,27 @@
                                     {{ $isEditing ? $errors->first('descarcare_cod_postal') : '' }}
                                 </div>
                             </div>
+                            <div class="col-md-6" data-country-field>
+                                <label for="{{ $editPrefix }}descarcare-tara" class="form-label">Țară descărcare</label>
+                                <input type="hidden" name="descarcare_tara_id" value="{{ $editDescarcareTaraId }}" data-country-hidden="true">
+                                <input
+                                    type="text"
+                                    name="descarcare_tara_text"
+                                    id="{{ $editPrefix }}descarcare-tara"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('descarcare_tara_id') ? 'is-invalid' : '' }}"
+                                    value="{{ $editDescarcareTaraText }}"
+                                    maxlength="255"
+                                    autocomplete="off"
+                                    list="valabilitati-curse-tari"
+                                    data-country-input
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('descarcare_tara_id') ? 'd-block' : '' }}"
+                                    data-error-for="descarcare_tara_id"
+                                >
+                                    {{ $isEditing ? $errors->first('descarcare_tara_id') : '' }}
+                                </div>
+                            </div>
                             <div class="col-md-6">
                                 <label for="{{ $editPrefix }}data" class="form-label">Data și ora cursei</label>
                                 <input
@@ -260,6 +413,24 @@
                                     data-error-for="data_cursa"
                                 >
                                     {{ $isEditing ? $errors->first('data_cursa') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="{{ $editPrefix }}km-bord" class="form-label">Km bord</label>
+                                <input
+                                    type="number"
+                                    name="km_bord"
+                                    id="{{ $editPrefix }}km-bord"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmBordValue }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord"
+                                >
+                                    {{ $isEditing ? $errors->first('km_bord') : '' }}
                                 </div>
                             </div>
                             <div class="col-12">

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -11,9 +11,12 @@
         <td class="text-nowrap">{{ $rowNumber }}</td>
         <td>{{ $cursa->incarcare_localitate ?: '—' }}</td>
         <td>{{ $cursa->incarcare_cod_postal ?: '—' }}</td>
+        <td>{{ $cursa->incarcareTara?->nume ?: '—' }}</td>
         <td>{{ $cursa->descarcare_localitate ?: '—' }}</td>
         <td>{{ $cursa->descarcare_cod_postal ?: '—' }}</td>
+        <td>{{ $cursa->descarcareTara?->nume ?: '—' }}</td>
         <td class="text-nowrap">{{ $dataCursa ?: '—' }}</td>
+        <td class="text-nowrap">{{ $cursa->km_bord !== null ? $cursa->km_bord : '—' }}</td>
         <td>{{ $cursa->observatii ?: '—' }}</td>
         <td class="text-end">
             <div class="d-flex flex-wrap justify-content-end">

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Valabilitati;
 use App\Models\Permission;
 use App\Models\Role;
 use App\Models\User;
+use App\Models\Tara;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -19,14 +20,21 @@ class ValabilitateCursaTest extends TestCase
     {
         $user = $this->createValabilitatiUser();
         $valabilitate = Valabilitate::factory()->create();
+        $incarcareTara = Tara::factory()->create(['nume' => 'România']);
+        $descarcareTara = Tara::factory()->create(['nume' => 'Ungaria']);
 
         $response = $this->actingAs($user)->post(route('valabilitati.curse.store', $valabilitate), [
             'incarcare_localitate' => 'Cluj-Napoca',
             'incarcare_cod_postal' => '400000',
+            'incarcare_tara_id' => $incarcareTara->id,
+            'incarcare_tara_text' => $incarcareTara->nume,
             'descarcare_localitate' => 'Oradea',
             'descarcare_cod_postal' => '410001',
+            'descarcare_tara_id' => $descarcareTara->id,
+            'descarcare_tara_text' => $descarcareTara->nume,
             'data_cursa' => '2025-05-01T08:30',
             'observatii' => 'Livrare completă',
+            'km_bord' => 12345,
         ]);
 
         $response->assertRedirect(route('valabilitati.curse.index', $valabilitate));
@@ -36,10 +44,13 @@ class ValabilitateCursaTest extends TestCase
             'valabilitate_id' => $valabilitate->id,
             'incarcare_localitate' => 'Cluj-Napoca',
             'incarcare_cod_postal' => '400000',
+            'incarcare_tara_id' => $incarcareTara->id,
             'descarcare_localitate' => 'Oradea',
             'descarcare_cod_postal' => '410001',
+            'descarcare_tara_id' => $descarcareTara->id,
             'data_cursa' => '2025-05-01 08:30:00',
             'observatii' => 'Livrare completă',
+            'km_bord' => 12345,
         ]);
 
         $cursa = ValabilitateCursa::firstOrFail();
@@ -50,21 +61,34 @@ class ValabilitateCursaTest extends TestCase
     public function test_user_can_update_cursa_fields(): void
     {
         $user = $this->createValabilitatiUser();
+        $initialIncarcareTara = Tara::factory()->create(['nume' => 'Franța']);
+        $initialDescarcareTara = Tara::factory()->create(['nume' => 'Italia']);
         $cursa = ValabilitateCursa::factory()->create([
             'incarcare_localitate' => 'Brașov',
             'incarcare_cod_postal' => '500100',
+            'incarcare_tara_id' => $initialIncarcareTara->id,
             'descarcare_localitate' => 'Sibiu',
             'descarcare_cod_postal' => '550200',
+            'descarcare_tara_id' => $initialDescarcareTara->id,
             'data_cursa' => '2025-05-03 10:00:00',
+            'km_bord' => 78000,
         ]);
+
+        $newIncarcareTara = Tara::factory()->create(['nume' => 'Germania']);
+        $newDescarcareTara = Tara::factory()->create(['nume' => 'Polonia']);
 
         $response = $this->actingAs($user)->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
             'incarcare_localitate' => 'Iași',
             'incarcare_cod_postal' => '700505',
+            'incarcare_tara_id' => $newIncarcareTara->id,
+            'incarcare_tara_text' => $newIncarcareTara->nume,
             'descarcare_localitate' => 'Galați',
             'descarcare_cod_postal' => '800010',
+            'descarcare_tara_id' => $newDescarcareTara->id,
+            'descarcare_tara_text' => $newDescarcareTara->nume,
             'data_cursa' => '2025-05-05T14:45',
             'observatii' => 'Actualizare detalii',
+            'km_bord' => 98765,
         ]);
 
         $response->assertRedirect(route('valabilitati.curse.index', $cursa->valabilitate));
@@ -74,10 +98,13 @@ class ValabilitateCursaTest extends TestCase
             'id' => $cursa->id,
             'incarcare_localitate' => 'Iași',
             'incarcare_cod_postal' => '700505',
+            'incarcare_tara_id' => $newIncarcareTara->id,
             'descarcare_localitate' => 'Galați',
             'descarcare_cod_postal' => '800010',
+            'descarcare_tara_id' => $newDescarcareTara->id,
             'data_cursa' => '2025-05-05 14:45:00',
             'observatii' => 'Actualizare detalii',
+            'km_bord' => 98765,
         ]);
     }
 
@@ -93,26 +120,34 @@ class ValabilitateCursaTest extends TestCase
         $this->assertDatabaseMissing('valabilitati_curse', ['id' => $cursa->id]);
     }
 
-    public function test_show_view_displays_split_fields_and_datetime(): void
+    public function test_index_view_displays_fields_and_datetime(): void
     {
         $user = $this->createValabilitatiUser();
         $valabilitate = Valabilitate::factory()->create();
+        $incarcareTara = Tara::factory()->create(['nume' => 'Austria']);
+        $descarcareTara = Tara::factory()->create(['nume' => 'Cehia']);
         $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
             'incarcare_localitate' => 'Timișoara',
             'incarcare_cod_postal' => '300001',
+            'incarcare_tara_id' => $incarcareTara->id,
             'descarcare_localitate' => 'Arad',
             'descarcare_cod_postal' => '310002',
             'data_cursa' => '2025-06-10 16:20:00',
+            'descarcare_tara_id' => $descarcareTara->id,
+            'km_bord' => 15400,
         ]);
 
-        $response = $this->actingAs($user)->get(route('valabilitati.show', $valabilitate));
+        $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
 
         $response->assertOk();
         $response->assertSeeText('Timișoara');
         $response->assertSeeText('300001');
+        $response->assertSeeText($incarcareTara->nume);
         $response->assertSeeText('Arad');
         $response->assertSeeText('310002');
+        $response->assertSeeText($descarcareTara->nume);
         $response->assertSeeText('10.06.2025 16:20');
+        $response->assertSeeText('15400');
     }
 
     private function createValabilitatiUser(): User


### PR DESCRIPTION
## Summary
- add a follow-up migration that links valabilitati_curse entries to tara records and stores the onboard kilometres
- extend the backend (model, validation, controller, factories, tests) to handle the new country relations and km_bord field
- refresh the valabilitati curse UI to remove the redundant back button, surface the new data, and offer country autocompletion in the modals

## Testing
- not run (phpunit binary is not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145081d458832699b5b7b0d08897c1)