### PR TITLE
Ensure modal AJAX submissions send POST payloads

### DIFF
--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -37,6 +37,15 @@ class Valabilitate extends Model
         return $this->hasMany(ValabilitateCursa::class);
     }
 
+    /**
+     * Alias required for Laravel's scoped implicit bindings which expect the
+     * pluralised child parameter ("cursas") when resolving nested bindings.
+     */
+    public function cursas(): HasMany
+    {
+        return $this->curse();
+    }
+
     public function syncSummary(): void
     {
         // Funcționalitatea pentru curse va fi adăugată când schema este disponibilă.

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -199,6 +199,19 @@
 
             const supportsAjax = () => typeof window.fetch === 'function' && typeof window.FormData === 'function';
 
+            const resolveCsrfToken = (() => {
+                let cachedToken = null;
+                return () => {
+                    if (cachedToken !== null) {
+                        return cachedToken;
+                    }
+
+                    const meta = document.querySelector('meta[name="csrf-token"]');
+                    cachedToken = meta ? meta.getAttribute('content') : '';
+                    return cachedToken;
+                };
+            })();
+
             const loadState = {
                 button: null,
                 trigger: null,
@@ -413,12 +426,49 @@
                 const alert = document.createElement('div');
                 alert.className = `alert alert-${type} alert-dismissible fade show mt-3`;
                 alert.setAttribute('role', 'alert');
-                alert.innerHTML = `
-                    <span>${message}</span>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Închide"></button>
-                `;
+
+                const messageSpan = document.createElement('span');
+                messageSpan.textContent = message;
+                alert.appendChild(messageSpan);
+
+                const closeButton = document.createElement('button');
+                closeButton.type = 'button';
+                closeButton.className = 'btn-close';
+                closeButton.setAttribute('data-bs-dismiss', 'alert');
+                closeButton.setAttribute('aria-label', 'Închide');
+                alert.appendChild(closeButton);
 
                 feedbackContainer.appendChild(alert);
+            };
+
+            const buildErrorDetails = (error) => {
+                if (!error || typeof error !== 'object') {
+                    return '';
+                }
+
+                const details = [];
+                const status = typeof error.status === 'number' ? error.status : error.statusCode;
+
+                if (typeof status === 'number') {
+                    details.push(`cod ${status}`);
+                }
+
+                if (error.statusText) {
+                    details.push(error.statusText);
+                }
+
+                if (error.message && !['request_failed', 'validation'].includes(error.message)) {
+                    details.push(error.message);
+                }
+
+                if (error.body) {
+                    const snippet = String(error.body).trim().replace(/\s+/g, ' ');
+                    if (snippet) {
+                        details.push(snippet.length > 200 ? `${snippet.slice(0, 200)}…` : snippet);
+                    }
+                }
+
+                return details.length ? ` Detalii: ${details.join(' | ')}` : '';
             };
 
             const clearFormErrors = (form) => {
@@ -537,17 +587,34 @@
                     `;
                 }
 
-                const method = (form.getAttribute('method') || 'POST').toUpperCase();
+                const methodAttribute = (form.getAttribute('method') || 'POST').toUpperCase();
+                const spoofedMethodInput = form.querySelector('input[name="_method"]');
+                const spoofedMethod =
+                    methodAttribute === 'POST' && spoofedMethodInput && spoofedMethodInput.value
+                        ? spoofedMethodInput.value.toUpperCase()
+                        : null;
+                const fetchMethod = methodAttribute === 'GET' ? 'GET' : 'POST';
+
                 const fetchOptions = {
-                    method,
+                    method: fetchMethod,
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json',
                     },
+                    credentials: 'same-origin',
                 };
 
-                if (method !== 'GET') {
+                const csrfToken = resolveCsrfToken();
+                if (csrfToken) {
+                    fetchOptions.headers['X-CSRF-TOKEN'] = csrfToken;
+                }
+
+                if (fetchMethod !== 'GET') {
                     fetchOptions.body = new FormData(form);
+
+                    if (spoofedMethod) {
+                        fetchOptions.headers['X-HTTP-Method-Override'] = spoofedMethod;
+                    }
                 }
 
                 fetch(form.action, fetchOptions)
@@ -560,7 +627,14 @@
                         }
 
                         if (!response.ok) {
-                            throw new Error('request_failed');
+                            return response.text().then(body => {
+                                const error = new Error('request_failed');
+                                error.status = response.status;
+                                error.statusText = response.statusText;
+                                error.body = body;
+                                error.url = response.url;
+                                throw error;
+                            });
                         }
 
                         return response.json();
@@ -579,7 +653,11 @@
                             return;
                         }
 
-                        showFeedback('A apărut o eroare neașteptată. Reîncercați.', 'danger');
+                        console.error('Valabilități curse AJAX error', error);
+
+                        const detailText = buildErrorDetails(error);
+                        const baseMessage = 'A apărut o eroare neașteptată. Reîncercați.';
+                        showFeedback(detailText ? `${baseMessage}${detailText}` : baseMessage, 'danger');
                     })
                     .finally(() => {
                         if (submitButton) {

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -161,6 +161,19 @@
 
             const supportsAjax = () => typeof window.fetch === 'function' && typeof window.FormData === 'function';
 
+            const resolveCsrfToken = (() => {
+                let cachedToken = null;
+                return () => {
+                    if (cachedToken !== null) {
+                        return cachedToken;
+                    }
+
+                    const meta = document.querySelector('meta[name="csrf-token"]');
+                    cachedToken = meta ? meta.getAttribute('content') : '';
+                    return cachedToken;
+                };
+            })();
+
             const loadState = {
                 button: null,
                 trigger: null,
@@ -259,12 +272,49 @@
                 const alert = document.createElement('div');
                 alert.className = `alert alert-${type} alert-dismissible fade show mt-3`;
                 alert.setAttribute('role', 'alert');
-                alert.innerHTML = `
-                    <span>${message}</span>
-                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Închide"></button>
-                `;
+
+                const messageSpan = document.createElement('span');
+                messageSpan.textContent = message;
+                alert.appendChild(messageSpan);
+
+                const closeButton = document.createElement('button');
+                closeButton.type = 'button';
+                closeButton.className = 'btn-close';
+                closeButton.setAttribute('data-bs-dismiss', 'alert');
+                closeButton.setAttribute('aria-label', 'Închide');
+                alert.appendChild(closeButton);
 
                 feedbackContainer.appendChild(alert);
+            };
+
+            const buildErrorDetails = (error) => {
+                if (!error || typeof error !== 'object') {
+                    return '';
+                }
+
+                const details = [];
+                const status = typeof error.status === 'number' ? error.status : error.statusCode;
+
+                if (typeof status === 'number') {
+                    details.push(`cod ${status}`);
+                }
+
+                if (error.statusText) {
+                    details.push(error.statusText);
+                }
+
+                if (error.message && !['request_failed', 'validation'].includes(error.message)) {
+                    details.push(error.message);
+                }
+
+                if (error.body) {
+                    const snippet = String(error.body).trim().replace(/\s+/g, ' ');
+                    if (snippet) {
+                        details.push(snippet.length > 200 ? `${snippet.slice(0, 200)}…` : snippet);
+                    }
+                }
+
+                return details.length ? ` Detalii: ${details.join(' | ')}` : '';
             };
 
             const clearFormErrors = (form) => {
@@ -367,17 +417,34 @@
                     `;
                 }
 
-                const method = (form.getAttribute('method') || 'POST').toUpperCase();
+                const methodAttribute = (form.getAttribute('method') || 'POST').toUpperCase();
+                const spoofedMethodInput = form.querySelector('input[name="_method"]');
+                const spoofedMethod =
+                    methodAttribute === 'POST' && spoofedMethodInput && spoofedMethodInput.value
+                        ? spoofedMethodInput.value.toUpperCase()
+                        : null;
+                const fetchMethod = methodAttribute === 'GET' ? 'GET' : 'POST';
+
                 const fetchOptions = {
-                    method,
+                    method: fetchMethod,
                     headers: {
                         'X-Requested-With': 'XMLHttpRequest',
                         'Accept': 'application/json',
                     },
+                    credentials: 'same-origin',
                 };
 
-                if (method !== 'GET') {
+                const csrfToken = resolveCsrfToken();
+                if (csrfToken) {
+                    fetchOptions.headers['X-CSRF-TOKEN'] = csrfToken;
+                }
+
+                if (fetchMethod !== 'GET') {
                     fetchOptions.body = new FormData(form);
+
+                    if (spoofedMethod) {
+                        fetchOptions.headers['X-HTTP-Method-Override'] = spoofedMethod;
+                    }
                 }
 
                 fetch(form.action, fetchOptions)
@@ -390,7 +457,14 @@
                         }
 
                         if (!response.ok) {
-                            throw new Error('request_failed');
+                            return response.text().then(body => {
+                                const error = new Error('request_failed');
+                                error.status = response.status;
+                                error.statusText = response.statusText;
+                                error.body = body;
+                                error.url = response.url;
+                                throw error;
+                            });
                         }
 
                         return response.json();
@@ -409,7 +483,11 @@
                             return;
                         }
 
-                        showFeedback('A apărut o eroare neașteptată. Reîncercați.', 'danger');
+                        console.error('Valabilități AJAX error', error);
+
+                        const detailText = buildErrorDetails(error);
+                        const baseMessage = 'A apărut o eroare neașteptată. Reîncercați.';
+                        showFeedback(detailText ? `${baseMessage}${detailText}` : baseMessage, 'danger');
                     })
                     .finally(() => {
                         if (submitButton) {


### PR DESCRIPTION
## Summary
- update the valabilități modal AJAX helper to always submit payloads with POST while preserving spoofed method headers so Laravel processes the form data
- apply the same POST transport fix to the valabilități curse modal forms to keep their asynchronous edits persisted correctly

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914643088d48326be55178ec1a15eff)