### PR TITLE
Add nr_cursa support for valabilitati curse

### DIFF
--- a/app/Http/Requests/SoferValabilitateCursaRequest.php
+++ b/app/Http/Requests/SoferValabilitateCursaRequest.php
@@ -26,6 +26,7 @@ class SoferValabilitateCursaRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
             'incarcare_tara_id' => ['nullable', Rule::exists('tari', 'id')],

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -20,6 +20,7 @@ class ValabilitateCursaRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
             'incarcare_tara_id' => ['nullable', 'exists:tari,id'],

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -14,6 +14,7 @@ class ValabilitateCursa extends Model
 
     protected $fillable = [
         'valabilitate_id',
+        'nr_cursa',
         'incarcare_localitate',
         'incarcare_cod_postal',
         'incarcare_tara_id',

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -18,6 +18,7 @@ class ValabilitateCursaFactory extends Factory
     {
         return [
             'valabilitate_id' => Valabilitate::factory(),
+            'nr_cursa' => fake()->optional()->bothify('Cursa-###'),
             'incarcare_localitate' => fake()->city(),
             'incarcare_cod_postal' => fake()->postcode(),
             'incarcare_tara_id' => Tara::factory(),

--- a/database/migrations/2025_03_24_060000_add_nr_cursa_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_060000_add_nr_cursa_to_valabilitati_curse_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->string('nr_cursa')->nullable()->after('valabilitate_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn('nr_cursa');
+        });
+    }
+};

--- a/resources/views/sofer/valabilitati/curse/partials/form.blade.php
+++ b/resources/views/sofer/valabilitati/curse/partials/form.blade.php
@@ -37,6 +37,7 @@
     }
 
     $requireTimeDefault = $requiresTime || $finalReturnValue === 1 || $lockTime;
+    $nrCursa = old('nr_cursa', optional($cursa)->nr_cursa);
 @endphp
 
 <form
@@ -59,6 +60,19 @@
     <input type="hidden" name="final_return" value="{{ $finalReturnValue }}" data-final-return-input>
 
     <div class="row g-3">
+        <div class="col-12 col-md-6">
+            <label class="form-label small text-uppercase fw-semibold">Număr cursă</label>
+            <input
+                type="text"
+                name="nr_cursa"
+                class="form-control form-control-sm @error('nr_cursa') is-invalid @enderror"
+                value="{{ $nrCursa }}"
+                autocomplete="off"
+            >
+            @error('nr_cursa')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
         <div class="col-12 col-md-6">
             <label class="form-label small text-uppercase fw-semibold">Localitate încărcare</label>
             <input

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -75,6 +75,10 @@
                         >
                             <div class="w-100 d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2">
                                 <div class="d-flex flex-wrap align-items-center gap-2">
+                                    <span class="fw-semibold text-dark small text-uppercase">
+                                        Nr. cursă:
+                                        <span class="text-body-secondary">{{ $cursa->nr_cursa ?? '—' }}</span>
+                                    </span>
                                     <span class="text-primary">
                                         {{ $cursa->incarcare_localitate ?? '—' }}
                                         <span class="mx-1">→</span>
@@ -101,6 +105,14 @@
 
                                 <div class="row g-3 align-items-start">
                                     <div class="col-12 col-lg-12">
+                                        <div class="row g-2 small text-muted mb-2">
+                                            <div class="col-12">
+                                                <p class="fw-semibold text-uppercase text-dark small mb-1">Număr cursă</p>
+                                                <p class="mb-0">
+                                                    <span class="text-body-secondary">{{ $cursa->nr_cursa ?? '—' }}</span>
+                                                </p>
+                                            </div>
+                                        </div>
                                         {{-- Încărcare left, Descărcare right (always 50% / 50%) --}}
                                         <div class="row g-2 small text-muted cursa-card__locations">
                                             <div class="col-6">

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -113,7 +113,7 @@
             <table class="table table-sm table-striped table-hover rounded align-middle">
                 <thead class="text-white rounded culoare2">
                     <tr>
