### PR TITLE
Add driver valabilitate management workflow

### DIFF
--- a/app/Http/Controllers/SoferDashboardController.php
+++ b/app/Http/Controllers/SoferDashboardController.php
@@ -3,15 +3,35 @@
 namespace App\Http\Controllers;
 
 use App\Models\MasinaValabilitati;
+use App\Models\Valabilitate;
+use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 
 class SoferDashboardController extends Controller
 {
-    public function __invoke()
+    public function __invoke(Request $request)
     {
         $today = Carbon::today();
+        $driver = $request->user();
 
-        $valabilitati = MasinaValabilitati::query()
+        $activeValabilitate = null;
+
+        if ($driver) {
+            $activeValabilitate = Valabilitate::query()
+                ->select(['id', 'numar_auto', 'denumire', 'data_inceput', 'data_sfarsit'])
+                ->where('sofer_id', $driver->id)
+                ->whereDate('data_inceput', '<=', $today)
+                ->where(function ($query) use ($today) {
+                    $query
+                        ->whereNull('data_sfarsit')
+                        ->orWhereDate('data_sfarsit', '>=', $today);
+                })
+                ->withCount('curse')
+                ->orderByDesc('data_inceput')
+                ->first();
+        }
+
+        $legacyValabilitati = MasinaValabilitati::query()
             ->select([
                 'id',
                 'nr_auto',
@@ -57,7 +77,8 @@ class SoferDashboardController extends Controller
             ->get();
 
         return view('sofer.dashboard', [
-            'valabilitati' => $valabilitati,
+            'activeValabilitate' => $activeValabilitate,
+            'legacyValabilitati' => $legacyValabilitati,
         ]);
     }
 }

--- a/app/Http/Controllers/SoferValabilitateCursaController.php
+++ b/app/Http/Controllers/SoferValabilitateCursaController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\SoferValabilitateCursaRequest;
+use App\Models\Tara;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class SoferValabilitateCursaController extends Controller
+{
+    public function show(Request $request, Valabilitate $valabilitate): View
+    {
+        $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
+
+        $valabilitate->load([
+            'curse' => function ($query) {
+                $query->orderBy('data_cursa')->orderBy('id');
+            },
+            'curse.incarcareTara',
+            'curse.descarcareTara',
+        ]);
+
+        $tari = Tara::query()
+            ->orderBy('nume')
+            ->get(['id', 'nume']);
+
+        return view('sofer.valabilitati.show', [
+            'valabilitate' => $valabilitate,
+            'curse' => $valabilitate->curse,
+            'tari' => $tari,
+            'modalKey' => session('sofer_curse_modal'),
+        ]);
+    }
+
+    public function store(SoferValabilitateCursaRequest $request, Valabilitate $valabilitate): RedirectResponse
+    {
+        $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
+
+        $valabilitate->curse()->create($request->validated());
+
+        return redirect()
+            ->route('sofer.valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost adăugată cu succes.');
+    }
+
+    public function update(SoferValabilitateCursaRequest $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): RedirectResponse
+    {
+        $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
+        $this->ensureCursaBelongsToValabilitate($valabilitate, $cursa);
+
+        $cursa->update($request->validated());
+
+        return redirect()
+            ->route('sofer.valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost actualizată.');
+    }
+
+    public function destroy(Request $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): RedirectResponse
+    {
+        $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
+        $this->ensureCursaBelongsToValabilitate($valabilitate, $cursa);
+
+        $cursa->delete();
+
+        return redirect()
+            ->route('sofer.valabilitati.show', $valabilitate)
+            ->with('status', 'Cursa a fost ștearsă.');
+    }
+
+    private function ensureDriverOwnsValabilitate(Request $request, Valabilitate $valabilitate): Valabilitate
+    {
+        $userId = $request->user()?->id;
+
+        abort_unless((int) $valabilitate->sofer_id === (int) $userId, 403);
+
+        return $valabilitate;
+    }
+
+    private function ensureCursaBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void
+    {
+        abort_unless((int) $cursa->valabilitate_id === (int) $valabilitate->id, 404);
+    }
+}

--- a/app/Http/Requests/SoferValabilitateCursaRequest.php
+++ b/app/Http/Requests/SoferValabilitateCursaRequest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Valabilitate;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class SoferValabilitateCursaRequest extends FormRequest
+{
+    protected bool $shouldRequireTime = false;
+
+    public function authorize(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+        $userId = $this->user()?->id;
+
+        if (! $valabilitate instanceof Valabilitate) {
+            return false;
+        }
+
+        return (int) $valabilitate->sofer_id === (int) $userId;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'incarcare_localitate' => ['nullable', 'string', 'max:255'],
+            'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'incarcare_tara_id' => ['nullable', Rule::exists('tari', 'id')],
+            'descarcare_localitate' => ['nullable', 'string', 'max:255'],
+            'descarcare_cod_postal' => ['nullable', 'string', 'max:255'],
+            'descarcare_tara_id' => ['nullable', Rule::exists('tari', 'id')],
+            'data_cursa_date' => ['nullable', 'date'],
+            'data_cursa_time' => ['nullable', 'date_format:H:i'],
+            'data_cursa' => ['nullable', 'date'],
+            'observatii' => ['nullable', 'string'],
+            'km_bord' => ['nullable', 'integer', 'min:0'],
+            'final_return' => ['nullable', 'boolean'],
+            'form_type' => ['nullable', 'string'],
+            'form_id' => ['nullable', 'integer'],
+        ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->shouldRequireTime = $this->determineIfTimeIsRequired();
+
+        $dateInput = $this->input('data_cursa_date');
+        $timeInput = $this->input('data_cursa_time');
+
+        if ($dateInput === null && $timeInput === null) {
+            return;
+        }
+
+        $date = trim((string) $dateInput);
+        $time = trim((string) $timeInput);
+
+        if ($date === '') {
+            $this->merge(['data_cursa' => null]);
+
+            return;
+        }
+
+        if ($time === '') {
+            $time = '00:00';
+        }
+
+        $this->merge([
+            'data_cursa' => sprintf('%s %s', $date, $time),
+        ]);
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        $validated = parent::validated($key, $default);
+
+        unset(
+            $validated['data_cursa_date'],
+            $validated['data_cursa_time'],
+            $validated['final_return'],
+            $validated['form_type'],
+            $validated['form_id'],
+        );
+
+        return $validated;
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        if ($this->expectsJson()) {
+            parent::failedValidation($validator);
+
+            return;
+        }
+
+        $valabilitate = $this->route('valabilitate');
+        $modalKey = $this->determineModalKey();
+
+        $response = redirect()
+            ->route('sofer.valabilitati.show', $valabilitate)
+            ->withErrors($validator)
+            ->withInput($this->all())
+            ->with('sofer_curse_modal', $modalKey);
+
+        throw new ValidationException($validator, $response);
+    }
+
+    protected function withValidator($validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if (! $this->shouldRequireTime) {
+                return;
+            }
+
+            $date = trim((string) $this->input('data_cursa_date'));
+            $time = trim((string) $this->input('data_cursa_time'));
+
+            if ($date === '') {
+                $validator->errors()->add('data_cursa_date', 'Completați data cursei.');
+            }
+
+            if ($time === '') {
+                $validator->errors()->add('data_cursa_time', 'Completați ora cursei.');
+            }
+        });
+    }
+
+    private function determineIfTimeIsRequired(): bool
+    {
+        if ($this->boolean('final_return')) {
+            return true;
+        }
+
+        $valabilitate = $this->route('valabilitate');
+
+        if (! $valabilitate instanceof Valabilitate) {
+            return false;
+        }
+
+        if ($this->isMethod('post')) {
+            return ! $valabilitate->curse()->exists();
+        }
+
+        return false;
+    }
+
+    private function determineModalKey(): string
+    {
+        $formType = (string) $this->input('form_type', '');
+
+        if ($formType === 'edit') {
+            $formId = (int) $this->input('form_id');
+
+            return $formId > 0 ? 'edit:' . $formId : 'edit';
+        }
+
+        return 'create';
+    }
+}

