### PR TITLE
Enhance valabilitati date filters and split curse datetime inputs

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -108,6 +108,10 @@ class ValabilitateController extends Controller
             'numar_auto',
             'sofer',
             'denumire',
+            'inceput_start',
+            'inceput_end',
+            'sfarsit_start',
+            'sfarsit_end',
             'interval_start',
             'interval_end',
         ]));
@@ -147,12 +151,20 @@ class ValabilitateController extends Controller
             $query->whereRaw('LOWER(numar_auto) LIKE ?', ["%{$numarAuto}%"]);
         }
 
-        if ($filters['interval_start']) {
-            $query->whereDate('data_inceput', '>=', $filters['interval_start']);
+        if ($filters['inceput_start']) {
+            $query->whereDate('data_inceput', '>=', $filters['inceput_start']);
         }
 
-        if ($filters['interval_end']) {
-            $query->whereDate('data_inceput', '<=', $filters['interval_end']);
+        if ($filters['inceput_end']) {
+            $query->whereDate('data_inceput', '<=', $filters['inceput_end']);
+        }
+
+        if ($filters['sfarsit_start']) {
+            $query->whereDate('data_sfarsit', '>=', $filters['sfarsit_start']);
+        }
+
+        if ($filters['sfarsit_end']) {
+            $query->whereDate('data_sfarsit', '<=', $filters['sfarsit_end']);
         }
 
         return $query;
@@ -196,18 +208,27 @@ class ValabilitateController extends Controller
             'numar_auto' => ['nullable', 'string', 'max:255'],
             'sofer' => ['nullable', 'string', 'max:255'],
             'denumire' => ['nullable', 'string', 'max:255'],
+            'inceput_start' => ['nullable', 'date'],
+            'inceput_end' => ['nullable', 'date', 'after_or_equal:inceput_start'],
+            'sfarsit_start' => ['nullable', 'date'],
+            'sfarsit_end' => ['nullable', 'date', 'after_or_equal:sfarsit_start'],
             'interval_start' => ['nullable', 'date'],
             'interval_end' => ['nullable', 'date', 'after_or_equal:interval_start'],
         ]);
 
         $validated = $validator->validate();
 
+        $inceputStart = $validated['inceput_start'] ?? $validated['interval_start'] ?? null;
+        $inceputEnd = $validated['inceput_end'] ?? $validated['interval_end'] ?? null;
+
         return [
             'numar_auto' => trim((string) ($validated['numar_auto'] ?? '')),
             'sofer' => trim((string) ($validated['sofer'] ?? '')),
             'denumire' => trim((string) ($validated['denumire'] ?? '')),
-            'interval_start' => $validated['interval_start'] ?? null,
-            'interval_end' => $validated['interval_end'] ?? null,
+            'inceput_start' => $inceputStart,
+            'inceput_end' => $inceputEnd,
+            'sfarsit_start' => $validated['sfarsit_start'] ?? null,
+            'sfarsit_end' => $validated['sfarsit_end'] ?? null,
         ];
     }
 

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -32,6 +32,33 @@ class ValabilitateCursaRequest extends FormRequest
         ];
     }
 
+    protected function prepareForValidation(): void
+    {
+        $dateInput = $this->input('data_cursa_date');
+        $timeInput = $this->input('data_cursa_time');
+
+        if ($dateInput === null && $timeInput === null) {
+            return;
+        }
+
+        $date = trim((string) $dateInput);
+        $time = trim((string) $timeInput);
+
+        if ($date === '') {
+            $this->merge(['data_cursa' => null]);
+
+            return;
+        }
+
+        if ($time === '') {
+            $time = '00:00';
+        }
+
+        $this->merge([
+            'data_cursa' => sprintf('%s %s', $date, $time),
+        ]);
+    }
+
     protected function failedValidation(Validator $validator): void
     {
         if ($this->expectsJson()) {

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -439,6 +439,8 @@
 
                 Object.entries(errors).forEach(([field, messages]) => {
                     const inputs = form.querySelectorAll(`[name="${field}"]`);
+                    const proxyInputs = form.querySelectorAll(`[data-error-proxy="${field}"]`);
+
                     inputs.forEach(input => {
                         input.classList.add('is-invalid');
 
@@ -450,6 +452,10 @@
                                 textInput.classList.add('is-invalid');
                             }
                         }
+                    });
+
+                    proxyInputs.forEach(proxy => {
+                        proxy.classList.add('is-invalid');
                     });
 
                     const feedback = form.querySelector(`[data-error-for="${field}"]`);

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -11,6 +11,17 @@
 
         return optional($tariCollection->get($id))->nume ?? '';
     };
+    $formatDateTimeValue = static function ($value, string $format) {
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        try {
+            return \Illuminate\Support\Carbon::parse($value)->format($format);
+        } catch (\Throwable $exception) {
+            return '';
+        }
+    };
 @endphp
 
 @if (($includeCreate ?? false) === true)
@@ -62,6 +73,17 @@
                             }
 
                             $createKmBord = $isCreateActive ? old('km_bord', '') : '';