-                        <th class="text-nowrap">#</th>
+                        <th>Nr. cursă</th>
                         <th>Încărcare - localitate</th>
                         <th>Încărcare - cod poștal</th>
                         <th>Încărcare - țară</th>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -60,6 +60,7 @@
                     <input type="hidden" name="form_type" value="create">
                     <div class="modal-body">
                         @php
+                            $createNrCursa = $isCreateActive ? old('nr_cursa', '') : '';
                             $createIncarcareTaraId = $isCreateActive ? old('incarcare_tara_id', '') : '';
                             $createIncarcareTaraText = $isCreateActive ? old('incarcare_tara_text', '') : '';
                             if ($createIncarcareTaraText === '' && $createIncarcareTaraId !== '') {
@@ -87,6 +88,23 @@
                             }
                         @endphp
                         <div class="row g-3">
+                            <div class="col-md-4">
+                                <label for="cursa-create-nr" class="form-label">Număr cursă</label>
+                                <input
+                                    type="text"
+                                    name="nr_cursa"
+                                    id="cursa-create-nr"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('nr_cursa') ? 'is-invalid' : '' }}"
+                                    value="{{ $createNrCursa }}"
+                                    maxlength="255"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('nr_cursa') ? 'd-block' : '' }}"
+                                    data-error-for="nr_cursa"
+                                >
+                                    {{ $isCreateActive ? $errors->first('nr_cursa') : '' }}
+                                </div>
+                            </div>
                             <div class="col-md-4">
                                 <label for="cursa-create-incarcare-localitate" class="form-label">Localitate încărcare</label>
                                 <input
@@ -333,6 +351,10 @@
         if ($editKmBordDescarcare === null) {
             $editKmBordDescarcare = '';
         }
+        $editNrCursa = $isEditing ? old('nr_cursa', $cursa->nr_cursa) : $cursa->nr_cursa;
+        if ($editNrCursa === null) {
+            $editNrCursa = '';
+        }
     @endphp
     <div
         class="modal fade text-dark"
@@ -360,6 +382,23 @@
                     <input type="hidden" name="form_id" value="{{ $cursa->id }}">
                     <div class="modal-body">
                         <div class="row g-3">
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}nr" class="form-label">Număr cursă</label>
+                                <input
+                                    type="text"
+                                    name="nr_cursa"
+                                    id="{{ $editPrefix }}nr"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('nr_cursa') ? 'is-invalid' : '' }}"
+                                    value="{{ $editNrCursa }}"
+                                    maxlength="255"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('nr_cursa') ? 'd-block' : '' }}"
+                                    data-error-for="nr_cursa"
+                                >
+                                    {{ $isEditing ? $errors->first('nr_cursa') : '' }}
+                                </div>
+                            </div>
                             <div class="col-md-4">
                                 <label for="{{ $editPrefix }}incarcare-localitate" class="form-label">Localitate încărcare</label>
                                 <input

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,14 +1,9 @@
-@php
-    $startIndex = $curse->firstItem() ?? 1;
-@endphp
-
 @foreach ($curse as $cursa)
     @php
-        $rowNumber = $startIndex + $loop->index;
         $dataCursa = $cursa->data_cursa?->format('d.m.Y H:i');
     @endphp
     <tr>
-        <td class="text-nowrap">{{ $rowNumber }}</td>
+        <td class="text-nowrap">{{ $cursa->nr_cursa ?: '—' }}</td>
         <td>{{ $cursa->incarcare_localitate ?: '—' }}</td>
         <td>{{ $cursa->incarcare_cod_postal ?: '—' }}</td>
         <td>{{ $cursa->incarcareTara?->nume ?: '—' }}</td>


### PR DESCRIPTION
## Summary
- add a migration and model/request updates so valabilități curse can persist an optional `nr_cursa`
- expose the new field in the admin curse table and modal forms, replacing the row-number column with the course number
- surface `nr_cursa` in the driver-facing pages and forms so it is the first value entered and displayed alongside each course

## Testing
- ./vendor/bin/phpunit *(fails: vendor directory is missing in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170fc0f7188326b0a77b46b0a91daa)