### PR TITLE
Add separate odometer fields for valabilitati curse entries

### DIFF
--- a/app/Http/Requests/SoferValabilitateCursaRequest.php
+++ b/app/Http/Requests/SoferValabilitateCursaRequest.php
@@ -36,7 +36,8 @@ class SoferValabilitateCursaRequest extends FormRequest
             'data_cursa_time' => ['nullable', 'date_format:H:i'],
             'data_cursa' => ['nullable', 'date'],
             'observatii' => ['nullable', 'string'],
-            'km_bord' => ['nullable', 'integer', 'min:0'],
+            'km_bord_incarcare' => ['nullable', 'integer', 'min:0'],
+            'km_bord_descarcare' => ['nullable', 'integer', 'min:0'],
             'final_return' => ['nullable', 'boolean'],
         ];
     }

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -28,7 +28,8 @@ class ValabilitateCursaRequest extends FormRequest
             'descarcare_tara_id' => ['nullable', 'exists:tari,id'],
             'data_cursa' => ['nullable', 'date'],
             'observatii' => ['nullable', 'string'],
-            'km_bord' => ['nullable', 'integer', 'min:0'],
+            'km_bord_incarcare' => ['nullable', 'integer', 'min:0'],
+            'km_bord_descarcare' => ['nullable', 'integer', 'min:0'],
         ];
     }
 

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -22,12 +22,14 @@ class ValabilitateCursa extends Model
         'descarcare_tara_id',
         'data_cursa',
         'observatii',
-        'km_bord',
+        'km_bord_incarcare',
+        'km_bord_descarcare',
     ];
 
     protected $casts = [
         'data_cursa' => 'datetime',
-        'km_bord' => 'integer',
+        'km_bord_incarcare' => 'integer',
+        'km_bord_descarcare' => 'integer',
     ];
 
     public function incarcareTara(): BelongsTo

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -26,7 +26,8 @@ class ValabilitateCursaFactory extends Factory
             'descarcare_tara_id' => Tara::factory(),
             'data_cursa' => fake()->dateTimeBetween('-1 week', '+1 week'),
             'observatii' => fake()->optional()->sentence(),
-            'km_bord' => fake()->numberBetween(0, 500000),
+            'km_bord_incarcare' => fake()->numberBetween(0, 500000),
+            'km_bord_descarcare' => fake()->numberBetween(0, 500000),
         ];
     }
 }

--- a/database/migrations/2025_03_24_050000_split_km_bord_fields_in_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_050000_split_km_bord_fields_in_valabilitati_curse_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\DB;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->unsignedInteger('km_bord_incarcare')->nullable()->after('observatii');
+            $table->unsignedInteger('km_bord_descarcare')->nullable()->after('km_bord_incarcare');
+        });
+
+        DB::table('valabilitati_curse')
+            ->whereNotNull('km_bord')
+            ->update([
+                'km_bord_incarcare' => DB::raw('km_bord'),
+                'km_bord_descarcare' => DB::raw('km_bord'),
+            ]);
+
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn('km_bord');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->unsignedInteger('km_bord')->nullable()->after('observatii');
+        });
+
+        DB::statement('UPDATE valabilitati_curse SET km_bord = COALESCE(km_bord_incarcare, km_bord_descarcare)');
+
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn(['km_bord_incarcare', 'km_bord_descarcare']);
+        });
+    }
+};

--- a/resources/views/sofer/valabilitati/curse/partials/form.blade.php
+++ b/resources/views/sofer/valabilitati/curse/partials/form.blade.php
@@ -176,16 +176,30 @@
             @endif
         </div>
         <div class="col-12 col-md-6">
-            <label class="form-label small text-uppercase fw-semibold">Kilometraj bord</label>
+            <label class="form-label small text-uppercase fw-semibold">Km bord încărcare</label>
             <input
                 type="number"
-                name="km_bord"
-                class="form-control form-control-sm @error('km_bord') is-invalid @enderror"
-                value="{{ old('km_bord', optional($cursa)->km_bord) }}"
+                name="km_bord_incarcare"
+                class="form-control form-control-sm @error('km_bord_incarcare') is-invalid @enderror"
+                value="{{ old('km_bord_incarcare', optional($cursa)->km_bord_incarcare) }}"
                 min="0"
                 step="1"
             >
-            @error('km_bord')
+            @error('km_bord_incarcare')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class="col-12 col-md-6">
+            <label class="form-label small text-uppercase fw-semibold">Km bord descărcare</label>
+            <input
+                type="number"
+                name="km_bord_descarcare"
+                class="form-control form-control-sm @error('km_bord_descarcare') is-invalid @enderror"
+                value="{{ old('km_bord_descarcare', optional($cursa)->km_bord_descarcare) }}"
+                min="0"
+                step="1"
+            >
+            @error('km_bord_descarcare')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -126,6 +126,26 @@
                                             </div>
                                         </div>
 