+                            $createDataDateValue = $isCreateActive ? old('data_cursa_date', '') : '';
+                            $createDataTimeValue = $isCreateActive ? old('data_cursa_time', '') : '';
+                            if ($isCreateActive) {
+                                $oldCombinedValue = old('data_cursa', '');
+                                if ($createDataDateValue === '' && $oldCombinedValue !== '') {
+                                    $createDataDateValue = $formatDateTimeValue($oldCombinedValue, 'Y-m-d');
+                                }
+                                if ($createDataTimeValue === '' && $oldCombinedValue !== '') {
+                                    $createDataTimeValue = $formatDateTimeValue($oldCombinedValue, 'H:i');
+                                }
+                            }
                         @endphp
                         <div class="row g-3">
                             <div class="col-md-6">
@@ -175,14 +197,30 @@
                                 </div>
                             </div>
                             <div class="col-md-6">
-                                <label for="cursa-create-data" class="form-label">Data și ora cursei</label>
-                                <input
-                                    type="datetime-local"
-                                    name="data_cursa"
-                                    id="cursa-create-data"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('data_cursa') ? 'is-invalid' : '' }}"
-                                    value="{{ $isCreateActive ? old('data_cursa', '') : '' }}"
-                                >
+                                <label for="cursa-create-data-date" class="form-label">Data și ora cursei</label>
+                                <div class="row g-2">
+                                    <div class="col-6">
+                                        <input
+                                            type="date"
+                                            name="data_cursa_date"
+                                            id="cursa-create-data-date"
+                                            class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('data_cursa') ? 'is-invalid' : '' }}"
+                                            value="{{ $createDataDateValue }}"
+                                            data-error-proxy="data_cursa"
+                                        >
+                                    </div>
+                                    <div class="col-6">
+                                        <input
+                                            type="time"
+                                            name="data_cursa_time"
+                                            id="cursa-create-data-time"
+                                            class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('data_cursa') ? 'is-invalid' : '' }}"
+                                            value="{{ $createDataTimeValue }}"
+                                            step="60"
+                                            data-error-proxy="data_cursa"
+                                        >
+                                    </div>
+                                </div>
                                 <div
                                     class="invalid-feedback {{ $isCreateActive && $errors->has('data_cursa') ? 'd-block' : '' }}"
                                     data-error-for="data_cursa"
@@ -241,9 +279,19 @@
     @php
         $isEditing = $currentFormType === 'edit' && $currentFormId === (int) $cursa->id;
         $editPrefix = 'cursa-edit-' . $cursa->id . '-';
-        $editDataValue = $isEditing
-            ? old('data_cursa', optional($cursa->data_cursa)->format('Y-m-d\TH:i'))
-            : optional($cursa->data_cursa)->format('Y-m-d\TH:i');
+        $baseDataDate = optional($cursa->data_cursa)->format('Y-m-d');
+        $baseDataTime = optional($cursa->data_cursa)->format('H:i');
+        $editDataDateValue = $isEditing ? old('data_cursa_date', $baseDataDate) : $baseDataDate;
+        $editDataTimeValue = $isEditing ? old('data_cursa_time', $baseDataTime) : $baseDataTime;
+        if ($isEditing) {
+            $oldCombinedValue = old('data_cursa', '');
+            if ($editDataDateValue === '' && $oldCombinedValue !== '') {
+                $editDataDateValue = $formatDateTimeValue($oldCombinedValue, 'Y-m-d');
+            }
+            if ($editDataTimeValue === '' && $oldCombinedValue !== '') {
+                $editDataTimeValue = $formatDateTimeValue($oldCombinedValue, 'H:i');
+            }
+        }
         $baseIncarcareTaraId = $cursa->incarcare_tara_id;
         $editIncarcareTaraId = $isEditing ? old('incarcare_tara_id', $baseIncarcareTaraId) : $baseIncarcareTaraId;
         $editIncarcareTaraText = $isEditing ? old('incarcare_tara_text', '') : optional($cursa->incarcareTara)->nume;
@@ -400,14 +448,30 @@
                                 </div>
                             </div>
                             <div class="col-md-6">
