### PR TITLE
Fix valabilitati curse query return type

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -11,6 +11,7 @@ use App\Support\Valabilitati\ValabilitatiFilterState;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -134,7 +135,7 @@ class ValabilitateCursaController extends Controller
         return array_filter($filters, static fn ($value) => $value !== null && $value !== '');
     }
 
-    private function buildFilteredQuery(Valabilitate $valabilitate, array $filters): Builder
+    private function buildFilteredQuery(Valabilitate $valabilitate, array $filters): HasMany
     {
         $query = $valabilitate->curse()->with([
             'incarcareTara',


### PR DESCRIPTION
## Summary
- fix the buildFilteredQuery helper to return the has-many relation used for filtering
- import the has-many relation class to keep type hints accurate

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691459ba09c883269ea98ae6d7caad64)