### PR TITLE
Add driver self-service valabilitate management UI

### DIFF
--- a/app/Http/Controllers/Driver/CursaController.php
+++ b/app/Http/Controllers/Driver/CursaController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Driver\CursaRequest;
+use App\Http\Resources\Driver\ValabilitateResource;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use App\Services\Driver\ActiveValabilitatiService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class CursaController extends Controller
+{
+    public function __construct(private readonly ActiveValabilitatiService $service)
+    {
+    }
+
+    public function store(CursaRequest $request, Valabilitate $valabilitate): JsonResponse
+    {
+        $user = Auth::user();
+        $valabilitate = $this->service->ensureActiveForUser($user, $valabilitate);
+
+        $valabilitate->curse()->create($request->validated());
+
+        $valabilitate = $this->service->loadDetail($valabilitate->fresh());
+
+        return response()->json([
+            'valabilitate' => new ValabilitateResource($valabilitate),
+        ]);
+    }
+
+    public function update(CursaRequest $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): JsonResponse
+    {
+        $user = Auth::user();
+        $valabilitate = $this->service->ensureActiveForUser($user, $valabilitate);
+
+        abort_unless((int) $cursa->valabilitate_id === (int) $valabilitate->id, 404);
+
+        $cursa->update($request->validated());
+
+        $valabilitate = $this->service->loadDetail($valabilitate->fresh());
+
+        return response()->json([
+            'valabilitate' => new ValabilitateResource($valabilitate),
+        ]);
+    }
+
+    public function destroy(Valabilitate $valabilitate, ValabilitateCursa $cursa): JsonResponse
+    {
+        $user = Auth::user();
+        $valabilitate = $this->service->ensureActiveForUser($user, $valabilitate);
+
+        abort_unless((int) $cursa->valabilitate_id === (int) $valabilitate->id, 404);
+
+        $cursa->delete();
+
+        $valabilitate = $this->service->loadDetail($valabilitate->fresh());
+
+        return response()->json([
+            'valabilitate' => new ValabilitateResource($valabilitate),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Driver/DashboardController.php
+++ b/app/Http/Controllers/Driver/DashboardController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Services\Driver\ActiveValabilitatiService;
+use App\Models\Tara;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+
+class DashboardController extends Controller
+{
+    public function __invoke(ActiveValabilitatiService $service): View
+    {
+        $user = Auth::user();
+
+        $valabilitati = $service->listForUser($user);
+
+        $tari = Tara::query()
+            ->orderBy('nume')
+            ->get(['id', 'nume']);
+
+        return view('driver.dashboard', [
+            'valabilitati' => $valabilitati,
+            'tari' => $tari,
+            'romaniaId' => $service->romaniaId(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Driver/LocalitateController.php
+++ b/app/Http/Controllers/Driver/LocalitateController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Models\LocOperareIstoric;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class LocalitateController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $term = trim((string) $request->input('term', ''));
+
+        $query = LocOperareIstoric::query()
+            ->selectRaw('DISTINCT oras as localitate')
+            ->whereNotNull('oras')
+            ->orderBy('oras');
+
+        if ($term !== '') {
+            $query->whereRaw('LOWER(oras) LIKE ?', ['%' . Str::lower($term) . '%']);
+        }
+
+        $localitati = $query
+            ->limit(15)
+            ->pluck('localitate')
+            ->filter()
+            ->values();
+
+        return response()->json([
+            'localitati' => $localitati,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Driver/ValabilitateController.php
+++ b/app/Http/Controllers/Driver/ValabilitateController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers\Driver;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Driver\ValabilitateResource;
+use App\Models\Valabilitate;
+use App\Services\Driver\ActiveValabilitatiService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+
+class ValabilitateController extends Controller
+{
+    public function __construct(private readonly ActiveValabilitatiService $service)
+    {
+    }
+
+    public function index(): JsonResponse
+    {
+        $user = Auth::user();
+        $valabilitati = $this->service->listForUser($user);
+
+        return response()->json([
+            'valabilitati' => ValabilitateResource::collection($valabilitati),
+        ]);
+    }
+
+    public function show(Valabilitate $valabilitate): JsonResponse
+    {
+        $user = Auth::user();
+        $this->service->ensureActiveForUser($user, $valabilitate);
+
+        $valabilitate = $this->service->loadDetail($valabilitate);
+
+        return response()->json([
+            'valabilitate' => new ValabilitateResource($valabilitate),
+        ]);
+    }
+}

--- a/app/Http/Requests/Driver/CursaRequest.php
+++ b/app/Http/Requests/Driver/CursaRequest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Http\Requests\Driver;
+
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use App\Services\Driver\ActiveValabilitatiService;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Arr;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CursaRequest extends FormRequest
+{
+    protected bool $dateProvided = false;
+    protected bool $timeProvided = false;
+
+    public function authorize(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        if (! $valabilitate instanceof Valabilitate) {
+            return false;
+        }
+
+        try {
+            app(ActiveValabilitatiService::class)->ensureActiveForUser($this->user(), $valabilitate);
+        } catch (ModelNotFoundException) {
+            return false;
+        }
+
+        $cursa = $this->route('cursa');
+
+        if ($cursa instanceof ValabilitateCursa && (int) $cursa->valabilitate_id !== (int) $valabilitate->id) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'incarcare_localitate' => ['required', 'string', 'max:255'],
+            'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'incarcare_tara_id' => ['required', 'exists:tari,id'],
+            'descarcare_localitate' => ['required', 'string', 'max:255'],
+            'descarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'descarcare_tara_id' => ['required', 'exists:tari,id'],
+            'data_cursa' => ['nullable', 'date'],
+            'data_cursa_date' => ['nullable', 'date'],
+            'data_cursa_time' => ['nullable', 'date_format:H:i'],
+            'observatii' => ['nullable', 'string'],
+            'km_bord' => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $date = trim((string) $this->input('data_cursa_date', ''));
+        $time = trim((string) $this->input('data_cursa_time', ''));
+
+        $this->dateProvided = $date !== '';
+        $this->timeProvided = $time !== '';
+
+        if ($date === '') {
+            $this->merge(['data_cursa' => null]);
+
+            return;
+        }
+
+        if ($time === '') {
+            $this->merge(['data_cursa' => $date]);
+
+            return;
+        }
+
+        $this->merge([
+            'data_cursa' => sprintf('%s %s', $date, $time),
+        ]);
+    }
+
+    protected function passedValidation(): void
+    {
+        if (! $this->dateProvided) {
+            $this->merge(['data_cursa' => null]);
+        }
+    }
+
+    protected function withValidator($validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            /** @var Valabilitate|null $valabilitate */
+            $valabilitate = $this->route('valabilitate');
+
+            if (! $valabilitate instanceof Valabilitate) {
+                return;
+            }
+
+            $service = app(ActiveValabilitatiService::class);
+
+            try {
+                $service->ensureActiveForUser($this->user(), $valabilitate);
+            } catch (ModelNotFoundException) {
+                $validator->errors()->add('valabilitate', __('Valabilitatea nu este disponibilă.'));
+
+                return;
+            }
+
+            $requiresTime = $this->requiresTime($valabilitate, $service);
+
+            if ($requiresTime) {
+                if (! $this->dateProvided) {
+                    $validator->errors()->add('data_cursa_date', __('Data este obligatorie.'));
+                }
+
+                if (! $this->timeProvided) {
+                    $validator->errors()->add('data_cursa_time', __('Ora este obligatorie.'));
+                }
+            }
+        });
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $validated = Arr::except(parent::validated(), ['data_cursa_date', 'data_cursa_time']);
+
+        return data_get($validated, $key, $validated) ?? $default;
+    }
+
+    private function requiresTime(Valabilitate $valabilitate, ActiveValabilitatiService $service): bool
+    {
+        if ($service->requiresRomaniaTime($this->resolveTaraId())) {
+            return true;
+        }
+
+        $cursa = $this->route('cursa');
+
+        $firstExisting = $valabilitate->curse()
+            ->orderBy('data_cursa')
+            ->orderBy('created_at')
+            ->first();
+
+        if (! $firstExisting) {
+            return true;
+        }
+
+        if ($cursa instanceof ValabilitateCursa) {
+            return (int) $cursa->id === (int) $firstExisting->id;
+        }
+
+        return false;
+    }
+
+    private function resolveTaraId(): ?int
+    {
+        $id = $this->input('descarcare_tara_id');
+
+        if ($id === null || $id === '') {
+            return null;
+        }
+
+        return (int) $id;
+    }
+}

--- a/app/Http/Resources/Driver/CursaResource.php
+++ b/app/Http/Resources/Driver/CursaResource.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Resources\Driver;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Str;
+
+class CursaResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $dataCursa = $this->data_cursa;
+
+        return [
+            'id' => $this->id,
+            'incarcare_localitate' => $this->incarcare_localitate,
+            'incarcare_cod_postal' => $this->incarcare_cod_postal,
+            'incarcare_tara_id' => $this->incarcare_tara_id,
+            'incarcare_tara' => $this->whenLoaded('incarcareTara', fn () => $this->incarcareTara?->nume),
+            'descarcare_localitate' => $this->descarcare_localitate,
+            'descarcare_cod_postal' => $this->descarcare_cod_postal,
+            'descarcare_tara_id' => $this->descarcare_tara_id,
+            'descarcare_tara' => $this->whenLoaded('descarcareTara', fn () => $this->descarcareTara?->nume),
+            'data_cursa' => $dataCursa?->toDateTimeString(),
+            'data_date' => $dataCursa?->format('Y-m-d'),
+            'data_time' => $dataCursa?->format('H:i'),
+            'observatii' => $this->observatii,
+            'km_bord' => $this->km_bord,
+            'requires_time_for_romania' => $this->requiresTimeForRomania(),
+        ];
+    }
+
+    private function requiresTimeForRomania(): bool
+    {
+        $tara = $this->relationLoaded('descarcareTara') ? $this->descarcareTara : null;
+
+        if (! $tara) {
+            return false;
+        }
+
+        return Str::lower((string) $tara->nume) === 'romania';
+    }
+}

--- a/app/Http/Resources/Driver/ValabilitateResource.php
+++ b/app/Http/Resources/Driver/ValabilitateResource.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Resources\Driver;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ValabilitateResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        $orderedCurse = $this->relationLoaded('curse')
+            ? $this->curse->sortBy([
+                ['data_cursa', 'asc'],
+                ['created_at', 'asc'],
+            ])
+            : null;
+
+        $curse = $this->whenLoaded('curse', function () use ($orderedCurse) {
+            return CursaResource::collection(($orderedCurse ?? collect())->values());
+        });
+
+        $firstCursaId = $orderedCurse?->first()?->id;
+
+        return [
+            'id' => $this->id,
+            'numar_auto' => $this->numar_auto,
+            'denumire' => $this->denumire,
+            'data_inceput' => $this->data_inceput?->format('Y-m-d'),
+            'data_sfarsit' => $this->data_sfarsit?->format('Y-m-d'),
+            'curse_count' => $this->curse_count ?? ($this->relationLoaded('curse') ? $this->curse->count() : 0),
+            'curse' => $curse,
+            'first_cursa_id' => $firstCursaId,
+            'has_curse' => ($this->curse_count ?? 0) > 0 || ($orderedCurse?->isNotEmpty() ?? false),
+        ];
+    }
+}

--- a/app/Services/Driver/ActiveValabilitatiService.php
+++ b/app/Services/Driver/ActiveValabilitatiService.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Services\Driver;
+
+use App\Models\Tara;
+use App\Models\User;
+use App\Models\Valabilitate;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
+
+class ActiveValabilitatiService
+{
+    private ?int $cachedRomaniaId = null;
+
+    public function listForUser(User $user): EloquentCollection
+    {
+        $today = CarbonImmutable::today(Date::now()->timezone);
+
+        return Valabilitate::query()
+            ->where('sofer_id', $user->getKey())
+            ->whereDate('data_inceput', '<=', $today)
+            ->where(function ($query) use ($today): void {
+                $query
+                    ->whereNull('data_sfarsit')
+                    ->orWhereDate('data_sfarsit', '>=', $today);
+            })
+            ->orderBy('data_sfarsit')
+            ->orderBy('data_inceput')
+            ->orderBy('denumire')
+            ->withCount('curse')
+            ->get([
+                'id',
+                'numar_auto',
+                'denumire',
+                'data_inceput',
+                'data_sfarsit',
+            ]);
+    }
+
+    public function loadDetail(Valabilitate $valabilitate): Valabilitate
+    {
+        return $valabilitate->load([
+            'curse' => static function ($query): void {
+                $query
+                    ->orderBy('data_cursa')
+                    ->orderBy('created_at');
+            },
+            'curse.incarcareTara:id,nume',
+            'curse.descarcareTara:id,nume',
+        ]);
+    }
+
+    public function ensureActiveForUser(User $user, Valabilitate $valabilitate): Valabilitate
+    {
+        if ((int) $valabilitate->sofer_id !== (int) $user->getKey()) {
+            throw new ModelNotFoundException();
+        }
+
+        $today = CarbonImmutable::today(Date::now()->timezone);
+
+        $isActive = $valabilitate->data_inceput !== null
+            && $valabilitate->data_inceput->lte($today)
+            && ($valabilitate->data_sfarsit === null || $valabilitate->data_sfarsit->gte($today));
+
+        if (! $isActive) {
+            throw new ModelNotFoundException();
+        }
+
+        return $valabilitate;
+    }
+
+    public function romaniaId(): ?int
+    {
+        if ($this->cachedRomaniaId !== null) {
+            return $this->cachedRomaniaId;
+        }
+
+        $this->cachedRomaniaId = Tara::query()
+            ->whereRaw('LOWER(nume) = ?', ['romania'])
+            ->value('id');
+
+        if ($this->cachedRomaniaId !== null) {
+            $this->cachedRomaniaId = (int) $this->cachedRomaniaId;
+        }
+
+        return $this->cachedRomaniaId;
+    }
+
+    public function requiresRomaniaTime(?int $taraId): bool
+    {
+        if ($taraId === null) {
+            return false;
+        }
+
+        $romaniaId = $this->romaniaId();
+
+        if ($romaniaId !== null) {
+            return $romaniaId === (int) $taraId;
+        }
+
+        $taraName = Tara::query()
+            ->whereKey($taraId)
+            ->value('nume');
+
+        return $taraName !== null && Str::lower((string) $taraName) === 'romania';
+    }
+}

--- a/resources/js/components/driver/DriverApp.vue
+++ b/resources/js/components/driver/DriverApp.vue
@@ -1,0 +1,259 @@
+<template>
+    <div class="driver-app">
+        <div v-if="error" class="alert alert-danger" role="alert">
+            {{ error }}
+        </div>
+
+        <div class="row gy-4">
+            <div class="col-12 col-lg-4">
+                <ValabilitateList
+                    :valabilitati="valabilitati"
+                    :loading="listLoading"
+                    :selected-id="selectedId"
+                    @select="handleSelect"
+                    @refresh="fetchValabilitati"
+                />
+            </div>
+            <div class="col-12 col-lg-8">
+                <ValabilitateDetail
+                    v-if="activeValabilitate"
+                    :valabilitate="activeValabilitate"
+                    :countries="tari"
+                    :romania-id="romaniaId"
+                    :loading="detailLoading"
+                    :saving="mutationInFlight"
+                    :create-cursa="createCursa"
+                    :update-cursa="updateCursa"
+                    :delete-cursa="deleteCursa"
+                    :localitati-endpoint="localitatiEndpoint"
+                />
+                <div v-else-if="!listLoading" class="alert alert-info" role="status">
+                    Nu există valabilități active în acest moment.
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { onMounted, ref, watch } from 'vue';
+import ValabilitateList from './ValabilitateList.vue';
+import ValabilitateDetail from './ValabilitateDetail.vue';
+
+const props = defineProps({
+    valabilitatiEndpoint: {
+        type: String,
+        required: true,
+    },
+    localitatiEndpoint: {
+        type: String,
+        required: true,
+    },
+    tari: {
+        type: Array,
+        default: () => [],
+    },
+    romaniaId: {
+        type: [Number, null],
+        default: null,
+    },
+    initialValabilitati: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const listLoading = ref(false);
+const detailLoading = ref(false);
+const mutationInFlight = ref(false);
+const error = ref('');
+
+const valabilitati = ref(normalizeList(props.initialValabilitati));
+const selectedId = ref(valabilitati.value[0]?.id ?? null);
+const activeValabilitate = ref(null);
+
+onMounted(() => {
+    if (selectedId.value) {
+        loadValabilitate(selectedId.value);
+    } else {
+        fetchValabilitati();
+    }
+});
+
+watch(() => selectedId.value, (newId) => {
+    if (! newId) {
+        activeValabilitate.value = null;
+
+        return;
+    }
+
+    loadValabilitate(newId);
+});
+
+function normalizeList(items) {
+    return (items ?? []).map((item) => ({
+        id: item.id,
+        denumire: item.denumire,
+        numar_auto: item.numar_auto,
+        data_inceput: item.data_inceput ?? null,
+        data_sfarsit: item.data_sfarsit ?? null,
+        curse_count: item.curse_count ?? 0,
+    }));
+}
+
+async function fetchValabilitati() {
+    listLoading.value = true;
+    error.value = '';
+
+    try {
+        const response = await window.axios.get(props.valabilitatiEndpoint);
+        const payload = response?.data?.valabilitati ?? [];
+        valabilitati.value = normalizeList(payload);
+
+        if (! selectedId.value && valabilitati.value.length > 0) {
+            selectedId.value = valabilitati.value[0].id;
+        }
+    } catch (exception) {
+        console.error(exception);
+        error.value = 'Nu am putut încărca lista de valabilități. Încercați din nou.';
+    } finally {
+        listLoading.value = false;
+    }
+}
+
+async function loadValabilitate(id) {
+    if (! id) {
+        return;
+    }
+
+    detailLoading.value = true;
+    error.value = '';
+
+    try {
+        const response = await window.axios.get(`${props.valabilitatiEndpoint}/${id}`);
+        setActiveValabilitate(response?.data?.valabilitate ?? null);
+    } catch (exception) {
+        console.error(exception);
+        error.value = 'Nu am putut încărca detaliile valabilității selectate.';
+    } finally {
+        detailLoading.value = false;
+    }
+}
+
+function setActiveValabilitate(valabilitate) {
+    if (! valabilitate) {
+        activeValabilitate.value = null;
+
+        return;
+    }
+
+    activeValabilitate.value = valabilitate;
+    upsertSummary(valabilitate);
+}
+
+function upsertSummary(valabilitate) {
+    const summary = {
+        id: valabilitate.id,
+        denumire: valabilitate.denumire,
+        numar_auto: valabilitate.numar_auto,
+        data_inceput: valabilitate.data_inceput,
+        data_sfarsit: valabilitate.data_sfarsit,
+        curse_count: valabilitate.curse_count ?? (valabilitate.curse?.length ?? 0),
+    };
+
+    const index = valabilitati.value.findIndex((item) => item.id === summary.id);
+
+    if (index === -1) {
+        valabilitati.value.push(summary);
+    } else {
+        valabilitati.value.splice(index, 1, summary);
+    }
+}
+
+function handleSelect(id) {
+    if (selectedId.value === id) {
+        return;
+    }
+
+    selectedId.value = id;
+}
+
+async function createCursa(payload) {
+    if (! activeValabilitate.value) {
+        return;
+    }
+
+    mutationInFlight.value = true;
+
+    try {
+        const response = await window.axios.post(
+            `${props.valabilitatiEndpoint}/${activeValabilitate.value.id}/curse`,
+            payload,
+        );
+
+        setActiveValabilitate(response?.data?.valabilitate ?? null);
+    } catch (exception) {
+        if (exception?.response?.status === 422) {
+            throw {
+                type: 'validation',
+                errors: exception.response.data.errors ?? {},
+            };
+        }
+
+        console.error(exception);
+        throw exception;
+    } finally {
+        mutationInFlight.value = false;
+    }
+}
+
+async function updateCursa(cursaId, payload) {
+    if (! activeValabilitate.value) {
+        return;
+    }
+
+    mutationInFlight.value = true;
+
+    try {
+        const response = await window.axios.put(
+            `${props.valabilitatiEndpoint}/${activeValabilitate.value.id}/curse/${cursaId}`,
+            payload,
+        );
+
+        setActiveValabilitate(response?.data?.valabilitate ?? null);
+    } catch (exception) {
+        if (exception?.response?.status === 422) {
+            throw {
+                type: 'validation',
+                errors: exception.response.data.errors ?? {},
+            };
+        }
+
+        console.error(exception);
+        throw exception;
+    } finally {
+        mutationInFlight.value = false;
+    }
+}
+
+async function deleteCursa(cursaId) {
+    if (! activeValabilitate.value) {
+        return;
+    }
+
+    mutationInFlight.value = true;
+
+    try {
+        const response = await window.axios.delete(
+            `${props.valabilitatiEndpoint}/${activeValabilitate.value.id}/curse/${cursaId}`,
+        );
+
+        setActiveValabilitate(response?.data?.valabilitate ?? null);
+    } catch (exception) {
+        console.error(exception);
+        throw exception;
+    } finally {
+        mutationInFlight.value = false;
+    }
+}
+</script>

--- a/resources/js/components/driver/LocalitateAutocomplete.vue
+++ b/resources/js/components/driver/LocalitateAutocomplete.vue
@@ -1,0 +1,118 @@
+<template>
+    <div class="driver-autocomplete">
+        <label :for="id" class="form-label">{{ label }}</label>
+        <input
+            :id="id"
+            type="text"
+            class="form-control"
+            :placeholder="placeholder"
+            :value="modelValue"
+            :disabled="disabled"
+            @input="onInput"
+            @focus="handleFocus"
+            @blur="handleBlur"
+            autocomplete="off"
+        >
+        <div v-if="showSuggestions" class="driver-autocomplete__list mt-1">
+            <button
+                v-for="item in suggestions"
+                :key="item"
+                type="button"
+                class="driver-autocomplete__item w-100 text-start bg-transparent border-0"
+                @mousedown.prevent="select(item)"
+            >
+                {{ item }}
+            </button>
+            <div v-if="suggestions.length === 0" class="px-3 py-2 text-muted small">
+                Nu am găsit rezultate pentru "{{ modelValue }}".
+            </div>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { onBeforeUnmount, ref } from 'vue';
+import debounce from 'lodash/debounce';
+
+const props = defineProps({
+    modelValue: {
+        type: String,
+        default: '',
+    },
+    label: {
+        type: String,
+        required: true,
+    },
+    endpoint: {
+        type: String,
+        required: true,
+    },
+    id: {
+        type: String,
+        required: true,
+    },
+    placeholder: {
+        type: String,
+        default: '',
+    },
+    disabled: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const emit = defineEmits(['update:modelValue']);
+
+const suggestions = ref([]);
+const showSuggestions = ref(false);
+let active = true;
+
+const performSearch = debounce(async (query) => {
+    if (! query || query.trim().length < 2) {
+        suggestions.value = [];
+
+        return;
+    }
+
+    try {
+        const response = await window.axios.get(props.endpoint, {
+            params: { term: query },
+        });
+
+        if (! active) {
+            return;
+        }
+
+        suggestions.value = response?.data?.localitati ?? [];
+    } catch (error) {
+        console.error('Autocomplete localitate', error);
+        suggestions.value = [];
+    }
+}, 200);
+
+onBeforeUnmount(() => {
+    active = false;
+});
+
+function onInput(event) {
+    const value = event.target.value;
+    emit('update:modelValue', value);
+    performSearch(value);
+}
+
+function handleFocus(event) {
+    showSuggestions.value = true;
+    performSearch(event.target.value);
+}
+
+function handleBlur() {
+    setTimeout(() => {
+        showSuggestions.value = false;
+    }, 120);
+}
+
+function select(value) {
+    emit('update:modelValue', value);
+    showSuggestions.value = false;
+}
+</script>

--- a/resources/js/components/driver/ValabilitateDetail.vue
+++ b/resources/js/components/driver/ValabilitateDetail.vue
@@ -1,0 +1,485 @@
+<template>
+    <div class="driver-form-section p-4">
+        <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+            <div>
+                <h2 class="fs-4 mb-1">{{ valabilitate.denumire }}</h2>
+                <p class="text-muted mb-0">{{ valabilitate.numar_auto }} · {{ intervalLabel }}</p>
+            </div>
+            <button
+                v-if="!isFormVisible"
+                type="button"
+                class="btn btn-primary btn-lg"
+                @click="startCreate"
+            >
+                <i class="fa-solid fa-circle-plus me-2"></i> Adaugă cursă
+            </button>
+        </div>
+
+        <div v-if="loading" class="text-center py-5">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Încărcare...</span>
+            </div>
+        </div>
+
+        <template v-else>
+            <section v-if="isFormVisible" class="mt-4">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h3 class="fs-5 mb-0">{{ formTitle }}</h3>
+                    <button type="button" class="btn btn-link text-decoration-none" @click="cancelForm">
+                        Renunță
+                    </button>
+                </div>
+
+                <div v-if="generalError" class="alert alert-danger" role="alert">
+                    {{ generalError }}
+                </div>
+
+                <form class="row g-3" @submit.prevent="submitForm">
+                    <div class="col-12 col-md-6">
+                        <LocalitateAutocomplete
+                            id="incarcare-localitate"
+                            label="Localitate încărcare"
+                            :endpoint="localitatiEndpoint"
+                            v-model="form.incarcare_localitate"
+                            :disabled="saving"
+                        />
+                        <div v-if="formErrors.incarcare_localitate" class="text-danger small mt-1">
+                            {{ formErrors.incarcare_localitate[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label for="incarcare_cod_postal" class="form-label">Cod poștal încărcare</label>
+                        <input
+                            id="incarcare_cod_postal"
+                            type="text"
+                            class="form-control"
+                            v-model="form.incarcare_cod_postal"
+                            :disabled="saving"
+                        >
+                        <div v-if="formErrors.incarcare_cod_postal" class="text-danger small mt-1">
+                            {{ formErrors.incarcare_cod_postal[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label for="incarcare_tara_id" class="form-label">Țară încărcare</label>
+                        <select
+                            id="incarcare_tara_id"
+                            class="form-select"
+                            v-model="form.incarcare_tara_id"
+                            :disabled="saving"
+                        >
+                            <option value="">Alegeți țara</option>
+                            <option v-for="tara in countries" :key="tara.id" :value="String(tara.id)">
+                                {{ tara.nume }}
+                            </option>
+                        </select>
+                        <div v-if="formErrors.incarcare_tara_id" class="text-danger small mt-1">
+                            {{ formErrors.incarcare_tara_id[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <LocalitateAutocomplete
+                            id="descarcare-localitate"
+                            label="Localitate descărcare"
+                            :endpoint="localitatiEndpoint"
+                            v-model="form.descarcare_localitate"
+                            :disabled="saving"
+                        />
+                        <div v-if="formErrors.descarcare_localitate" class="text-danger small mt-1">
+                            {{ formErrors.descarcare_localitate[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label for="descarcare_cod_postal" class="form-label">Cod poștal descărcare</label>
+                        <input
+                            id="descarcare_cod_postal"
+                            type="text"
+                            class="form-control"
+                            v-model="form.descarcare_cod_postal"
+                            :disabled="saving"
+                        >
+                        <div v-if="formErrors.descarcare_cod_postal" class="text-danger small mt-1">
+                            {{ formErrors.descarcare_cod_postal[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label for="descarcare_tara_id" class="form-label">Țară descărcare</label>
+                        <select
+                            id="descarcare_tara_id"
+                            class="form-select"
+                            v-model="form.descarcare_tara_id"
+                            :disabled="saving"
+                        >
+                            <option value="">Alegeți țara</option>
+                            <option v-for="tara in countries" :key="tara.id" :value="String(tara.id)">
+                                {{ tara.nume }}
+                            </option>
+                        </select>
+                        <div v-if="formErrors.descarcare_tara_id" class="text-danger small mt-1">
+                            {{ formErrors.descarcare_tara_id[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label for="data_cursa_date" class="form-label">Data cursei</label>
+                        <input
+                            id="data_cursa_date"
+                            type="date"
+                            class="form-control"
+                            v-model="form.data_cursa_date"
+                            :disabled="saving"
+                        >
+                        <div v-if="formErrors.data_cursa || formErrors.data_cursa_date" class="text-danger small mt-1">
+                            {{ resolveError('data_cursa_date') }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6" v-if="showTimeField">
+                        <label for="data_cursa_time" class="form-label">Ora cursei</label>
+                        <input
+                            id="data_cursa_time"
+                            type="time"
+                            class="form-control"
+                            v-model="form.data_cursa_time"
+                            :disabled="saving"
+                        >
+                        <div v-if="formErrors.data_cursa_time" class="text-danger small mt-1">
+                            {{ formErrors.data_cursa_time[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12" v-else>
+                        <button type="button" class="btn btn-outline-secondary w-100" @click="manualTimeToggle = true">
+                            Adaugă ora cursei (opțional)
+                        </button>
+                    </div>
+                    <div class="col-12">
+                        <label for="observatii" class="form-label">Observații</label>
+                        <textarea
+                            id="observatii"
+                            class="form-control"
+                            rows="3"
+                            v-model="form.observatii"
+                            :disabled="saving"
+                        ></textarea>
+                        <div v-if="formErrors.observatii" class="text-danger small mt-1">
+                            {{ formErrors.observatii[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label for="km_bord" class="form-label">KM bord</label>
+                        <input
+                            id="km_bord"
+                            type="number"
+                            class="form-control"
+                            min="0"
+                            v-model="form.km_bord"
+                            :disabled="saving"
+                        >
+                        <div v-if="formErrors.km_bord" class="text-danger small mt-1">
+                            {{ formErrors.km_bord[0] }}
+                        </div>
+                    </div>
+                    <div class="col-12 d-flex gap-3 flex-wrap">
+                        <button type="submit" class="btn btn-success btn-lg" :disabled="saving">
+                            {{ saving ? 'Se salvează...' : 'Salvează' }}
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary btn-lg" :disabled="saving" @click="cancelForm">
+                            Anulează
+                        </button>
+                    </div>
+                </form>
+            </section>
+
+            <section class="mt-5">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h3 class="fs-5 mb-0">Curse înregistrate</h3>
+                    <button
+                        v-if="!isFormVisible"
+                        type="button"
+                        class="btn btn-outline-primary btn-lg"
+                        @click="startCreate"
+                    >
+                        Adaugă cursă
+                    </button>
+                </div>
+                <div v-if="valabilitate.curse && valabilitate.curse.length" class="d-flex flex-column gap-3">
+                    <article v-for="cursa in valabilitate.curse" :key="cursa.id" class="border rounded-4 p-3">
+                        <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                            <div>
+                                <p class="fw-semibold mb-1">{{ cursa.incarcare_localitate }} → {{ cursa.descarcare_localitate }}</p>
+                                <p class="mb-0 text-muted small">
+                                    {{ formatDateTime(cursa) }} · {{ cursa.descarcare_tara ?? 'Țară nedefinită' }}
+                                </p>
+                            </div>
+                            <div class="d-flex flex-column gap-2">
+                                <button type="button" class="btn btn-outline-secondary btn-lg" @click="startEdit(cursa)">
+                                    Editează
+                                </button>
+                                <button type="button" class="btn btn-outline-danger btn-lg" @click="requestDelete(cursa)">
+                                    Șterge
+                                </button>
+                            </div>
+                        </div>
+                        <div v-if="cursa.observatii" class="mt-3 text-muted">
+                            {{ cursa.observatii }}
+                        </div>
+                    </article>
+                </div>
+                <div v-else class="alert alert-light border rounded-4">
+                    Nu au fost adăugate curse pentru această valabilitate.
+                </div>
+            </section>
+        </template>
+    </div>
+</template>
+
+<script setup>
+import { computed, reactive, ref, watch } from 'vue';
+import LocalitateAutocomplete from './LocalitateAutocomplete.vue';
+
+const props = defineProps({
+    valabilitate: {
+        type: Object,
+        required: true,
+    },
+    countries: {
+        type: Array,
+        default: () => [],
+    },
+    romaniaId: {
+        type: [Number, null],
+        default: null,
+    },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
+    saving: {
+        type: Boolean,
+        default: false,
+    },
+    createCursa: {
+        type: Function,
+        required: true,
+    },
+    updateCursa: {
+        type: Function,
+        required: true,
+    },
+    deleteCursa: {
+        type: Function,
+        required: true,
+    },
+    localitatiEndpoint: {
+        type: String,
+        required: true,
+    },
+});
+
+const formMode = ref(null);
+const form = reactive(defaultForm());
+const formErrors = reactive({});
+const generalError = ref('');
+const manualTimeToggle = ref(false);
+
+const isFormVisible = computed(() => formMode.value !== null);
+const formTitle = computed(() => (formMode.value === 'edit' ? 'Editează cursa' : 'Adaugă cursă'));
+
+const intervalLabel = computed(() => {
+    const start = props.valabilitate.data_inceput ? new Date(props.valabilitate.data_inceput) : null;
+    const end = props.valabilitate.data_sfarsit ? new Date(props.valabilitate.data_sfarsit) : null;
+    const options = { year: 'numeric', month: 'long', day: 'numeric' };
+
+    if (start && end) {
+        return `${start.toLocaleDateString(undefined, options)} – ${end.toLocaleDateString(undefined, options)}`;
+    }
+
+    if (start) {
+        return `Din ${start.toLocaleDateString(undefined, options)}`;
+    }
+
+    if (end) {
+        return `Până la ${end.toLocaleDateString(undefined, options)}`;
+    }
+
+    return 'Interval necunoscut';
+});
+
+const requiresOra = computed(() => {
+    if (! isFormVisible.value) {
+        return false;
+    }
+
+    const descarcareId = form.descarcare_tara_id ? parseInt(form.descarcare_tara_id, 10) : null;
+
+    if (props.romaniaId !== null && descarcareId === props.romaniaId) {
+        return true;
+    }
+
+    if (formMode.value === 'create') {
+        return ! (props.valabilitate.has_curse ?? false);
+    }
+
+    if (formMode.value === 'edit') {
+        return props.valabilitate.first_cursa_id === form.id;
+    }
+
+    return false;
+});
+
+const showTimeField = computed(() => requiresOra.value || manualTimeToggle.value || !!form.data_cursa_time);
+
+watch(
+    () => props.valabilitate,
+    () => {
+        resetForm();
+    },
+    { deep: true },
+);
+
+watch(
+    () => form.descarcare_tara_id,
+    (newValue, oldValue) => {
+        if (! newValue || props.romaniaId === null) {
+            return;
+        }
+
+        const parsedNew = parseInt(newValue, 10);
+        const parsedOld = oldValue ? parseInt(oldValue, 10) : null;
+
+        if (parsedNew === props.romaniaId && parsedOld !== props.romaniaId) {
+            const confirmed = window.confirm('Descărcarea în România necesită completarea orei. Continuați?');
+
+            if (! confirmed) {
+                form.descarcare_tara_id = oldValue ?? '';
+            }
+        }
+    },
+);
+
+function defaultForm() {
+    return {
+        id: null,
+        incarcare_localitate: '',
+        incarcare_cod_postal: '',
+        incarcare_tara_id: '',
+        descarcare_localitate: '',
+        descarcare_cod_postal: '',
+        descarcare_tara_id: '',
+        data_cursa_date: '',
+        data_cursa_time: '',
+        observatii: '',
+        km_bord: '',
+    };
+}
+
+function resetForm() {
+    Object.assign(form, defaultForm());
+    Object.keys(formErrors).forEach((key) => delete formErrors[key]);
+    generalError.value = '';
+    formMode.value = null;
+    manualTimeToggle.value = false;
+}
+
+function startCreate() {
+    resetForm();
+    formMode.value = 'create';
+}
+
+function startEdit(cursa) {
+    resetForm();
+    formMode.value = 'edit';
+    form.id = cursa.id;
+    form.incarcare_localitate = cursa.incarcare_localitate ?? '';
+    form.incarcare_cod_postal = cursa.incarcare_cod_postal ?? '';
+    form.incarcare_tara_id = cursa.incarcare_tara_id ? String(cursa.incarcare_tara_id) : '';
+    form.descarcare_localitate = cursa.descarcare_localitate ?? '';
+    form.descarcare_cod_postal = cursa.descarcare_cod_postal ?? '';
+    form.descarcare_tara_id = cursa.descarcare_tara_id ? String(cursa.descarcare_tara_id) : '';
+    form.data_cursa_date = cursa.data_date ?? '';
+    form.data_cursa_time = cursa.data_time ?? '';
+    form.observatii = cursa.observatii ?? '';
+    form.km_bord = cursa.km_bord ?? '';
+    manualTimeToggle.value = !! form.data_cursa_time;
+}
+
+function cancelForm() {
+    resetForm();
+}
+
+function resolveError(field) {
+    if (formErrors[field]) {
+        return formErrors[field][0];
+    }
+
+    if (formErrors.data_cursa) {
+        return formErrors.data_cursa[0];
+    }
+
+    return null;
+}
+
+async function submitForm() {
+    Object.keys(formErrors).forEach((key) => delete formErrors[key]);
+    generalError.value = '';
+
+    const payload = {
+        incarcare_localitate: form.incarcare_localitate,
+        incarcare_cod_postal: form.incarcare_cod_postal,
+        incarcare_tara_id: form.incarcare_tara_id || null,
+        descarcare_localitate: form.descarcare_localitate,
+        descarcare_cod_postal: form.descarcare_cod_postal,
+        descarcare_tara_id: form.descarcare_tara_id || null,
+        data_cursa_date: form.data_cursa_date || null,
+        data_cursa_time: showTimeField.value ? (form.data_cursa_time || null) : null,
+        observatii: form.observatii,
+        km_bord: form.km_bord === '' ? null : form.km_bord,
+    };
+
+    try {
+        if (formMode.value === 'edit') {
+            await props.updateCursa(form.id, payload);
+        } else {
+            await props.createCursa(payload);
+        }
+
+        resetForm();
+    } catch (error) {
+        if (error?.type === 'validation') {
+            Object.assign(formErrors, error.errors ?? {});
+            generalError.value = 'Verificați câmpurile marcate și încercați din nou.';
+        } else {
+            generalError.value = 'A apărut o eroare neașteptată. Încercați mai târziu.';
+            console.error(error);
+        }
+    }
+}
+
+async function requestDelete(cursa) {
+    const confirmed = window.confirm('Sigur doriți să ștergeți această cursă?');
+
+    if (! confirmed) {
+        return;
+    }
+
+    try {
+        await props.deleteCursa(cursa.id);
+    } catch (error) {
+        console.error(error);
+        generalError.value = 'Cursa nu a putut fi ștearsă. Încercați din nou.';
+    }
+}
+
+function formatDateTime(cursa) {
+    if (! cursa.data_date) {
+        return 'Dată necompletată';
+    }
+
+    const date = new Date(`${cursa.data_date}T${cursa.data_time ?? '00:00'}`);
+    const dateOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+
+    if (cursa.data_time) {
+        return `${date.toLocaleDateString(undefined, dateOptions)} · ${cursa.data_time}`;
+    }
+
+    return date.toLocaleDateString(undefined, dateOptions);
+}
+</script>

--- a/resources/js/components/driver/ValabilitateList.vue
+++ b/resources/js/components/driver/ValabilitateList.vue
@@ -1,0 +1,83 @@
+<template>
+    <div>
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2 class="fs-5 mb-0">Valabilitățile mele</h2>
+            <button class="btn btn-sm btn-outline-primary" type="button" @click="$emit('refresh')" :disabled="loading">
+                <i class="fa-solid fa-rotate"></i>
+                <span class="ms-1">Actualizează</span>
+            </button>
+        </div>
+
+        <div v-if="loading" class="text-center py-5">
+            <div class="spinner-border text-primary" role="status">
+                <span class="visually-hidden">Încărcare...</span>
+            </div>
+        </div>
+
+        <div v-else-if="valabilitati.length === 0" class="alert alert-light border rounded-4" role="status">
+            Nu există valabilități active alocate utilizatorului curent.
+        </div>
+
+        <div v-else class="driver-scroll pe-1">
+            <button
+                v-for="item in valabilitati"
+                :key="item.id"
+                type="button"
+                class="driver-card-button w-100 text-start p-4 mb-3"
+                :class="{ active: item.id === selectedId }"
+                @click="$emit('select', item.id)"
+            >
+                <div class="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                    <div>
+                        <span class="d-block fw-semibold">{{ item.denumire }}</span>
+                        <span class="text-muted small">{{ item.numar_auto }}</span>
+                    </div>
+                    <span class="badge bg-primary rounded-pill px-3 py-2">
+                        {{ item.curse_count }} {{ item.curse_count === 1 ? 'cursă' : 'curse' }}
+                    </span>
+                </div>
+                <div class="mt-3 text-muted small">
+                    {{ formatInterval(item) }}
+                </div>
+            </button>
+        </div>
+    </div>
+</template>
+
+<script setup>
+const props = defineProps({
+    valabilitati: {
+        type: Array,
+        default: () => [],
+    },
+    selectedId: {
+        type: Number,
+        default: null,
+    },
+    loading: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+function formatInterval(item) {
+    const start = item.data_inceput ? new Date(item.data_inceput) : null;
+    const end = item.data_sfarsit ? new Date(item.data_sfarsit) : null;
+
+    const formatOptions = { year: 'numeric', month: 'short', day: 'numeric' };
+
+    if (start && end) {
+        return `${start.toLocaleDateString(undefined, formatOptions)} – ${end.toLocaleDateString(undefined, formatOptions)}`;
+    }
+
+    if (start) {
+        return `Din ${start.toLocaleDateString(undefined, formatOptions)}`;
+    }
+
+    if (end) {
+        return `Până la ${end.toLocaleDateString(undefined, formatOptions)}`;
+    }
+
+    return 'Interval necunoscut';
+}
+</script>

--- a/resources/js/driver.js
+++ b/resources/js/driver.js
@@ -1,0 +1,40 @@
+import './bootstrap';
+import '../sass/driver.scss';
+
+import { createApp } from 'vue';
+import DriverApp from './components/driver/DriverApp.vue';
+
+const element = document.getElementById('driver-app');
+
+if (element) {
+    const props = {
+        valabilitatiEndpoint: element.dataset.valabilitatiEndpoint,
+        localitatiEndpoint: element.dataset.localitatiEndpoint,
+        tari: [],
+        romaniaId: null,
+        initialValabilitati: [],
+    };
+
+    if (element.dataset.tari) {
+        try {
+            props.tari = JSON.parse(element.dataset.tari);
+        } catch (error) {
+            console.error('Nu s-au putut încărca țările', error);
+        }
+    }
+
+    if (element.dataset.romaniaId) {
+        const parsed = parseInt(element.dataset.romaniaId, 10);
+        props.romaniaId = Number.isNaN(parsed) ? null : parsed;
+    }
+
+    if (element.dataset.initialValabilitati) {
+        try {
+            props.initialValabilitati = JSON.parse(element.dataset.initialValabilitati);
+        } catch (error) {
+            console.warn('Datele inițiale pentru valabilități nu au putut fi interpretate.', error);
+        }
+    }
+
+    createApp(DriverApp, props).mount(element);
+}

--- a/resources/sass/driver.scss
+++ b/resources/sass/driver.scss
@@ -1,0 +1,70 @@
+.driver-layout {
+    min-height: 100vh;
+}
+
+.driver-shell {
+    min-height: 60vh;
+}
+
+.driver-card-button {
+    border: 0;
+    border-radius: 1rem;
+    transition: transform .15s ease, box-shadow .15s ease;
+    background-color: #ffffff;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, .08);
+}
+
+.driver-card-button:focus,
+.driver-card-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, .15);
+}
+
+.driver-card-button.active {
+    border: 2px solid #0d6efd;
+}
+
+.driver-scroll {
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+.driver-form-section {
+    background-color: #ffffff;
+    border-radius: 1.25rem;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, .08);
+}
+
+.driver-form-section .form-control,
+.driver-form-section .form-select,
+.driver-form-section button {
+    min-height: 48px;
+    font-size: 1rem;
+}
+
+.driver-autocomplete {
+    position: relative;
+}
+
+.driver-autocomplete__list {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    max-height: 240px;
+    overflow-y: auto;
+    background: #ffffff;
+    border-radius: .75rem;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, .12);
+}
+
+.driver-autocomplete__item {
+    cursor: pointer;
+    padding: .75rem 1rem;
+}
+
+.driver-autocomplete__item:hover,
+.driver-autocomplete__item:focus {
+    background-color: #f1f5f9;
+}

--- a/resources/views/driver/dashboard.blade.php
+++ b/resources/views/driver/dashboard.blade.php
@@ -1,0 +1,15 @@
+@extends('layouts.driver')
+
+@section('title', __('Zona șoferului'))
+
+@section('content')
+    <div
+        id="driver-app"
+        data-valabilitati-endpoint="{{ route('driver.api.valabilitati.index') }}"
+        data-localitati-endpoint="{{ route('driver.api.localitati.index') }}"
+        data-tari='@json($tari)'
+        data-romania-id="{{ $romaniaId ?? '' }}"
+        data-initial-valabilitati='@json($valabilitati)'
+        class="driver-shell"
+    ></div>
+@endsection

--- a/resources/views/layouts/driver.blade.php
+++ b/resources/views/layouts/driver.blade.php
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+
+    <title>@yield('title', config('app.name'))</title>
+
+    @vite(['resources/js/driver.js'])
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-Xx9x5xukdxbYF9bBlt3FqMsTnA4wZ0UnvItg5jGJPD7W82dManIeZDV4SSQdlqzTeWY5Avzkdxl3pNGdisz8ig==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+    @stack('driver-styles')
+</head>
+<body class="driver-layout bg-light">
+    <header class="driver-header shadow-sm bg-white">
+        <div class="container py-3 d-flex justify-content-between align-items-center">
+            <div>
+                <h1 class="fs-4 mb-0">@yield('heading', __('Zona șoferului'))</h1>
+                <p class="mb-0 text-muted small">{{ __('Gestionați cursele active rapid și în siguranță.') }}</p>
+            </div>
+            <div class="text-end">
+                <a href="{{ route('logout') }}" class="btn btn-outline-secondary btn-sm"
+                   onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                    {{ __('Deconectare') }}
+                </a>
+                <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
+                    @csrf
+                </form>
+            </div>
+        </div>
+    </header>
+
+    <main class="py-4">
+        <div class="container">
+            @yield('content')
+        </div>
+    </main>
+
+    @stack('driver-scripts')
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,10 @@ use App\Http\Controllers\Masini\MasiniMementoController;
 use App\Http\Controllers\DocumentWordController;
 use App\Http\Controllers\KeyPerformanceIndicatorController;
 use App\Http\Controllers\OfertaCursaController;
+use App\Http\Controllers\Driver\DashboardController as DriverDashboardController;
+use App\Http\Controllers\Driver\ValabilitateController as DriverValabilitateController;
+use App\Http\Controllers\Driver\CursaController as DriverCursaController;
+use App\Http\Controllers\Driver\LocalitateController as DriverLocalitateController;
 use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorController;
 use App\Http\Controllers\FacturiFurnizori\FacturaFurnizorFisierController;
 use App\Http\Controllers\FacturiFurnizori\PlataCalupController;
@@ -90,6 +94,26 @@ Route::get('oferte-curse', [OfertaCursaController::class, 'index'])->name('ofert
 Route::redirect('/', '/acasa');
 
 Route::middleware(['auth'])->group(function () {
+    Route::prefix('driver')
+        ->name('driver.')
+        ->middleware('role:soferi')
+        ->group(function () {
+            Route::get('/', DriverDashboardController::class)->name('dashboard');
+
+            Route::get('/api/valabilitati', [DriverValabilitateController::class, 'index'])
+                ->name('api.valabilitati.index');
+            Route::get('/api/valabilitati/{valabilitate}', [DriverValabilitateController::class, 'show'])
+                ->name('api.valabilitati.show');
+            Route::post('/api/valabilitati/{valabilitate}/curse', [DriverCursaController::class, 'store'])
+                ->name('api.valabilitati.curse.store');
+            Route::put('/api/valabilitati/{valabilitate}/curse/{cursa}', [DriverCursaController::class, 'update'])
+                ->name('api.valabilitati.curse.update');
+            Route::delete('/api/valabilitati/{valabilitate}/curse/{cursa}', [DriverCursaController::class, 'destroy'])
+                ->name('api.valabilitati.curse.destroy');
+            Route::get('/api/localitati', DriverLocalitateController::class)
+                ->name('api.localitati.index');
+        });
+
     Route::middleware('role:sofer')->group(function () {
         Route::get('sofer/dashboard', SoferDashboardController::class)->name('sofer.dashboard');
     });

--- a/tests/Feature/Driver/DriverValabilitateTest.php
+++ b/tests/Feature/Driver/DriverValabilitateTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tests\Feature\Driver;
+
+use App\Models\Role;
+use App\Models\Tara;
+use App\Models\User;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DriverValabilitateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_driver_routes_require_soferi_role(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $this->get('/driver')->assertStatus(403);
+
+        $driver = User::factory()->create();
+        $this->assignDriverRole($driver);
+
+        $this->actingAs($driver);
+
+        $this->get('/driver')->assertOk();
+    }
+
+    public function test_active_valabilitati_are_filtered_for_driver(): void
+    {
+        Carbon::setTestNow('2025-04-01');
+
+        $driver = User::factory()->create();
+        $this->assignDriverRole($driver);
+
+        $active = Valabilitate::factory()->create([
+            'sofer_id' => $driver->id,
+            'data_inceput' => now()->subDay()->toDateString(),
+            'data_sfarsit' => now()->addWeek()->toDateString(),
+        ]);
+
+        Valabilitate::factory()->create([
+            'sofer_id' => $driver->id,
+            'data_inceput' => now()->addDay()->toDateString(),
+            'data_sfarsit' => now()->addDays(10)->toDateString(),
+        ]);
+
+        Valabilitate::factory()->create(); // another driver
+
+        $this->actingAs($driver);
+
+        $response = $this->getJson(route('driver.api.valabilitati.index'));
+
+        $response
+            ->assertOk()
+            ->assertJsonCount(1, 'valabilitati')
+            ->assertJsonPath('valabilitati.0.id', $active->id);
+
+        $this->getJson(route('driver.api.valabilitati.show', $active))
+            ->assertOk()
+            ->assertJsonPath('valabilitate.id', $active->id);
+    }
+
+    public function test_first_cursa_requires_time(): void
+    {
+        Carbon::setTestNow('2025-04-01');
+
+        $driver = User::factory()->create();
+        $this->assignDriverRole($driver);
+
+        $valabilitate = Valabilitate::factory()->create([
+            'sofer_id' => $driver->id,
+            'data_inceput' => now()->subDay()->toDateString(),
+            'data_sfarsit' => now()->addDays(3)->toDateString(),
+        ]);
+
+        $tara = Tara::factory()->create();
+
+        $payload = [
+            'incarcare_localitate' => 'Cluj',
+            'incarcare_cod_postal' => '12345',
+            'incarcare_tara_id' => $tara->id,
+            'descarcare_localitate' => 'Arad',
+            'descarcare_cod_postal' => '67890',
+            'descarcare_tara_id' => $tara->id,
+            'data_cursa_date' => now()->toDateString(),
+            'data_cursa_time' => '',
+        ];
+
+        $this->actingAs($driver);
+
+        $this->postJson(route('driver.api.valabilitati.curse.store', $valabilitate), $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['data_cursa_time']);
+
+        $payload['data_cursa_time'] = '08:30';
+
+        $this->postJson(route('driver.api.valabilitati.curse.store', $valabilitate), $payload)
+            ->assertOk()
+            ->assertJsonPath('valabilitate.curse.0.data_time', '08:30');
+    }
+
+    public function test_romania_descarcare_requires_time(): void
+    {
+        Carbon::setTestNow('2025-04-01');
+
+        $driver = User::factory()->create();
+        $this->assignDriverRole($driver);
+
+        $romania = Tara::factory()->create(['nume' => 'Romania']);
+        $germany = Tara::factory()->create(['nume' => 'Germania']);
+
+        $valabilitate = Valabilitate::factory()->create([
+            'sofer_id' => $driver->id,
+            'data_inceput' => now()->subDay()->toDateString(),
+            'data_sfarsit' => now()->addDays(3)->toDateString(),
+        ]);
+
+        ValabilitateCursa::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'incarcare_tara_id' => $germany->id,
+            'descarcare_tara_id' => $germany->id,
+            'data_cursa' => now()->subDay()->setTime(7, 0),
+        ]);
+
+        $payload = [
+            'incarcare_localitate' => 'Berlin',
+            'incarcare_cod_postal' => '10115',
+            'incarcare_tara_id' => $germany->id,
+            'descarcare_localitate' => 'Cluj',
+            'descarcare_cod_postal' => '400000',
+            'descarcare_tara_id' => $romania->id,
+            'data_cursa_date' => now()->toDateString(),
+            'data_cursa_time' => '',
+        ];
+
+        $this->actingAs($driver);
+
+        $this->postJson(route('driver.api.valabilitati.curse.store', $valabilitate), $payload)
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['data_cursa_time']);
+
+        $payload['data_cursa_time'] = '10:15';
+
+        $this->postJson(route('driver.api.valabilitati.curse.store', $valabilitate), $payload)
+            ->assertOk()
+            ->assertJsonPath('valabilitate.curse.1.data_time', '10:15');
+    }
+
+    private function assignDriverRole(User $user): void
+    {
+        $role = Role::query()->firstOrCreate(
+            ['slug' => 'soferi'],
+            ['name' => 'Șoferi']
+        );
+
+        $user->roles()->attach($role);
+    }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
             input: [
                 'resources/sass/app.scss',
                 'resources/js/app.js',
+                'resources/js/driver.js',
             ],
             refresh: true,
         }),


### PR DESCRIPTION
## Summary
- introduce an authenticated /driver namespace guarded by the soferi role with a dedicated layout for mobile drivers
- expose driver-focused JSON endpoints and validation enforcing active-valabilitate access and the ora business rules for curse
- build a Vue-based driver dashboard with autocomplete-powered forms for managing valabilitati and curse details

## Testing
- php artisan test --testsuite=Feature --filter=DriverValabilitateTest *(fails: Composer requires a GitHub token to install dependencies in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914c45dae0c8326ac4eded7d1c62701)