+                                        <div class="row g-2 small text-muted mt-2">
+                                            <div class="col-6">
+                                                <p class="fw-semibold text-uppercase text-dark small mb-1">Km bord încărcare</p>
+                                                <p class="mb-0">
+                                                    <span class="text-body-secondary">
+                                                        {{ $cursa->km_bord_incarcare ?? '—' }}
+                                                    </span>
+                                                </p>
+                                            </div>
+
+                                            <div class="col-6 text-end">
+                                                <p class="fw-semibold text-uppercase text-dark small mb-1">Km bord descărcare</p>
+                                                <p class="mb-0">
+                                                    <span class="text-body-secondary">
+                                                        {{ $cursa->km_bord_descarcare ?? '—' }}
+                                                    </span>
+                                                </p>
+                                            </div>
+                                        </div>
+
                                         @if ($cursa->observatii)
                                             <p class="text-muted small mt-3 mb-0">{{ $cursa->observatii }}</p>
                                         @endif

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -121,7 +121,8 @@
                         <th>Descărcare - cod poștal</th>
                         <th>Descărcare - țară</th>
                         <th>Data cursă</th>
-                        <th>Km bord</th>
+                        <th>Încărcare - km bord</th>
+                        <th>Descărcare - km bord</th>
                         <th class="text-end">Acțiuni</th>
                     </tr>
                 </thead>
@@ -130,7 +131,7 @@
                         @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                     @else
                         <tr>
-                            <td colspan="10" class="text-center py-4">Nu există curse care să respecte criteriile selectate.</td>
+                            <td colspan="11" class="text-center py-4">Nu există curse care să respecte criteriile selectate.</td>
                         </tr>
                     @endif
                 </tbody>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -72,7 +72,8 @@
                                 $createDescarcareTaraText = $resolveTaraName($createDescarcareTaraId);
                             }
 
-                            $createKmBord = $isCreateActive ? old('km_bord', '') : '';
+                            $createKmBordIncarcare = $isCreateActive ? old('km_bord_incarcare', '') : '';
+                            $createKmBordDescarcare = $isCreateActive ? old('km_bord_descarcare', '') : '';
                             $createDataDateValue = $isCreateActive ? old('data_cursa_date', '') : '';
                             $createDataTimeValue = $isCreateActive ? old('data_cursa_time', '') : '';
                             if ($isCreateActive) {
@@ -229,21 +230,39 @@
                                 </div>
                             </div>
                             <div class="col-md-4">
-                                <label for="cursa-create-km-bord" class="form-label">Km bord</label>
+                                <label for="cursa-create-km-bord-incarcare" class="form-label">Km bord încărcare</label>
                                 <input
                                     type="number"
-                                    name="km_bord"
-                                    id="cursa-create-km-bord"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord') ? 'is-invalid' : '' }}"
-                                    value="{{ $createKmBord }}"
+                                    name="km_bord_incarcare"
+                                    id="cursa-create-km-bord-incarcare"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmBordIncarcare }}"
                                     min="0"
                                     step="1"
                                 >
                                 <div
-                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord') ? 'd-block' : '' }}"
-                                    data-error-for="km_bord"
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_incarcare"
                                 >
-                                    {{ $isCreateActive ? $errors->first('km_bord') : '' }}
+                                    {{ $isCreateActive ? $errors->first('km_bord_incarcare') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="cursa-create-km-bord-descarcare" class="form-label">Km bord descărcare</label>
+                                <input
+                                    type="number"
+                                    name="km_bord_descarcare"
+                                    id="cursa-create-km-bord-descarcare"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmBordDescarcare }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_descarcare"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
                             </div>
                             <div class="col-12">
@@ -306,9 +325,13 @@
             $editDescarcareTaraText = $resolveTaraName($editDescarcareTaraId) ?: optional($cursa->descarcareTara)->nume;
         }
 
-        $editKmBordValue = $isEditing ? old('km_bord', $cursa->km_bord) : $cursa->km_bord;
-        if ($editKmBordValue === null) {
-            $editKmBordValue = '';
+        $editKmBordIncarcare = $isEditing ? old('km_bord_incarcare', $cursa->km_bord_incarcare) : $cursa->km_bord_incarcare;
+        if ($editKmBordIncarcare === null) {
+            $editKmBordIncarcare = '';
+        }
+        $editKmBordDescarcare = $isEditing ? old('km_bord_descarcare', $cursa->km_bord_descarcare) : $cursa->km_bord_descarcare;
+        if ($editKmBordDescarcare === null) {
+            $editKmBordDescarcare = '';
         }
     @endphp
     <div
@@ -480,21 +503,39 @@
                                 </div>
                             </div>
                             <div class="col-md-4">
-                                <label for="{{ $editPrefix }}km-bord" class="form-label">Km bord</label>
+                                <label for="{{ $editPrefix }}km-bord-incarcare" class="form-label">Km bord încărcare</label>
                                 <input
                                     type="number"
-                                    name="km_bord"
-                                    id="{{ $editPrefix }}km-bord"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord') ? 'is-invalid' : '' }}"
-                                    value="{{ $editKmBordValue }}"
+                                    name="km_bord_incarcare"
+                                    id="{{ $editPrefix }}km-bord-incarcare"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmBordIncarcare }}"
                                     min="0"
                                     step="1"
                                 >
                                 <div