-                                <label for="{{ $editPrefix }}data" class="form-label">Data și ora cursei</label>
-                                <input
-                                    type="datetime-local"
-                                    name="data_cursa"
-                                    id="{{ $editPrefix }}data"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('data_cursa') ? 'is-invalid' : '' }}"
-                                    value="{{ $isEditing ? old('data_cursa', $editDataValue) : $editDataValue }}"
-                                >
+                                <label for="{{ $editPrefix }}data-date" class="form-label">Data și ora cursei</label>
+                                <div class="row g-2">
+                                    <div class="col-6">
+                                        <input
+                                            type="date"
+                                            name="data_cursa_date"
+                                            id="{{ $editPrefix }}data-date"
+                                            class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('data_cursa') ? 'is-invalid' : '' }}"
+                                            value="{{ $editDataDateValue }}"
+                                            data-error-proxy="data_cursa"
+                                        >
+                                    </div>
+                                    <div class="col-6">
+                                        <input
+                                            type="time"
+                                            name="data_cursa_time"
+                                            id="{{ $editPrefix }}data-time"
+                                            class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('data_cursa') ? 'is-invalid' : '' }}"
+                                            value="{{ $editDataTimeValue }}"
+                                            step="60"
+                                            data-error-proxy="data_cursa"
+                                        >
+                                    </div>
+                                </div>
                                 <div
                                     class="invalid-feedback {{ $isEditing && $errors->has('data_cursa') ? 'd-block' : '' }}"
                                     data-error-for="data_cursa"

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -22,16 +22,46 @@
                     <div class="col-lg-2 col-md-6 mb-2 mb-lg-0">
                         <input type="text" class="form-control rounded-3" id="filter-denumire" name="denumire" placeholder="Denumire" value="{{ $filters['denumire'] }}">
                     </div>
-                    <div class="col-lg-2 col-md-6 mb-2 mb-lg-0">
-                        <label for="filter-interval-start" class="form-label mb-0 ps-3">Început</label>
-                        <input type="date" class="form-control rounded-3" id="filter-interval-start" name="interval_start" value="{{ $filters['interval_start'] }}">
-                    </div>
-                    <div class="col-lg-2 col-md-6 mb-2 mb-lg-0">
-                        <label for="filter-interval-end" class="form-label mb-0 ps-3">Sfârșit</label>
-                        <input type="date" class="form-control rounded-3" id="filter-interval-end" name="interval_end" value="{{ $filters['interval_end'] }}">
-                    </div>
                 </div>
-                <div class="row custom-search-form justify-content-center">
+                @php
+                    $inceputRangeFilter = implode(',', array_filter([
+                        $filters['inceput_start'] ?? null,
+                        $filters['inceput_end'] ?? null,
+                    ]));
+                    $sfarsitRangeFilter = implode(',', array_filter([
+                        $filters['sfarsit_start'] ?? null,
+                        $filters['sfarsit_end'] ?? null,
+                    ]));
+                @endphp
+                <div class="row custom-search-form justify-content-center align-items-end" id="datePicker">
+                    <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
+                        <label for="filter-interval-inceput" class="form-label mb-0 ps-3">Început</label>
+                        <vue-datepicker-next
+                            id="filter-interval-inceput"
+                            data-veche="{{ $inceputRangeFilter }}"
+                            tip="date"
+                            value-type="YYYY-MM-DD"
+                            format="DD.MM.YYYY"
+                            :latime="{ width: '100%' }"
+                            :range="true"
+                            range-start-name="inceput_start"
+                            range-end-name="inceput_end"
+                        ></vue-datepicker-next>
+                    </div>
+                    <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
+                        <label for="filter-interval-sfarsit" class="form-label mb-0 ps-3">Sfârșit</label>
+                        <vue-datepicker-next
+                            id="filter-interval-sfarsit"
+                            data-veche="{{ $sfarsitRangeFilter }}"
+                            tip="date"
+                            value-type="YYYY-MM-DD"
+                            format="DD.MM.YYYY"
+                            :latime="{ width: '100%' }"
+                            :range="true"
+                            range-start-name="sfarsit_start"
+                            range-end-name="sfarsit_end"
+                        ></vue-datepicker-next>
+                    </div>
                     <div class="col-lg-3 col-md-4 mb-2 mb-md-0">
                         <button class="btn btn-sm w-100 btn-primary text-white border border-dark rounded-3" type="submit">
                             <i class="fas fa-search text-white me-1"></i>Caută

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -32,7 +32,8 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_cod_postal' => '410001',
             'descarcare_tara_id' => $descarcareTara->id,
             'descarcare_tara_text' => $descarcareTara->nume,
-            'data_cursa' => '2025-05-01T08:30',
+            'data_cursa_date' => '2025-05-01',
+            'data_cursa_time' => '08:30',
             'observatii' => 'Livrare completă',
             'km_bord' => 12345,
         ]);
@@ -86,7 +87,8 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_cod_postal' => '800010',
             'descarcare_tara_id' => $newDescarcareTara->id,
             'descarcare_tara_text' => $newDescarcareTara->nume,
