### PR TITLE
Fix tari foreign key types in valabilitati curse migration

### DIFF
--- a/database/migrations/2025_03_24_040900_add_tari_and_km_bord_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_040900_add_tari_and_km_bord_to_valabilitati_curse_table.php
@@ -8,8 +8,18 @@ return new class extends Migration {
     public function up(): void
     {
         Schema::table('valabilitati_curse', function (Blueprint $table): void {
-            $table->foreignId('incarcare_tara_id')->nullable()->after('incarcare_cod_postal')->constrained('tari');
-            $table->foreignId('descarcare_tara_id')->nullable()->after('descarcare_cod_postal')->constrained('tari');
+            $table->unsignedSmallInteger('incarcare_tara_id')->nullable()->after('incarcare_cod_postal');
+            $table->unsignedSmallInteger('descarcare_tara_id')->nullable()->after('descarcare_cod_postal');
+            $table
+                ->foreign('incarcare_tara_id')
+                ->references('id')
+                ->on('tari')
+                ->nullOnDelete();
+            $table
+                ->foreign('descarcare_tara_id')
+                ->references('id')
+                ->on('tari')
+                ->nullOnDelete();
             $table->unsignedInteger('km_bord')->nullable()->after('observatii');
         });
     }
@@ -18,8 +28,9 @@ return new class extends Migration {
     {
         Schema::table('valabilitati_curse', function (Blueprint $table): void {
             $table->dropColumn('km_bord');
-            $table->dropConstrainedForeignId('descarcare_tara_id');
-            $table->dropConstrainedForeignId('incarcare_tara_id');
+            $table->dropForeign(['descarcare_tara_id']);
+            $table->dropForeign(['incarcare_tara_id']);
+            $table->dropColumn(['descarcare_tara_id', 'incarcare_tara_id']);
         });
     }
 };


### PR DESCRIPTION
## Summary
- change the `valabilitati_curse` migration to use unsigned small integers for the `tari` foreign keys
- add explicit foreign key definitions compatible with the `tari.id` column type and null on delete behaviour
- update the down migration to drop the foreign key constraints and columns correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691458816254832699e179531bab5772)