### PR TITLE
Ensure AJAX forms use spoofed HTTP methods

### DIFF
--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -537,17 +537,27 @@
                     `;
                 }
 
-                const method = (form.getAttribute('method') || 'POST').toUpperCase();
+                const methodAttribute = (form.getAttribute('method') || 'POST').toUpperCase();
+                const spoofedMethodInput = form.querySelector('input[name="_method"]');
+                const actualMethod =
+                    methodAttribute === 'POST' && spoofedMethodInput && spoofedMethodInput.value
+                        ? spoofedMethodInput.value.toUpperCase()
+                        : methodAttribute;
+
                 const fetchOptions = {
-                    method,
+                    method: actualMethod,
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json',
                     },
                 };
 
-                if (method !== 'GET') {
+                if (actualMethod !== 'GET') {
                     fetchOptions.body = new FormData(form);
+
+                    if (actualMethod !== methodAttribute && spoofedMethodInput) {
+                        fetchOptions.headers['X-HTTP-Method-Override'] = spoofedMethodInput.value.toUpperCase();
+                    }
                 }
 
                 fetch(form.action, fetchOptions)

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -367,17 +367,27 @@
                     `;
                 }
 
-                const method = (form.getAttribute('method') || 'POST').toUpperCase();
+                const methodAttribute = (form.getAttribute('method') || 'POST').toUpperCase();
+                const spoofedMethodInput = form.querySelector('input[name="_method"]');
+                const actualMethod =
+                    methodAttribute === 'POST' && spoofedMethodInput && spoofedMethodInput.value
+                        ? spoofedMethodInput.value.toUpperCase()
+                        : methodAttribute;
+
                 const fetchOptions = {
-                    method,
+                    method: actualMethod,
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json',
                     },
                 };
 
-                if (method !== 'GET') {
+                if (actualMethod !== 'GET') {
                     fetchOptions.body = new FormData(form);
+
+                    if (actualMethod !== methodAttribute && spoofedMethodInput) {
+                        fetchOptions.headers['X-HTTP-Method-Override'] = spoofedMethodInput.value.toUpperCase();
+                    }
                 }
 
                 fetch(form.action, fetchOptions)


### PR DESCRIPTION
## Summary
- ensure the valabilitati curse modal forms submit using the spoofed HTTP verb when present
- mirror the same method handling logic for the main valabilitati modal forms

## Testing
- php artisan test tests/Feature/Valabilitati/ValabilitateCursaTest.php *(fails: vendor autoload missing because composer install requires GitHub authentication)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914643088d48326be55178ec1a15eff)