### PR TITLE
Adjust valabilitati curse layout and filters

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -105,7 +105,6 @@ class ValabilitateCursaController extends Controller
             'cod_postal',
             'data_start',
             'data_end',
-            'observatii',
         ]));
     }
 
@@ -116,7 +115,6 @@ class ValabilitateCursaController extends Controller
             'cod_postal' => ['nullable', 'string', 'max:255'],
             'data_start' => ['nullable', 'date'],
             'data_end' => ['nullable', 'date', 'after_or_equal:data_start'],
-            'observatii' => ['nullable', 'string'],
         ]);
 
         $validated = $validator->validate();
@@ -126,7 +124,6 @@ class ValabilitateCursaController extends Controller
             'cod_postal' => trim((string) ($validated['cod_postal'] ?? '')),
             'data_start' => $validated['data_start'] ?? null,
             'data_end' => $validated['data_end'] ?? null,
-            'observatii' => trim((string) ($validated['observatii'] ?? '')),
         ];
     }
 
@@ -158,11 +155,6 @@ class ValabilitateCursaController extends Controller
                     ->whereRaw('LOWER(incarcare_cod_postal) LIKE ?', ["%{$term}%"])
                     ->orWhereRaw('LOWER(descarcare_cod_postal) LIKE ?', ["%{$term}%"]);
             });
-        }
-
-        if ($filters['observatii'] !== '') {
-            $term = Str::lower($filters['observatii']);
-            $query->whereRaw('LOWER(observatii) LIKE ?', ["%{$term}%"]);
         }
 
         if ($filters['data_start']) {

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -14,7 +14,7 @@
         <div class="col-lg-8 mb-0" id="formularCurse">
             <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ url()->current() }}">
                 <div class="row mb-1 custom-search-form justify-content-center align-items-end">
-                    <div class="col-lg-4 col-md-6 mb-2 mb-lg-0">
+                    <div class="col-lg-6 col-md-6 mb-2 mb-lg-0">
                         <input
                             type="text"
                             class="form-control rounded-3"
@@ -24,7 +24,7 @@
                             value="{{ $filters['localitate'] }}"
                         >
                     </div>
-                    <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
+                    <div class="col-lg-6 col-md-6 mb-2 mb-lg-0">
                         <input
                             type="text"
                             class="form-control rounded-3"
@@ -32,16 +32,6 @@
                             name="cod_postal"
                             placeholder="Cod poștal"
                             value="{{ $filters['cod_postal'] }}"
-                        >
-                    </div>
-                    <div class="col-lg-5 col-md-12 mb-2 mb-lg-0">
-                        <input
-                            type="text"
-                            class="form-control rounded-3"
-                            id="filter-observatii"
-                            name="observatii"
-                            placeholder="Observații"
-                            value="{{ $filters['observatii'] }}"
                         >
                     </div>
                 </div>
@@ -134,7 +124,6 @@
                         <th>Descărcare - țară</th>
                         <th>Data cursă</th>
                         <th>Km bord</th>
-                        <th>Observații</th>
                         <th class="text-end">Acțiuni</th>
                     </tr>
                 </thead>
@@ -143,7 +132,7 @@
                         @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                     @else
                         <tr>
-                            <td colspan="11" class="text-center py-4">Nu există curse care să respecte criteriile selectate.</td>
+                            <td colspan="10" class="text-center py-4">Nu există curse care să respecte criteriile selectate.</td>
                         </tr>
                     @endif
                 </tbody>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -44,7 +44,7 @@
         aria-labelledby="cursaCreateModalLabel"
         aria-hidden="true"
     >
-        <div class="modal-dialog" role="document">
+        <div class="modal-dialog" role="document" style="--bs-modal-width: 750px;">
             <div class="modal-content">
                 <div class="modal-header bg-success text-white">
                     <h5 class="modal-title" id="cursaCreateModalLabel">Adaugă cursă</h5>
@@ -86,7 +86,7 @@
                             }
                         @endphp
                         <div class="row g-3">
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="cursa-create-incarcare-localitate" class="form-label">Localitate încărcare</label>
                                 <input
                                     type="text"