-            'data_cursa' => '2025-05-05T14:45',
+            'data_cursa_date' => '2025-05-05',
+            'data_cursa_time' => '14:45',
             'observatii' => 'Actualizare detalii',
             'km_bord' => 98765,
         ]);
@@ -105,6 +107,51 @@ class ValabilitateCursaTest extends TestCase
             'data_cursa' => '2025-05-05 14:45:00',
             'observatii' => 'Actualizare detalii',
             'km_bord' => 98765,
+        ]);
+    }
+
+    public function test_ajax_update_returns_json_payload(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $cursa = ValabilitateCursa::factory()->create([
+            'data_cursa' => '2025-05-02 09:00:00',
+        ]);
+        $newIncarcareTara = Tara::factory()->create(['nume' => 'Austria']);
+        $newDescarcareTara = Tara::factory()->create(['nume' => 'Cehia']);
+
+        $response = $this
+            ->actingAs($user)
+            ->withHeaders([
+                'X-Requested-With' => 'XMLHttpRequest',
+                'Accept' => 'application/json',
+            ])
+            ->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
+                'incarcare_localitate' => 'București',
+                'incarcare_cod_postal' => '010101',
+                'incarcare_tara_id' => $newIncarcareTara->id,
+                'descarcare_localitate' => 'Praga',
+                'descarcare_cod_postal' => '11000',
+                'descarcare_tara_id' => $newDescarcareTara->id,
+                'data_cursa_date' => '2025-05-10',
+                'data_cursa_time' => '11:15',
+            ]);
+
+        $response->assertOk();
+        $response->assertJsonStructure([
+            'message',
+            'table_html',
+            'modals_html',
+            'next_url',
+        ]);
+        $response->assertJson([
+            'message' => 'Cursa a fost actualizată.',
+        ]);
+
+        $this->assertDatabaseHas('valabilitati_curse', [
+            'id' => $cursa->id,
+            'incarcare_localitate' => 'București',
+            'descarcare_localitate' => 'Praga',
+            'data_cursa' => '2025-05-10 11:15:00',
         ]);
     }
 

--- a/tests/Feature/Valabilitati/ValabilitateFilterTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateFilterTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Valabilitati;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Valabilitate;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ValabilitateFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_filters_by_inceput_and_sfarsit_ranges(): void
+    {
+        $user = $this->createValabilitatiUser();
+
+        $matching = Valabilitate::factory()->create([
+            'denumire' => 'Valabilitate potrivită',
+            'data_inceput' => '2025-01-15',
+            'data_sfarsit' => '2025-02-12',
+        ]);
+
+        Valabilitate::factory()->create([
+            'denumire' => 'Înainte de interval',
+            'data_inceput' => '2025-01-05',
+            'data_sfarsit' => '2025-02-12',
+        ]);
+
+        Valabilitate::factory()->create([
+            'denumire' => 'După interval',
+            'data_inceput' => '2025-01-18',
+            'data_sfarsit' => '2025-02-25',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.index', [
+            'inceput_start' => '2025-01-10',
+            'inceput_end' => '2025-01-20',
+            'sfarsit_start' => '2025-02-05',
+            'sfarsit_end' => '2025-02-20',
+        ]));
+
+        $response->assertOk();
+        $response->assertSeeText($matching->denumire);
+        $response->assertDontSeeText('Înainte de interval');
+        $response->assertDontSeeText('După interval');
+    }
+
+    public function test_legacy_interval_parameters_are_supported(): void
+    {
+        $user = $this->createValabilitatiUser();
+
+        $inside = Valabilitate::factory()->create([
+            'denumire' => 'Compatibil Legacy',
+            'data_inceput' => '2025-03-10',
+            'data_sfarsit' => '2025-03-20',
+        ]);
+
+        Valabilitate::factory()->create([
+            'denumire' => 'În afara Legacy',
+            'data_inceput' => '2025-03-25',
+            'data_sfarsit' => '2025-03-28',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.index', [
+            'interval_start' => '2025-03-05',
+            'interval_end' => '2025-03-15',
+        ]));
+
+        $response->assertOk();
+        $response->assertSeeText($inside->denumire);
+        $response->assertDontSeeText('În afara Legacy');
+    }
+
+    private function createValabilitatiUser(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::create([
+            'name' => 'Valabilități',
+            'slug' => 'access-valabilitati',
+            'module' => 'valabilitati',
+        ]);
+
+        $role = Role::create([
+            'name' => 'Administrator',
+            'slug' => 'admin',
+        ]);
+
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the valabilitati list filters with range pickers for both start and end dates and update the backend query logic
- split the curse form datetime field into separate date and time inputs, adjusting validation and AJAX feedback handling
- add feature coverage for the new filters and AJAX update path for curse edits

## Testing
- unable to run tests (composer install requires GitHub credentials for GitHub API access)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145d8a8dd88326ab2490d7917691d7)