--- a/resources/views/sofer/dashboard.blade.php
+++ b/resources/views/sofer/dashboard.blade.php
@@ -10,71 +10,114 @@
         <p class="text-muted small mb-0">Consultați rapid documentele și termenele limită asociate flotei.</p>
     </div>
 
-    @if ($valabilitati->isEmpty())
-        <div class="card border-0 shadow-sm">
+    @if ($activeValabilitate)
+        <article class="card border-0 shadow-sm mb-4">
+            <div class="card-body p-4 p-lg-5">
+                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                    <span class="badge bg-primary text-uppercase fw-semibold px-3 py-2">
+                        {{ $activeValabilitate->numar_auto ?? 'Fără număr' }}
+                    </span>
+                    <span class="text-muted small fw-semibold">
+                        {{ $activeValabilitate->denumire }}
+                    </span>
+                </div>
+
+                <div class="row g-4 align-items-center">
+                    <div class="col-12 col-md">
+                        <p class="text-uppercase text-muted small fw-semibold mb-1">Perioadă valabilitate</p>
+                        <p class="h6 fw-bold mb-0">
+                            {{ optional($activeValabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
+                            <span class="text-muted">–</span>
+                            {{ optional($activeValabilitate->data_sfarsit)->format('d.m.Y') ?? 'Prezent' }}
+                        </p>
+                    </div>
+                    <div class="col-12 col-md-auto text-md-end">
+                        <p class="text-uppercase text-muted small fw-semibold mb-1">Curse înregistrate</p>
+                        <p class="h5 fw-bold mb-2">{{ $activeValabilitate->curse_count }}</p>
+                        <a
+                            href="{{ route('sofer.valabilitati.show', $activeValabilitate) }}"
+                            class="btn btn-primary btn-sm px-4"
+                        >
+                            Gestionează cursele
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </article>
+    @else
+        <div class="card border-0 shadow-sm mb-4">
             <div class="card-body text-center py-5">
                 <i class="fa-solid fa-circle-check fa-3x text-success mb-3"></i>
                 <p class="fw-semibold mb-1">Nu aveți nicio valabilitate activă</p>
                 <p class="text-muted small mb-0">Veți fi notificat de echipă atunci când apar documente noi.</p>
             </div>
         </div>
-    @else
-        <div class="d-flex flex-column gap-3">
-            @foreach ($valabilitati as $valabilitate)
-                <article class="card border-0 shadow-sm">
-                    <div class="card-body p-4">
-                        <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
-                            <span class="badge bg-primary text-uppercase fw-semibold px-3 py-2">
-                                {{ $valabilitate->nr_auto ?? 'Fără număr' }}
-                            </span>
-                            @if ($valabilitate->divizie)
-                                <span class="text-muted small text-uppercase fw-semibold">
-                                    {{ $valabilitate->divizie }}
+    @endif
+
+    @if ($legacyValabilitati->isNotEmpty())
+        <section>
+            <header class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                <h2 class="h6 text-uppercase text-muted mb-0">Istoric valabilități flota</h2>
+                <span class="badge bg-secondary-subtle text-secondary fw-semibold">Arhivă</span>
+            </header>
+
+            <div class="d-flex flex-column gap-3">
+                @foreach ($legacyValabilitati as $valabilitate)
+                    <article class="card border-0 shadow-sm">
+                        <div class="card-body p-4">
+                            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 mb-3">
+                                <span class="badge bg-primary text-uppercase fw-semibold px-3 py-2">
+                                    {{ $valabilitate->nr_auto ?? 'Fără număr' }}
                                 </span>
+                                @if ($valabilitate->divizie)
+                                    <span class="text-muted small text-uppercase fw-semibold">
+                                        {{ $valabilitate->divizie }}
+                                    </span>
+                                @endif
+                            </div>
+
+                            @if ($valabilitate->nume_sofer)
+                                <p class="fw-semibold mb-1">{{ $valabilitate->nume_sofer }}</p>
                             @endif
+
+                            @if ($valabilitate->detalii_sofer)
+                                <p class="text-muted small mb-3">{{ $valabilitate->detalii_sofer }}</p>
+                            @endif
+
+                            <div class="row g-4">
+                                @if ($valabilitate->valabilitate_1_inceput || $valabilitate->valabilitate_1_sfarsit || $valabilitate->observatii_1)
+                                    <div class="col-12 col-md-6">
+                                        <h3 class="h6 text-uppercase text-muted mb-2">Valabilitate 1</h3>
+                                        <p class="mb-1 fw-semibold">
+                                            {{ optional($valabilitate->valabilitate_1_inceput)->format('d.m.Y') ?? '—' }}
+                                            <span class="text-muted">–</span>
+                                            {{ optional($valabilitate->valabilitate_1_sfarsit)->format('d.m.Y') ?? '—' }}
+                                        </p>
+                                        @if ($valabilitate->observatii_1)
+                                            <p class="text-muted small mb-0">{{ $valabilitate->observatii_1 }}</p>
+                                        @endif
+                                    </div>
+                                @endif
+
+                                @if ($valabilitate->valabilitate_2_inceput || $valabilitate->valabilitate_2_sfarsit || $valabilitate->observatii_2)
+                                    <div class="col-12 col-md-6">
+                                        <h3 class="h6 text-uppercase text-muted mb-2">Valabilitate 2</h3>
+                                        <p class="mb-1 fw-semibold">
+                                            {{ optional($valabilitate->valabilitate_2_inceput)->format('d.m.Y') ?? '—' }}
+                                            <span class="text-muted">–</span>
+                                            {{ optional($valabilitate->valabilitate_2_sfarsit)->format('d.m.Y') ?? '—' }}
+                                        </p>
+                                        @if ($valabilitate->observatii_2)
+                                            <p class="text-muted small mb-0">{{ $valabilitate->observatii_2 }}</p>
+                                        @endif
+                                    </div>
+                                @endif
+                            </div>
                         </div>
-
-                        @if ($valabilitate->nume_sofer)
-                            <p class="fw-semibold mb-1">{{ $valabilitate->nume_sofer }}</p>
-                        @endif
-
-                        @if ($valabilitate->detalii_sofer)
-                            <p class="text-muted small mb-3">{{ $valabilitate->detalii_sofer }}</p>
-                        @endif
-
-                        <div class="row g-4">
-                            @if ($valabilitate->valabilitate_1_inceput || $valabilitate->valabilitate_1_sfarsit || $valabilitate->observatii_1)
-                                <div class="col-12 col-md-6">
-                                    <h2 class="h6 text-uppercase text-muted mb-2">Valabilitate 1</h2>
-                                    <p class="mb-1 fw-semibold">
-                                        {{ optional($valabilitate->valabilitate_1_inceput)->format('d.m.Y') ?? '—' }}
-                                        <span class="text-muted">–</span>
-                                        {{ optional($valabilitate->valabilitate_1_sfarsit)->format('d.m.Y') ?? '—' }}
-                                    </p>
-                                    @if ($valabilitate->observatii_1)
-                                        <p class="text-muted small mb-0">{{ $valabilitate->observatii_1 }}</p>
-                                    @endif
-                                </div>
-                            @endif
-
-                            @if ($valabilitate->valabilitate_2_inceput || $valabilitate->valabilitate_2_sfarsit || $valabilitate->observatii_2)
-                                <div class="col-12 col-md-6">
-                                    <h2 class="h6 text-uppercase text-muted mb-2">Valabilitate 2</h2>
-                                    <p class="mb-1 fw-semibold">
-                                        {{ optional($valabilitate->valabilitate_2_inceput)->format('d.m.Y') ?? '—' }}
-                                        <span class="text-muted">–</span>
-                                        {{ optional($valabilitate->valabilitate_2_sfarsit)->format('d.m.Y') ?? '—' }}
-                                    </p>
-                                    @if ($valabilitate->observatii_2)
-                                        <p class="text-muted small mb-0">{{ $valabilitate->observatii_2 }}</p>
-                                    @endif
-                                </div>
-                            @endif
-                        </div>
-                    </div>
-                </article>
-            @endforeach
-        </div>
+                    </article>
+                @endforeach
+            </div>
+        </section>
     @endif
 </div>
 @endsection

--- a/resources/views/sofer/valabilitati/partials/cursa-form.blade.php
+++ b/resources/views/sofer/valabilitati/partials/cursa-form.blade.php
@@ -1,0 +1,230 @@
+@php
+    $formType = $formType ?? 'create';
+    $formId = $formId ?? null;
+    $modalId = $modalId ?? 'cursaCreateModal';
+    $modalTitle = $modalTitle ?? 'Cursă';
+    $submitLabel = $submitLabel ?? 'Salvează';
+    $cursa = $cursa ?? null;
+    $tari = $tari ?? collect();
+    $requiresTimeByDefault = $requiresTimeByDefault ?? false;
+    $lockTime = $lockTime ?? false;
+
+    $modalKey = $formType === 'edit' ? 'edit:' . $formId : 'create';
+    $oldMatches = old('form_type') === $formType && ($formType === 'create' || (int) old('form_id') === (int) $formId);
+
+    $value = static function (string $field, $default, bool $useOld) {
+        return $useOld ? old($field, $default) : $default;
+    };
+
+    $dateDefault = optional(optional($cursa)->data_cursa)->format('Y-m-d');
+    $timeDefault = optional(optional($cursa)->data_cursa)->format('H:i');
+
+    $dateValue = $value('data_cursa_date', $dateDefault, $oldMatches);
+    $timeValue = $value('data_cursa_time', $timeDefault, $oldMatches);
+
+    $finalReturnValue = (int) $value('final_return', 0, $oldMatches);
+
+    $showTime = $requiresTimeByDefault || $lockTime;
+
+    if ($oldMatches) {
+        $showTime = (bool) old('final_return', $showTime);
+        if (! $showTime && filled($timeValue)) {
+            $showTime = true;
+        }
+    } elseif (! $showTime && filled($timeValue)) {
+        $showTime = true;
+    }
+
+    $showErrors = $oldMatches;
+    $requireTimeDefault = $requiresTimeByDefault || $finalReturnValue === 1;
+@endphp
+
+<div
+    class="modal fade"
+    id="{{ $modalId }}"
+    tabindex="-1"
+    aria-hidden="true"
+    data-modal-key="{{ $modalKey }}"
+>
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <form
+            method="POST"
+            action="{{ $formAction }}"
+            class="modal-content border-0 shadow-sm"
+            data-cursa-form
+            data-initial-time-visible="{{ $showTime ? 'true' : 'false' }}"
+            data-lock-time-visible="{{ $lockTime ? 'true' : 'false' }}"
+            data-require-time-default="{{ $requireTimeDefault ? 'true' : 'false' }}"
+            data-initial-final-return="{{ $finalReturnValue }}"
+        >
+            @csrf
+            @if ($method !== 'POST')
+                @method($method)
+            @endif
+
+            <input type="hidden" name="form_type" value="{{ $formType }}">
+            @if ($formType === 'edit')
+                <input type="hidden" name="form_id" value="{{ $formId }}">
+            @endif
+            <input type="hidden" name="final_return" value="{{ $finalReturnValue }}" data-final-return-input>
+
+            <div class="modal-header border-0 pb-0">
+                <h2 class="h5 modal-title fw-bold">{{ $modalTitle }}</h2>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Închide"></button>
+            </div>
+
+            <div class="modal-body">
+                <div class="row g-3">
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Localitate încărcare</label>
+                        <input
+                            type="text"
+                            name="incarcare_localitate"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('incarcare_localitate')) is-invalid @endif"
+                            value="{{ $value('incarcare_localitate', optional($cursa)->incarcare_localitate, $oldMatches) }}"
+                            autocomplete="off"
+                        >
+                        @if ($showErrors && $errors->has('incarcare_localitate'))
+                            <div class="invalid-feedback">{{ $errors->first('incarcare_localitate') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Cod poștal încărcare</label>
+                        <input
+                            type="text"
+                            name="incarcare_cod_postal"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('incarcare_cod_postal')) is-invalid @endif"
+                            value="{{ $value('incarcare_cod_postal', optional($cursa)->incarcare_cod_postal, $oldMatches) }}"
+                            autocomplete="off"
+                        >
+                        @if ($showErrors && $errors->has('incarcare_cod_postal'))
+                            <div class="invalid-feedback">{{ $errors->first('incarcare_cod_postal') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Țara încărcării</label>
+                        <select
+                            name="incarcare_tara_id"
+                            class="form-select form-select-sm @if ($showErrors && $errors->has('incarcare_tara_id')) is-invalid @endif"
+                        >
+                            <option value="">Selectați țara</option>
+                            @foreach ($tari as $tara)
+                                <option
+                                    value="{{ $tara->id }}"
+                                    @selected((int) $value('incarcare_tara_id', optional($cursa)->incarcare_tara_id, $oldMatches) === (int) $tara->id)
+                                >
+                                    {{ $tara->nume }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @if ($showErrors && $errors->has('incarcare_tara_id'))
+                            <div class="invalid-feedback">{{ $errors->first('incarcare_tara_id') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Localitate descărcare</label>
+                        <input
+                            type="text"
+                            name="descarcare_localitate"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('descarcare_localitate')) is-invalid @endif"
+                            value="{{ $value('descarcare_localitate', optional($cursa)->descarcare_localitate, $oldMatches) }}"
+                            autocomplete="off"
+                        >
+                        @if ($showErrors && $errors->has('descarcare_localitate'))
+                            <div class="invalid-feedback">{{ $errors->first('descarcare_localitate') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Cod poștal descărcare</label>
+                        <input
+                            type="text"
+                            name="descarcare_cod_postal"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('descarcare_cod_postal')) is-invalid @endif"
+                            value="{{ $value('descarcare_cod_postal', optional($cursa)->descarcare_cod_postal, $oldMatches) }}"
+                            autocomplete="off"
+                        >
+                        @if ($showErrors && $errors->has('descarcare_cod_postal'))
+                            <div class="invalid-feedback">{{ $errors->first('descarcare_cod_postal') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Țara descărcării</label>
+                        <select
+                            name="descarcare_tara_id"
+                            class="form-select form-select-sm @if ($showErrors && $errors->has('descarcare_tara_id')) is-invalid @endif"
+                            data-descarcare-select
+                        >
+                            <option value="">Selectați țara</option>
+                            @foreach ($tari as $tara)
+                                <option
+                                    value="{{ $tara->id }}"
+                                    @selected((int) $value('descarcare_tara_id', optional($cursa)->descarcare_tara_id, $oldMatches) === (int) $tara->id)
+                                >
+                                    {{ $tara->nume }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @if ($showErrors && $errors->has('descarcare_tara_id'))
+                            <div class="invalid-feedback">{{ $errors->first('descarcare_tara_id') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Data cursei</label>
+                        <input
+                            type="date"
+                            name="data_cursa_date"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('data_cursa_date')) is-invalid @endif"
+                            value="{{ $dateValue }}"
+                        >
+                        @if ($showErrors && $errors->has('data_cursa_date'))
+                            <div class="invalid-feedback">{{ $errors->first('data_cursa_date') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6 cursa-time-field @if (! $showTime) d-none @endif" data-time-container>
+                        <label class="form-label small text-uppercase fw-semibold">Ora cursei</label>
+                        <input
+                            type="time"
+                            name="data_cursa_time"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('data_cursa_time')) is-invalid @endif"
+                            value="{{ $timeValue }}"
+                            data-time-input
+                        >
+                        @if ($showErrors && $errors->has('data_cursa_time'))
+                            <div class="invalid-feedback">{{ $errors->first('data_cursa_time') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12 col-md-6">
+                        <label class="form-label small text-uppercase fw-semibold">Kilometraj bord</label>
+                        <input
+                            type="number"
+                            name="km_bord"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('km_bord')) is-invalid @endif"
+                            value="{{ $value('km_bord', optional($cursa)->km_bord, $oldMatches) }}"
+                            min="0"
+                            step="1"
+                        >
+                        @if ($showErrors && $errors->has('km_bord'))
+                            <div class="invalid-feedback">{{ $errors->first('km_bord') }}</div>
+                        @endif
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label small text-uppercase fw-semibold">Observații</label>
+                        <textarea
+                            name="observatii"
+                            class="form-control form-control-sm @if ($showErrors && $errors->has('observatii')) is-invalid @endif"
+                            rows="3"
+                        >{{ $value('observatii', optional($cursa)->observatii, $oldMatches) }}</textarea>
+                        @if ($showErrors && $errors->has('observatii'))
+                            <div class="invalid-feedback">{{ $errors->first('observatii') }}</div>
+                        @endif
+                    </div>
+                </div>
+            </div>
+
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Renunță</button>
+                <button type="submit" class="btn btn-primary">{{ $submitLabel }}</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/resources/views/sofer/valabilitati/partials/modals.blade.php
+++ b/resources/views/sofer/valabilitati/partials/modals.blade.php
@@ -1,0 +1,222 @@
+@php
+    $curse = $curse ?? collect();
+    $modalKey = $modalKey ?? null;
+@endphp
+
+@include('sofer.valabilitati.partials.cursa-form', [
+    'formType' => 'create',
+    'modalId' => 'cursaCreateModal',
+    'modalTitle' => 'Adaugă cursă',
+    'submitLabel' => 'Salvează cursa',
+    'formAction' => route('sofer.valabilitati.curse.store', $valabilitate),
+    'method' => 'POST',
+    'tari' => $tari,
+    'requiresTimeByDefault' => $curse->isEmpty(),
+    'lockTime' => $curse->isEmpty(),
+])
+
+@foreach ($curse as $cursa)
+    @include('sofer.valabilitati.partials.cursa-form', [
+        'formType' => 'edit',
+        'formId' => $cursa->id,
+        'modalId' => 'cursaEditModal-' . $cursa->id,
+        'modalTitle' => 'Editează cursa',
+        'submitLabel' => 'Actualizează cursa',
+        'formAction' => route('sofer.valabilitati.curse.update', [$valabilitate, $cursa]),
+        'method' => 'PUT',
+        'tari' => $tari,
+        'cursa' => $cursa,
+        'requiresTimeByDefault' => false,
+        'lockTime' => false,
+    ])
+@endforeach
+
+<div class="modal fade" id="finalReturnConfirmModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content border-0 shadow-sm">
+            <div class="modal-header border-0 pb-0">
+                <h2 class="h5 modal-title fw-bold">Ultima cursă către România?</h2>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Închide"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0">Confirmarea marchează această cursă ca fiind întoarcerea acasă. Vom solicita și ora sosirii.</p>
+            </div>
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-outline-secondary" data-final-return-cancel>Nu, continuă fără ora</button>
+                <button type="button" class="btn btn-primary" data-final-return-confirm>Da, adaug ora sosirii</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@push('page-styles')
+<style>
+    .sofer-valabilitati .list-group-item {
+        border-left: 0;
+        border-right: 0;
+    }
+
+    .sofer-valabilitati .list-group-item:first-child {
+        border-top: 0;
+    }
+
+    .sofer-valabilitati .list-group-item:last-child {
+        border-bottom: 0;
+    }
+
+    .sofer-valabilitati .cursa-time-field label::after {
+        content: '*';
+        color: #dc3545;
+        margin-left: 0.25rem;
+        font-weight: 600;
+        display: none;
+    }
+
+    .sofer-valabilitati .cursa-time-field.is-required label::after {
+        display: inline;
+    }
+
+    @media (max-width: 575.98px) {
+        .sofer-valabilitati .list-group-item {
+            padding-left: 1rem;
+            padding-right: 1rem;
+        }
+
+        .sofer-valabilitati .list-group-item .btn {
+            width: 100%;
+        }
+
+        .sofer-valabilitati .modal-dialog {
+            margin: 1rem;
+        }
+    }
+</style>
+@endpush
+
+@push('page-scripts')
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const modalKey = @json($modalKey);
+        const confirmModalEl = document.getElementById('finalReturnConfirmModal');
+
+        let pendingForm = null;
+
+        function toggleTimeField(form, visible, requireTime = null) {
+            const container = form.querySelector('[data-time-container]');
+            if (!container) {
+                return;
+            }
+
+            const locked = form.dataset.lockTimeVisible === 'true';
+            const defaultRequired = form.dataset.requireTimeDefault === 'true';
+            const shouldRequire = requireTime !== null ? requireTime : (locked || defaultRequired);
+
+            if (visible) {
+                container.classList.remove('d-none');
+                if (shouldRequire) {
+                    container.classList.add('is-required');
+                } else {
+                    container.classList.remove('is-required');
+                }
+            } else if (!locked) {
+                container.classList.add('d-none');
+                container.classList.remove('is-required');
+                const timeInput = container.querySelector('[data-time-input]');
+                if (timeInput && !timeInput.dataset.preserveValue) {
+                    timeInput.value = '';
+                }
+            }
+        }
+
+        function setFinalReturnFlag(form, value) {
+            const input = form.querySelector('[data-final-return-input]');
+            if (input) {
+                input.value = value ? '1' : '0';
+            }
+        }
+
+        function resetToInitialState(form) {
+            const initialVisible = form.dataset.initialTimeVisible === 'true';
+            const locked = form.dataset.lockTimeVisible === 'true';
+            const initialFinal = form.dataset.initialFinalReturn === '1';
+            toggleTimeField(form, initialVisible || locked, initialFinal || locked);
+            setFinalReturnFlag(form, initialFinal);
+        }
+
+        document.querySelectorAll('[data-cursa-form]').forEach((form) => {
+            const initialVisible = form.dataset.initialTimeVisible === 'true';
+            const locked = form.dataset.lockTimeVisible === 'true';
+
+            if (initialVisible || locked) {
+                toggleTimeField(form, true);
+            }
+
+            const finalFlag = form.querySelector('[data-final-return-input]');
+            if (finalFlag && finalFlag.value === '1') {
+                toggleTimeField(form, true);
+            }
+
+            const select = form.querySelector('[data-descarcare-select]');
+            if (!select) {
+                return;
+            }
+
+            select.addEventListener('change', () => {
+                const selectedText = select.options[select.selectedIndex]?.text?.toLowerCase().trim();
+                const isRomania = selectedText === 'romania' || selectedText === 'românia';
+
+                if (!isRomania) {
+                    resetToInitialState(form);
+                    return;
+                }
+
+                pendingForm = form;
+                bootstrap.Modal.getOrCreateInstance(confirmModalEl).show();
+            });
+        });
+
+        if (confirmModalEl) {
+            const confirmModal = bootstrap.Modal.getOrCreateInstance(confirmModalEl);
+            const confirmButton = confirmModalEl.querySelector('[data-final-return-confirm]');
+            const cancelButton = confirmModalEl.querySelector('[data-final-return-cancel]');
+
+            confirmButton?.addEventListener('click', () => {
+                if (!pendingForm) {
+                    return;
+                }
+
+                toggleTimeField(pendingForm, true, true);
+                setFinalReturnFlag(pendingForm, 1);
+                confirmModal.hide();
+                pendingForm = null;
+            });
+
+            cancelButton?.addEventListener('click', () => {
+                if (!pendingForm) {
+                    return;
+                }
+
+                resetToInitialState(pendingForm);
+                confirmModal.hide();
+                pendingForm = null;
+            });
+
+            confirmModalEl.addEventListener('hidden.bs.modal', () => {
+                if (!pendingForm) {
+                    return;
+                }
+
+                resetToInitialState(pendingForm);
+                pendingForm = null;
+            });
+        }
+
+        if (modalKey) {
+            const modal = document.querySelector(`[data-modal-key="${modalKey}"]`);
+            if (modal) {
+                bootstrap.Modal.getOrCreateInstance(modal).show();
+            }
+        }
+    });
+</script>
+@endpush

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -1,0 +1,124 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container py-4 py-md-5 sofer-valabilitati">
+    <div class="mb-4">
+        <a href="{{ route('sofer.dashboard') }}" class="btn btn-link text-decoration-none px-0">
+            <i class="fa-solid fa-arrow-left-long me-1"></i>
+            Înapoi la panou
+        </a>
+    </div>
+
+    @if (session('status'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="fa-solid fa-circle-check me-2"></i>
+            {{ session('status') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Închide"></button>
+        </div>
+    @endif
+
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body p-4 p-lg-5">
+            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+                <div>
+                    <p class="text-uppercase text-muted small fw-semibold mb-1">Valabilitate activă</p>
+                    <h1 class="h4 fw-bold mb-1">{{ $valabilitate->denumire }}</h1>
+                    <p class="text-muted mb-0">
+                        {{ optional($valabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
+                        <span class="mx-1">–</span>
+                        {{ optional($valabilitate->data_sfarsit)->format('d.m.Y') ?? 'Prezent' }}
+                    </p>
+                </div>
+                <div class="text-md-end">
+                    <p class="text-uppercase text-muted small fw-semibold mb-1">Număr auto</p>
+                    <p class="h5 fw-bold mb-2">{{ $valabilitate->numar_auto ?? 'Fără număr' }}</p>
+                    <button
+                        type="button"
+                        class="btn btn-primary btn-sm px-4"
+                        data-bs-toggle="modal"
+                        data-bs-target="#cursaCreateModal"
+                    >
+                        <i class="fa-solid fa-plus me-1"></i>
+                        Adaugă cursă
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card border-0 shadow-sm">
+        <div class="card-body p-0">
+            @if ($curse->isEmpty())
+                <div class="p-4 text-center">
+                    <i class="fa-solid fa-route fa-2x text-primary mb-3"></i>
+                    <p class="fw-semibold mb-1">Nu există curse înregistrate</p>
+                    <p class="text-muted small mb-0">Începeți prin adăugarea primei curse pentru această valabilitate.</p>
+                </div>
+            @else
+                <div class="list-group list-group-flush">
+                    @foreach ($curse as $cursa)
+                        <div class="list-group-item py-4 px-3 px-md-4">
+                            <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3">
+                                <div class="flex-grow-1">
+                                    <div class="d-flex flex-wrap gap-2 align-items-center mb-2">
+                                        <span class="badge bg-light text-dark fw-semibold">
+                                            {{ optional($cursa->data_cursa)->format('d.m.Y H:i') ?? 'Fără dată' }}
+                                        </span>
+                                        @if ($cursa->km_bord)
+                                            <span class="badge bg-secondary-subtle text-secondary fw-semibold">
+                                                {{ number_format($cursa->km_bord, 0, '.', ' ') }} km
+                                            </span>
+                                        @endif
+                                    </div>
+                                    <div class="row g-3 small text-muted">
+                                        <div class="col-12 col-md-6">
+                                            <p class="fw-semibold text-uppercase text-dark small mb-1">Încărcare</p>
+                                            <p class="mb-0">{{ $cursa->incarcare_localitate ?? '—' }}</p>
+                                            <p class="mb-0">{{ $cursa->incarcare_cod_postal ?? '—' }}</p>
+                                            <p class="mb-0">{{ $cursa->incarcareTara?->nume ?? '—' }}</p>
+                                        </div>
+                                        <div class="col-12 col-md-6">
+                                            <p class="fw-semibold text-uppercase text-dark small mb-1">Descărcare</p>
+                                            <p class="mb-0">{{ $cursa->descarcare_localitate ?? '—' }}</p>
+                                            <p class="mb-0">{{ $cursa->descarcare_cod_postal ?? '—' }}</p>
+                                            <p class="mb-0">{{ $cursa->descarcareTara?->nume ?? '—' }}</p>
+                                        </div>
+                                    </div>
+                                    @if ($cursa->observatii)
+                                        <p class="text-muted small mt-3 mb-0">{{ $cursa->observatii }}</p>
+                                    @endif
+                                </div>
+                                <div class="d-flex flex-column flex-sm-row align-items-stretch gap-2">
+                                    <button
+                                        type="button"
+                                        class="btn btn-outline-primary btn-sm"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#cursaEditModal-{{ $cursa->id }}"
+                                    >
+                                        <i class="fa-solid fa-pen me-1"></i>
+                                        Editează
+                                    </button>
+                                    <form
+                                        method="POST"
+                                        action="{{ route('sofer.valabilitati.curse.destroy', [$valabilitate, $cursa]) }}"
+                                        onsubmit="return confirm('Sigur doriți să ștergeți această cursă?');"
+                                    >
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="btn btn-outline-danger btn-sm">
+                                            <i class="fa-solid fa-trash-can me-1"></i>
+                                            Șterge
+                                        </button>
+                                    </form>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+    </div>
+</div>
+@endsection
+
+@include('sofer.valabilitati.partials.modals')

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,6 +45,7 @@ use App\Http\Controllers\Tech\CronJobLogController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\SeederCenterController;
 use App\Http\Controllers\SoferDashboardController;
+use App\Http\Controllers\SoferValabilitateCursaController;
 use App\Http\Controllers\ValabilitateController;
 use App\Http\Controllers\ValabilitateCursaController;
 
@@ -92,6 +93,14 @@ Route::redirect('/', '/acasa');
 Route::middleware(['auth'])->group(function () {
     Route::middleware('role:sofer')->group(function () {
         Route::get('sofer/dashboard', SoferDashboardController::class)->name('sofer.dashboard');
+        Route::get('sofer/valabilitati/{valabilitate}', [SoferValabilitateCursaController::class, 'show'])
+            ->name('sofer.valabilitati.show');
+        Route::post('sofer/valabilitati/{valabilitate}/curse', [SoferValabilitateCursaController::class, 'store'])
+            ->name('sofer.valabilitati.curse.store');
+        Route::put('sofer/valabilitati/{valabilitate}/curse/{cursa}', [SoferValabilitateCursaController::class, 'update'])
+            ->name('sofer.valabilitati.curse.update');
+        Route::delete('sofer/valabilitati/{valabilitate}/curse/{cursa}', [SoferValabilitateCursaController::class, 'destroy'])
+            ->name('sofer.valabilitati.curse.destroy');
     });
 
     Route::middleware('permission:dashboard')->group(function () {

--- a/tests/Feature/Sofer/SoferValabilitateCursaTest.php
+++ b/tests/Feature/Sofer/SoferValabilitateCursaTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace Tests\Feature\Sofer;
+
+use App\Models\Role;
+use App\Models\Tara;
+use App\Models\User;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class SoferValabilitateCursaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_driver_cannot_view_valabilitate_of_another_driver(): void
+    {
+        $driver = $this->createSoferUser();
+        $otherDriver = $this->createSoferUser();
+
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $response = $this->actingAs($otherDriver)->get(route('sofer.valabilitati.show', $valabilitate));
+
+        $response->assertForbidden();
+    }
+
+    public function test_first_cursa_requires_time(): void
+    {
+        $driver = $this->createSoferUser();
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $descarcareTara = Tara::factory()->create(['nume' => 'Germania']);
+
+        $response = $this
+            ->actingAs($driver)
+            ->from(route('sofer.valabilitati.show', $valabilitate))
+            ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
+                'form_type' => 'create',
+                'incarcare_localitate' => 'Cluj',
+                'descarcare_localitate' => 'Berlin',
+                'descarcare_tara_id' => $descarcareTara->id,
+                'data_cursa_date' => Carbon::today()->format('Y-m-d'),
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+        $response->assertSessionHasErrors(['data_cursa_time']);
+        $this->assertDatabaseCount('valabilitati_curse', 0);
+    }
+
+    public function test_first_cursa_persists_when_time_is_provided(): void
+    {
+        $driver = $this->createSoferUser();
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $tara = Tara::factory()->create(['nume' => 'Ungaria']);
+
+        $response = $this
+            ->actingAs($driver)
+            ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
+                'form_type' => 'create',
+                'incarcare_localitate' => 'Cluj',
+                'descarcare_localitate' => 'Budapesta',
+                'descarcare_tara_id' => $tara->id,
+                'data_cursa_date' => '2025-05-20',
+                'data_cursa_time' => '08:15',
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+        $response->assertSessionHasNoErrors();
+
+        $this->assertDatabaseHas('valabilitati_curse', [
+            'valabilitate_id' => $valabilitate->id,
+            'data_cursa' => '2025-05-20 08:15:00',
+        ]);
+    }
+
+    public function test_final_return_requires_time(): void
+    {
+        $driver = $this->createSoferUser();
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        ValabilitateCursa::factory()->for($valabilitate)->create();
+
+        $romania = Tara::factory()->create(['nume' => 'Romania']);
+
+        $response = $this
+            ->actingAs($driver)
+            ->from(route('sofer.valabilitati.show', $valabilitate))
+            ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
+                'form_type' => 'create',
+                'descarcare_tara_id' => $romania->id,
+                'data_cursa_date' => '2025-06-10',
+                'final_return' => 1,
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+        $response->assertSessionHasErrors(['data_cursa_time']);
+        $this->assertDatabaseCount('valabilitati_curse', 1);
+    }
+
+    public function test_update_requires_time_when_marked_as_final_return(): void
+    {
+        $driver = $this->createSoferUser();
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
+            'data_cursa' => '2025-05-01 07:00:00',
+        ]);
+
+        $romania = Tara::factory()->create(['nume' => 'România']);
+
+        $response = $this
+            ->actingAs($driver)
+            ->from(route('sofer.valabilitati.show', $valabilitate))
+            ->put(route('sofer.valabilitati.curse.update', [$valabilitate, $cursa]), [
+                'form_type' => 'edit',
+                'form_id' => $cursa->id,
+                'descarcare_tara_id' => $romania->id,
+                'data_cursa_date' => '2025-05-02',
+                'final_return' => 1,
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+        $response->assertSessionHasErrors(['data_cursa_time']);
+
+        $this->assertDatabaseHas('valabilitati_curse', [
+            'id' => $cursa->id,
+            'data_cursa' => '2025-05-01 07:00:00',
+        ]);
+    }
+
+    private function createSoferUser(): User
+    {
+        $role = Role::firstOrCreate(
+            ['slug' => 'sofer'],
+            ['name' => 'Șofer']
+        );
+
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- load the authenticated driver’s active valabilitate on the dashboard and surface a link to manage its curse
- introduce a sofer valabilitate curse controller, request validation rules, and responsive blade views with a Romania return confirmation flow that toggles the time field
- register protected sofer routes and add feature coverage for access control, first-trip timing, and Romania return requirements

## Testing
- ⚠️ `composer install --no-interaction` *(fails: GitHub access returns 403 so dependencies cannot be downloaded)*
- ⚠️ `php artisan test tests/Feature/Sofer/SoferValabilitateCursaTest.php` *(cannot run because composer install failed and vendor/autoload.php is missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914dbb3886c8326ad3daa230e4f990b)