@@ -103,7 +103,7 @@
                                     {{ $isCreateActive ? $errors->first('incarcare_localitate') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="cursa-create-incarcare-cod-postal" class="form-label">Cod poștal încărcare</label>
                                 <input
                                     type="text"
@@ -120,7 +120,7 @@
                                     {{ $isCreateActive ? $errors->first('incarcare_cod_postal') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6" data-country-field>
+                            <div class="col-md-4" data-country-field>
                                 <label for="cursa-create-incarcare-tara" class="form-label">Țară încărcare</label>
                                 <input type="hidden" name="incarcare_tara_id" value="{{ $createIncarcareTaraId }}" data-country-hidden="true">
                                 <input
@@ -141,7 +141,7 @@
                                     {{ $isCreateActive ? $errors->first('incarcare_tara_id') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="cursa-create-descarcare-localitate" class="form-label">Localitate descărcare</label>
                                 <input
                                     type="text"
@@ -158,7 +158,7 @@
                                     {{ $isCreateActive ? $errors->first('descarcare_localitate') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="cursa-create-descarcare-cod-postal" class="form-label">Cod poștal descărcare</label>
                                 <input
                                     type="text"
@@ -175,7 +175,7 @@
                                     {{ $isCreateActive ? $errors->first('descarcare_cod_postal') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6" data-country-field>
+                            <div class="col-md-4" data-country-field>
                                 <label for="cursa-create-descarcare-tara" class="form-label">Țară descărcare</label>
                                 <input type="hidden" name="descarcare_tara_id" value="{{ $createDescarcareTaraId }}" data-country-hidden="true">
                                 <input
@@ -196,7 +196,7 @@
                                     {{ $isCreateActive ? $errors->first('descarcare_tara_id') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-8">
                                 <label for="cursa-create-data-date" class="form-label">Data și ora cursei</label>
                                 <div class="row g-2">
                                     <div class="col-6">
@@ -228,7 +228,7 @@
                                     {{ $isCreateActive ? $errors->first('data_cursa') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="cursa-create-km-bord" class="form-label">Km bord</label>
                                 <input
                                     type="number"
@@ -319,7 +319,7 @@
         aria-labelledby="cursaEditModalLabel{{ $cursa->id }}"
         aria-hidden="true"
     >
-        <div class="modal-dialog" role="document">
+        <div class="modal-dialog" role="document" style="--bs-modal-width: 750px;">
             <div class="modal-content">
                 <div class="modal-header bg-primary text-white">
                     <h5 class="modal-title" id="cursaEditModalLabel{{ $cursa->id }}">Modifică cursa</h5>
@@ -337,7 +337,7 @@
                     <input type="hidden" name="form_id" value="{{ $cursa->id }}">
                     <div class="modal-body">
                         <div class="row g-3">
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="{{ $editPrefix }}incarcare-localitate" class="form-label">Localitate încărcare</label>
                                 <input
                                     type="text"
@@ -354,7 +354,7 @@
                                     {{ $isEditing ? $errors->first('incarcare_localitate') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="{{ $editPrefix }}incarcare-cod-postal" class="form-label">Cod poștal încărcare</label>
                                 <input
                                     type="text"
@@ -371,7 +371,7 @@
                                     {{ $isEditing ? $errors->first('incarcare_cod_postal') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6" data-country-field>
+                            <div class="col-md-4" data-country-field>
                                 <label for="{{ $editPrefix }}incarcare-tara" class="form-label">Țară încărcare</label>
                                 <input type="hidden" name="incarcare_tara_id" value="{{ $editIncarcareTaraId }}" data-country-hidden="true">
                                 <input
@@ -392,7 +392,7 @@
                                     {{ $isEditing ? $errors->first('incarcare_tara_id') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="{{ $editPrefix }}descarcare-localitate" class="form-label">Localitate descărcare</label>
                                 <input
                                     type="text"
@@ -409,7 +409,7 @@
                                     {{ $isEditing ? $errors->first('descarcare_localitate') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="{{ $editPrefix }}descarcare-cod-postal" class="form-label">Cod poștal descărcare</label>
                                 <input
                                     type="text"
@@ -426,7 +426,7 @@
                                     {{ $isEditing ? $errors->first('descarcare_cod_postal') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6" data-country-field>
+                            <div class="col-md-4" data-country-field>
                                 <label for="{{ $editPrefix }}descarcare-tara" class="form-label">Țară descărcare</label>
                                 <input type="hidden" name="descarcare_tara_id" value="{{ $editDescarcareTaraId }}" data-country-hidden="true">
                                 <input
@@ -447,7 +447,7 @@
                                     {{ $isEditing ? $errors->first('descarcare_tara_id') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-8">
                                 <label for="{{ $editPrefix }}data-date" class="form-label">Data și ora cursei</label>
                                 <div class="row g-2">
                                     <div class="col-6">
@@ -479,7 +479,7 @@
                                     {{ $isEditing ? $errors->first('data_cursa') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-6">
+                            <div class="col-md-4">
                                 <label for="{{ $editPrefix }}km-bord" class="form-label">Km bord</label>
                                 <input
                                     type="number"

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -17,7 +17,6 @@
         <td>{{ $cursa->descarcareTara?->nume ?: '—' }}</td>
         <td class="text-nowrap">{{ $dataCursa ?: '—' }}</td>
         <td class="text-nowrap">{{ $cursa->km_bord !== null ? $cursa->km_bord : '—' }}</td>
-        <td>{{ $cursa->observatii ?: '—' }}</td>
         <td class="text-end">
             <div class="d-flex flex-wrap justify-content-end">
                 <div class="ms-1">


### PR DESCRIPTION
## Summary
- remove the Observații search field and table column from the valabilități curse listing
- widen the add/edit curse modals and group the fields by încărcare, descărcare, and scheduling details

## Testing
- php artisan test --filter=ValabilitateCursaTest *(fails: missing vendor directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147c321dfc8326aa999650b08d9480)