-                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord') ? 'd-block' : '' }}"
-                                    data-error-for="km_bord"
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_incarcare"
                                 >
-                                    {{ $isEditing ? $errors->first('km_bord') : '' }}
+                                    {{ $isEditing ? $errors->first('km_bord_incarcare') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}km-bord-descarcare" class="form-label">Km bord descărcare</label>
+                                <input
+                                    type="number"
+                                    name="km_bord_descarcare"
+                                    id="{{ $editPrefix }}km-bord-descarcare"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmBordDescarcare }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_descarcare"
+                                >
+                                    {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
                             </div>
                             <div class="col-12">

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -16,7 +16,8 @@
         <td>{{ $cursa->descarcare_cod_postal ?: '—' }}</td>
         <td>{{ $cursa->descarcareTara?->nume ?: '—' }}</td>
         <td class="text-nowrap">{{ $dataCursa ?: '—' }}</td>
-        <td class="text-nowrap">{{ $cursa->km_bord !== null ? $cursa->km_bord : '—' }}</td>
+        <td class="text-nowrap">{{ $cursa->km_bord_incarcare !== null ? $cursa->km_bord_incarcare : '—' }}</td>
+        <td class="text-nowrap">{{ $cursa->km_bord_descarcare !== null ? $cursa->km_bord_descarcare : '—' }}</td>
         <td class="text-end">
             <div class="d-flex flex-wrap justify-content-end">
                 <div class="ms-1">

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -35,7 +35,8 @@ class ValabilitateCursaTest extends TestCase
             'data_cursa_date' => '2025-05-01',
             'data_cursa_time' => '08:30',
             'observatii' => 'Livrare completă',
-            'km_bord' => 12345,
+            'km_bord_incarcare' => 12345,
+            'km_bord_descarcare' => 12500,
         ]);
 
         $response->assertRedirect(route('valabilitati.curse.index', $valabilitate));
@@ -51,7 +52,8 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_tara_id' => $descarcareTara->id,
             'data_cursa' => '2025-05-01 08:30:00',
             'observatii' => 'Livrare completă',
-            'km_bord' => 12345,
+            'km_bord_incarcare' => 12345,
+            'km_bord_descarcare' => 12500,
         ]);
 
         $cursa = ValabilitateCursa::firstOrFail();
@@ -72,7 +74,8 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_cod_postal' => '550200',
             'descarcare_tara_id' => $initialDescarcareTara->id,
             'data_cursa' => '2025-05-03 10:00:00',
-            'km_bord' => 78000,
+            'km_bord_incarcare' => 78000,
+            'km_bord_descarcare' => 78500,
         ]);
 
         $newIncarcareTara = Tara::factory()->create(['nume' => 'Germania']);
@@ -90,7 +93,8 @@ class ValabilitateCursaTest extends TestCase
             'data_cursa_date' => '2025-05-05',
             'data_cursa_time' => '14:45',
             'observatii' => 'Actualizare detalii',
-            'km_bord' => 98765,
+            'km_bord_incarcare' => 98765,
+            'km_bord_descarcare' => 99000,
         ]);
 
         $response->assertRedirect(route('valabilitati.curse.index', $cursa->valabilitate));
@@ -106,7 +110,8 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_tara_id' => $newDescarcareTara->id,
             'data_cursa' => '2025-05-05 14:45:00',
             'observatii' => 'Actualizare detalii',
-            'km_bord' => 98765,
+            'km_bord_incarcare' => 98765,
+            'km_bord_descarcare' => 99000,
         ]);
     }
 
@@ -181,7 +186,8 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_cod_postal' => '310002',
             'data_cursa' => '2025-06-10 16:20:00',
             'descarcare_tara_id' => $descarcareTara->id,
-            'km_bord' => 15400,
+            'km_bord_incarcare' => 15400,
+            'km_bord_descarcare' => 15900,
         ]);
 
         $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
@@ -195,6 +201,7 @@ class ValabilitateCursaTest extends TestCase
         $response->assertSeeText($descarcareTara->nume);
         $response->assertSeeText('10.06.2025 16:20');
         $response->assertSeeText('15400');
+        $response->assertSeeText('15900');
     }
 
     public function test_index_lists_curse_in_chronological_order(): void


### PR DESCRIPTION
## Summary
- split the valabilitati_curse table into dedicated odometer columns for loading and unloading, including a backfill migration
- expose the new fields across admin and driver forms, table rows, and detail views for valabilitati curse
- update factories and feature coverage to reflect the separate kilometre readings

## Testing
- composer install --no-interaction *(fails: CONNECT tunnel 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170b38c448832698f7061588d2a6b3)