### PR TITLE
Sort valabilitate curse chronologically and block deletion

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -97,6 +97,21 @@ class ValabilitateController extends Controller
 
     public function destroy(Request $request, Valabilitate $valabilitate): RedirectResponse|JsonResponse
     {
+        if ($valabilitate->curse()->exists()) {
+            $message = 'Valabilitatea nu poate fi ștearsă deoarece are curse asociate.';
+
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => $message,
+                    'errors' => [
+                        'curse' => [$message],
+                    ],
+                ], 422);
+            }
+
+            return redirect(ValabilitatiFilterState::route())->with('error', $message);
+        }
+
         $valabilitate->delete();
 
         return $this->respondAfterMutation($request, 'Valabilitatea a fost ștearsă.');

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -171,8 +171,8 @@ class ValabilitateCursaController extends Controller
     private function paginateCurse(Request $request, Valabilitate $valabilitate, array $filters, ?array $query = null): LengthAwarePaginator
     {
         $paginator = $this->buildFilteredQuery($valabilitate, $filters)
-            ->orderByDesc('data_cursa')
-            ->orderByDesc('created_at')
+            ->orderBy('data_cursa')
+            ->orderBy('created_at')
             ->paginate(self::PER_PAGE);
 
         if ($query !== null) {

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -197,6 +197,33 @@ class ValabilitateCursaTest extends TestCase
         $response->assertSeeText('15400');
     }
 
+    public function test_index_lists_curse_in_chronological_order(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create();
+
+        ValabilitateCursa::factory()->for($valabilitate)->create([
+            'data_cursa' => '2025-05-10 09:30:00',
+        ]);
+
+        ValabilitateCursa::factory()->for($valabilitate)->create([
+            'data_cursa' => '2025-05-01 08:00:00',
+        ]);
+
+        ValabilitateCursa::factory()->for($valabilitate)->create([
+            'data_cursa' => '2025-05-05 12:00:00',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
+
+        $response->assertOk();
+        $response->assertSeeInOrder([
+            '01.05.2025 08:00',
+            '05.05.2025 12:00',
+            '10.05.2025 09:30',
+        ]);
+    }
+
     private function createValabilitatiUser(): User
     {
         $user = User::factory()->create();

--- a/tests/Feature/Valabilitati/ValabilitateDeleteTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateDeleteTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Valabilitati;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ValabilitateDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_html_request_cannot_delete_valabilitate_with_curse(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()
+            ->has(ValabilitateCursa::factory(), 'curse')
+            ->create();
+
+        $response = $this->actingAs($user)->delete(route('valabilitati.destroy', $valabilitate));
+
+        $response->assertRedirect(route('valabilitati.index'));
+        $response->assertSessionHas('error', 'Valabilitatea nu poate fi ștearsă deoarece are curse asociate.');
+        $this->assertDatabaseHas('valabilitati', ['id' => $valabilitate->id]);
+    }
+
+    public function test_json_request_cannot_delete_valabilitate_with_curse(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()
+            ->has(ValabilitateCursa::factory(), 'curse')
+            ->create();
+
+        $response = $this->actingAs($user)->deleteJson(route('valabilitati.destroy', $valabilitate));
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'Valabilitatea nu poate fi ștearsă deoarece are curse asociate.',
+            'errors' => [
+                'curse' => ['Valabilitatea nu poate fi ștearsă deoarece are curse asociate.'],
+            ],
+        ]);
+        $this->assertDatabaseHas('valabilitati', ['id' => $valabilitate->id]);
+    }
+
+    private function createValabilitatiUser(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::create([
+            'name' => 'Valabilități',
+            'slug' => 'access-valabilitati',
+            'module' => 'valabilitati',
+        ]);
+
+        $role = Role::create([
+            'name' => 'Administrator',
+            'slug' => 'admin',
+        ]);
+
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- ensure valabilitate curse pagination orders runs chronologically by date (oldest first)
- prevent deleting a valabilitate that still has curse and return clear HTML/JSON feedback
- cover the new behaviours with feature tests for sorting and guarded deletion

## Testing
- `composer install --no-interaction` *(fails: unable to clone symfony/polyfill-mbstring due to CONNECT tunnel 403)*
- `./vendor/bin/phpunit --filter Valabilitate` *(not run because dependencies could not be installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691481981d988326b0d0085882cdadf2)