### PR TITLE
Add nr_ordine sequencing to valabilitati curse

### DIFF
--- a/app/Http/Controllers/SoferValabilitateCursaController.php
+++ b/app/Http/Controllers/SoferValabilitateCursaController.php
@@ -20,7 +20,7 @@ class SoferValabilitateCursaController extends Controller
 
         $valabilitate->load([
             'curse' => function ($query) {
-                $query->orderBy('data_cursa')->orderBy('id');
+                $query->orderBy('nr_ordine')->orderBy('data_cursa');
             },
             'curse.incarcareTara',
             'curse.descarcareTara',
@@ -48,6 +48,7 @@ class SoferValabilitateCursaController extends Controller
             'requiresTime' => $requiresTime,
             'lockTime' => $requiresTime,
             'romanianCountryIds' => $this->determineRomanianCountryIds($tari),
+            'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
         ]);
     }
 
@@ -71,6 +72,7 @@ class SoferValabilitateCursaController extends Controller
             'requiresTime' => $hasDateTime,
             'lockTime' => false,
             'romanianCountryIds' => $this->determineRomanianCountryIds($tari),
+            'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
         ]);
     }
 
@@ -139,5 +141,12 @@ class SoferValabilitateCursaController extends Controller
             ->map(static fn ($id) => (int) $id)
             ->values()
             ->all();
+    }
+
+    private function resolveNextNrOrdine(Valabilitate $valabilitate): int
+    {
+        $max = (int) $valabilitate->curse()->max('nr_ordine');
+
+        return $max > 0 ? $max + 1 : 1;
     }
 }

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -40,6 +40,7 @@ class ValabilitateCursaController extends Controller
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitate, $curse),
             'backUrl' => ValabilitatiFilterState::route(),
             'tari' => $this->loadTari(),
+            'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
         ]);
     }
 
@@ -62,6 +63,7 @@ class ValabilitateCursaController extends Controller
                 'curse' => $curse,
                 'includeCreate' => false,
                 'tari' => $this->loadTari(),
+                'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($request, $valabilitate, $curse),
         ]);
@@ -171,8 +173,9 @@ class ValabilitateCursaController extends Controller
     private function paginateCurse(Request $request, Valabilitate $valabilitate, array $filters, ?array $query = null): LengthAwarePaginator
     {
         $paginator = $this->buildFilteredQuery($valabilitate, $filters)
+            ->reorder()
+            ->orderBy('nr_ordine')
             ->orderBy('data_cursa')
-            ->orderBy('created_at')
             ->paginate(self::PER_PAGE);
 
         if ($query !== null) {
@@ -222,10 +225,20 @@ class ValabilitateCursaController extends Controller
                 'valabilitate' => $valabilitate,
                 'curse' => $curse,
                 'includeCreate' => true,
+                'formType' => old('form_type'),
+                'formId' => old('form_id'),
                 'tari' => $this->loadTari(),
+                'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($filtersRequest, $valabilitate, $curse),
         ]);
+    }
+
+    private function resolveNextNrOrdine(Valabilitate $valabilitate): int
+    {
+        $max = (int) $valabilitate->curse()->max('nr_ordine');
+
+        return $max > 0 ? $max + 1 : 1;
     }
 
     private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void

--- a/app/Http/Requests/SoferValabilitateCursaRequest.php
+++ b/app/Http/Requests/SoferValabilitateCursaRequest.php
@@ -26,6 +26,7 @@ class SoferValabilitateCursaRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'nr_ordine' => ['required', 'integer', 'min:1'],
             'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -20,6 +20,7 @@ class ValabilitateCursaRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'nr_ordine' => ['required', 'integer', 'min:1'],
             'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],

--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -34,7 +34,9 @@ class Valabilitate extends Model
 
     public function curse(): HasMany
     {
-        return $this->hasMany(ValabilitateCursa::class);
+        return $this->hasMany(ValabilitateCursa::class)
+            ->orderBy('nr_ordine')
+            ->orderBy('id');
     }
 
     /**

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -14,6 +14,7 @@ class ValabilitateCursa extends Model
 
     protected $fillable = [
         'valabilitate_id',
+        'nr_ordine',
         'nr_cursa',
         'incarcare_localitate',
         'incarcare_cod_postal',
@@ -28,6 +29,7 @@ class ValabilitateCursa extends Model
     ];
 
     protected $casts = [
+        'nr_ordine' => 'integer',
         'data_cursa' => 'datetime',
         'km_bord_incarcare' => 'integer',
         'km_bord_descarcare' => 'integer',

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -18,6 +18,7 @@ class ValabilitateCursaFactory extends Factory
     {
         return [
             'valabilitate_id' => Valabilitate::factory(),
+            'nr_ordine' => fake()->numberBetween(1, 20),
             'nr_cursa' => fake()->optional()->bothify('Cursa-###'),
             'incarcare_localitate' => fake()->city(),
             'incarcare_cod_postal' => fake()->postcode(),

--- a/database/migrations/2025_03_24_070000_add_nr_ordine_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_070000_add_nr_ordine_to_valabilitati_curse_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->unsignedInteger('nr_ordine')->nullable()->first();
+        });
+
+        DB::statement(<<<'SQL'
+            UPDATE valabilitati_curse vc
+            JOIN (
+                SELECT
+                    id,
+                    valabilitate_id,
+                    (@row_num := IF(@current_valabilitate = valabilitate_id, @row_num + 1, 1)) AS row_num,
+                    (@current_valabilitate := valabilitate_id) AS current_valabilitate
+                FROM valabilitati_curse
+                CROSS JOIN (SELECT @row_num := 0, @current_valabilitate := NULL) vars
+                ORDER BY valabilitate_id, created_at, id
+            ) ranked ON vc.id = ranked.id
+            SET vc.nr_ordine = ranked.row_num
+        SQL);
+
+        DB::statement('ALTER TABLE valabilitati_curse MODIFY nr_ordine INT UNSIGNED NOT NULL');
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn('nr_ordine');
+        });
+    }
+};

--- a/resources/views/sofer/valabilitati/curse/create.blade.php
+++ b/resources/views/sofer/valabilitati/curse/create.blade.php
@@ -22,6 +22,7 @@
                 'requiresTime' => $requiresTime,
                 'lockTime' => $lockTime,
                 'romanianCountryIds' => $romanianCountryIds,
+                'nextNrOrdine' => $nextNrOrdine,
             ])
         </div>
     </div>

--- a/resources/views/sofer/valabilitati/curse/edit.blade.php
+++ b/resources/views/sofer/valabilitati/curse/edit.blade.php
@@ -23,6 +23,7 @@
                 'requiresTime' => $requiresTime,
                 'lockTime' => $lockTime,
                 'romanianCountryIds' => $romanianCountryIds,
+                'nextNrOrdine' => $nextNrOrdine,
             ])
         </div>
     </div>

--- a/resources/views/sofer/valabilitati/curse/partials/form.blade.php
+++ b/resources/views/sofer/valabilitati/curse/partials/form.blade.php
@@ -37,6 +37,8 @@
     }
 
     $requireTimeDefault = $requiresTime || $finalReturnValue === 1 || $lockTime;
+    $nextNrOrdine = isset($nextNrOrdine) ? (int) $nextNrOrdine : 1;
+    $nrOrdine = old('nr_ordine', optional($cursa)->nr_ordine ?? $nextNrOrdine);
     $nrCursa = old('nr_cursa', optional($cursa)->nr_cursa);
 @endphp
 
@@ -60,6 +62,20 @@
     <input type="hidden" name="final_return" value="{{ $finalReturnValue }}" data-final-return-input>
 
     <div class="row g-3">
+        <div class="col-12 col-md-6">
+            <label class="form-label small text-uppercase fw-semibold">Nr. ordine</label>
+            <input
+                type="number"
+                name="nr_ordine"
+                class="form-control form-control-sm @error('nr_ordine') is-invalid @enderror"
+                value="{{ $nrOrdine }}"
+                min="1"
+                step="1"
+            >
+            @error('nr_ordine')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
         <div class="col-12 col-md-6">
             <label class="form-label small text-uppercase fw-semibold">Număr cursă</label>
             <input

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -75,6 +75,7 @@
                         >
                             <div class="w-100 d-flex flex-column flex-sm-row align-items-sm-center justify-content-between gap-2">
                                 <div class="d-flex flex-wrap align-items-center gap-2">
+                                    <span class="badge rounded-pill text-bg-secondary">#{{ $cursa->nr_ordine }}</span>
                                     <span class="fw-semibold text-dark small text-uppercase">
                                         <span class="text-body-secondary">{{ $cursa->nr_cursa ?? '—' }}</span>
                                     </span>
@@ -105,9 +106,10 @@
                                 <div class="row g-3 align-items-start">
                                     <div class="col-12 col-lg-12">
                                         <div class="row g-2 small text-muted mb-2">
-                                            <div class="col-12">
-                                                <p class="fw-semibold text-uppercase text-dark small mb-1">Număr cursă: {{ $cursa->nr_cursa ?? '—' }}</p>
-                                            </div>
+                                        <div class="col-12">
+                                            <p class="fw-semibold text-uppercase text-dark small mb-1">Nr. ordine: #{{ $cursa->nr_ordine }}</p>
+                                            <p class="fw-semibold text-uppercase text-dark small mb-1">Număr cursă: {{ $cursa->nr_cursa ?? '—' }}</p>
+                                        </div>
                                         </div>
                                         {{-- Încărcare left, Descărcare right (always 50% / 50%) --}}
                                         <div class="row g-2 small text-muted cursa-card__locations">

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -113,6 +113,7 @@
             <table class="table table-sm table-striped table-hover rounded align-middle">
                 <thead class="text-white rounded culoare2">
                     <tr>
+                        <th class="text-center">#</th>
                         <th>Nr. cursă</th>
                         <th>Încărcare - localitate</th>
                         <th>Încărcare - cod poștal</th>
@@ -131,7 +132,7 @@
                         @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                     @else
                         <tr>
-                            <td colspan="11" class="text-center py-4">Nu există curse care să respecte criteriile selectate.</td>
+                            <td colspan="12" class="text-center py-4">Nu există curse care să respecte criteriile selectate.</td>
                         </tr>
                     @endif
                 </tbody>
@@ -168,6 +169,7 @@
         'formType' => old('form_type'),
         'formId' => old('form_id'),
         'tari' => $tari,
+        'nextNrOrdine' => $nextNrOrdine,
     ])
 </div>
 

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -2,6 +2,7 @@
     $currentFormType = $formType ?? old('form_type');
     $currentFormId = (int) ($formId ?? old('form_id'));
     $tariCollection = collect($tari ?? [])->keyBy('id');
+    $nextNrOrdine = max(1, (int) ($nextNrOrdine ?? 1));
     $resolveTaraName = static function ($id) use ($tariCollection) {
         if ($id === null || $id === '') {
             return '';
@@ -60,6 +61,7 @@
                     <input type="hidden" name="form_type" value="create">
                     <div class="modal-body">
                         @php
+                            $createNrOrdine = $isCreateActive ? old('nr_ordine', $nextNrOrdine) : $nextNrOrdine;
                             $createNrCursa = $isCreateActive ? old('nr_cursa', '') : '';
                             $createIncarcareTaraId = $isCreateActive ? old('incarcare_tara_id', '') : '';
                             $createIncarcareTaraText = $isCreateActive ? old('incarcare_tara_text', '') : '';
@@ -88,7 +90,25 @@
                             }
                         @endphp
                         <div class="row g-3">
-                            <div class="col-md-4">
+                            <div class="col-md-3">
+                                <label for="cursa-create-nr-ordine" class="form-label">Nr. ordine</label>
+                                <input
+                                    type="number"
+                                    name="nr_ordine"
+                                    id="cursa-create-nr-ordine"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('nr_ordine') ? 'is-invalid' : '' }}"
+                                    value="{{ $createNrOrdine }}"
+                                    min="1"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('nr_ordine') ? 'd-block' : '' }}"
+                                    data-error-for="nr_ordine"
+                                >
+                                    {{ $isCreateActive ? $errors->first('nr_ordine') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-3">
                                 <label for="cursa-create-nr" class="form-label">Număr cursă</label>
                                 <input
                                     type="text"
@@ -105,7 +125,7 @@
                                     {{ $isCreateActive ? $errors->first('nr_cursa') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label for="cursa-create-incarcare-localitate" class="form-label">Localitate încărcare</label>
                                 <input
                                     type="text"
@@ -122,7 +142,7 @@
                                     {{ $isCreateActive ? $errors->first('incarcare_localitate') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label for="cursa-create-incarcare-cod-postal" class="form-label">Cod poștal încărcare</label>
                                 <input
                                     type="text"
@@ -351,6 +371,10 @@
         if ($editKmBordDescarcare === null) {
             $editKmBordDescarcare = '';
         }
+        $editNrOrdine = $isEditing ? old('nr_ordine', $cursa->nr_ordine) : $cursa->nr_ordine;
+        if ($editNrOrdine === null) {
+            $editNrOrdine = '';
+        }
         $editNrCursa = $isEditing ? old('nr_cursa', $cursa->nr_cursa) : $cursa->nr_cursa;
         if ($editNrCursa === null) {
             $editNrCursa = '';
@@ -382,7 +406,25 @@
                     <input type="hidden" name="form_id" value="{{ $cursa->id }}">
                     <div class="modal-body">
                         <div class="row g-3">
-                            <div class="col-md-4">
+                            <div class="col-md-3">
+                                <label for="{{ $editPrefix }}nr-ordine" class="form-label">Nr. ordine</label>
+                                <input
+                                    type="number"
+                                    name="nr_ordine"
+                                    id="{{ $editPrefix }}nr-ordine"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('nr_ordine') ? 'is-invalid' : '' }}"
+                                    value="{{ $editNrOrdine }}"
+                                    min="1"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('nr_ordine') ? 'd-block' : '' }}"
+                                    data-error-for="nr_ordine"
+                                >
+                                    {{ $isEditing ? $errors->first('nr_ordine') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-3">
                                 <label for="{{ $editPrefix }}nr" class="form-label">Număr cursă</label>
                                 <input
                                     type="text"
@@ -399,7 +441,7 @@
                                     {{ $isEditing ? $errors->first('nr_cursa') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label for="{{ $editPrefix }}incarcare-localitate" class="form-label">Localitate încărcare</label>
                                 <input
                                     type="text"
@@ -416,7 +458,7 @@
                                     {{ $isEditing ? $errors->first('incarcare_localitate') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
+                            <div class="col-md-3">
                                 <label for="{{ $editPrefix }}incarcare-cod-postal" class="form-label">Cod poștal încărcare</label>
                                 <input
                                     type="text"

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -3,6 +3,7 @@
         $dataCursa = $cursa->data_cursa?->format('d.m.Y H:i');
     @endphp
     <tr>
+        <td class="text-center fw-semibold">{{ $cursa->nr_ordine }}</td>
         <td class="text-nowrap">{{ $cursa->nr_cursa ?: '—' }}</td>
         <td>{{ $cursa->incarcare_localitate ?: '—' }}</td>
         <td>{{ $cursa->incarcare_cod_postal ?: '—' }}</td>

--- a/tests/Feature/Sofer/SoferValabilitateCursaTest.php
+++ b/tests/Feature/Sofer/SoferValabilitateCursaTest.php
@@ -49,6 +49,7 @@ class SoferValabilitateCursaTest extends TestCase
             ->from(route('sofer.valabilitati.show', $valabilitate))
             ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
                 'form_type' => 'create',
+                'nr_ordine' => 1,
                 'incarcare_localitate' => 'Cluj',
                 'descarcare_localitate' => 'Berlin',
                 'descarcare_tara_id' => $descarcareTara->id,
@@ -76,6 +77,7 @@ class SoferValabilitateCursaTest extends TestCase
             ->actingAs($driver)
             ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
                 'form_type' => 'create',
+                'nr_ordine' => 1,
                 'incarcare_localitate' => 'Cluj',
                 'descarcare_localitate' => 'Budapesta',
                 'descarcare_tara_id' => $tara->id,
@@ -102,7 +104,9 @@ class SoferValabilitateCursaTest extends TestCase
                 'data_sfarsit' => Carbon::today()->addWeek(),
             ]);
 
-        ValabilitateCursa::factory()->for($valabilitate)->create();
+        ValabilitateCursa::factory()->for($valabilitate)->create([
+            'nr_ordine' => 1,
+        ]);
 
         $romania = Tara::factory()->create(['nume' => 'Romania']);
 
@@ -111,6 +115,7 @@ class SoferValabilitateCursaTest extends TestCase
             ->from(route('sofer.valabilitati.show', $valabilitate))
             ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
                 'form_type' => 'create',
+                'nr_ordine' => 2,
                 'descarcare_tara_id' => $romania->id,
                 'data_cursa_date' => '2025-06-10',
                 'final_return' => 1,
@@ -132,6 +137,7 @@ class SoferValabilitateCursaTest extends TestCase
             ]);
 
         $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
+            'nr_ordine' => 1,
             'data_cursa' => '2025-05-01 07:00:00',
         ]);
 
@@ -143,6 +149,7 @@ class SoferValabilitateCursaTest extends TestCase
             ->put(route('sofer.valabilitati.curse.update', [$valabilitate, $cursa]), [
                 'form_type' => 'edit',
                 'form_id' => $cursa->id,
+                'nr_ordine' => $cursa->nr_ordine,
                 'descarcare_tara_id' => $romania->id,
                 'data_cursa_date' => '2025-05-02',
                 'final_return' => 1,

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -24,6 +24,7 @@ class ValabilitateCursaTest extends TestCase
         $descarcareTara = Tara::factory()->create(['nume' => 'Ungaria']);
 
         $response = $this->actingAs($user)->post(route('valabilitati.curse.store', $valabilitate), [
+            'nr_ordine' => 1,
             'incarcare_localitate' => 'Cluj-Napoca',
             'incarcare_cod_postal' => '400000',
             'incarcare_tara_id' => $incarcareTara->id,
@@ -44,6 +45,7 @@ class ValabilitateCursaTest extends TestCase
 
         $this->assertDatabaseHas('valabilitati_curse', [
             'valabilitate_id' => $valabilitate->id,
+            'nr_ordine' => 1,
             'incarcare_localitate' => 'Cluj-Napoca',
             'incarcare_cod_postal' => '400000',
             'incarcare_tara_id' => $incarcareTara->id,
@@ -67,6 +69,7 @@ class ValabilitateCursaTest extends TestCase
         $initialIncarcareTara = Tara::factory()->create(['nume' => 'Franța']);
         $initialDescarcareTara = Tara::factory()->create(['nume' => 'Italia']);
         $cursa = ValabilitateCursa::factory()->create([
+            'nr_ordine' => 1,
             'incarcare_localitate' => 'Brașov',
             'incarcare_cod_postal' => '500100',
             'incarcare_tara_id' => $initialIncarcareTara->id,
@@ -82,6 +85,7 @@ class ValabilitateCursaTest extends TestCase
         $newDescarcareTara = Tara::factory()->create(['nume' => 'Polonia']);
 
         $response = $this->actingAs($user)->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
+            'nr_ordine' => 2,
             'incarcare_localitate' => 'Iași',
             'incarcare_cod_postal' => '700505',
             'incarcare_tara_id' => $newIncarcareTara->id,
@@ -102,6 +106,7 @@ class ValabilitateCursaTest extends TestCase
 
         $this->assertDatabaseHas('valabilitati_curse', [
             'id' => $cursa->id,
+            'nr_ordine' => 2,
             'incarcare_localitate' => 'Iași',
             'incarcare_cod_postal' => '700505',
             'incarcare_tara_id' => $newIncarcareTara->id,
@@ -119,6 +124,7 @@ class ValabilitateCursaTest extends TestCase
     {
         $user = $this->createValabilitatiUser();
         $cursa = ValabilitateCursa::factory()->create([
+            'nr_ordine' => 3,
             'data_cursa' => '2025-05-02 09:00:00',
         ]);
         $newIncarcareTara = Tara::factory()->create(['nume' => 'Austria']);
@@ -131,6 +137,7 @@ class ValabilitateCursaTest extends TestCase
                 'Accept' => 'application/json',
             ])
             ->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
+                'nr_ordine' => 4,
                 'incarcare_localitate' => 'București',
                 'incarcare_cod_postal' => '010101',
                 'incarcare_tara_id' => $newIncarcareTara->id,
@@ -154,6 +161,7 @@ class ValabilitateCursaTest extends TestCase
 
         $this->assertDatabaseHas('valabilitati_curse', [
             'id' => $cursa->id,
+            'nr_ordine' => 4,
             'incarcare_localitate' => 'București',
             'descarcare_localitate' => 'Praga',
             'data_cursa' => '2025-05-10 11:15:00',
@@ -179,6 +187,7 @@ class ValabilitateCursaTest extends TestCase
         $incarcareTara = Tara::factory()->create(['nume' => 'Austria']);
         $descarcareTara = Tara::factory()->create(['nume' => 'Cehia']);
         $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
+            'nr_ordine' => 7,
             'incarcare_localitate' => 'Timișoara',
             'incarcare_cod_postal' => '300001',
             'incarcare_tara_id' => $incarcareTara->id,
@@ -198,6 +207,7 @@ class ValabilitateCursaTest extends TestCase
         $response->assertSeeText($incarcareTara->nume);
         $response->assertSeeText('Arad');
         $response->assertSeeText('310002');
+        $response->assertSeeText((string) $cursa->nr_ordine);
         $response->assertSeeText($descarcareTara->nume);
         $response->assertSeeText('10.06.2025 16:20');
         $response->assertSeeText('15400');


### PR DESCRIPTION
## Summary
- add an nr_ordine column with backfilled sequencing for existing valabilitati_curse rows
- require and cast nr_ordine across models, requests, controllers, and default ordering logic
- expose the course order in admin/driver UIs and feature tests for both interfaces

## Testing
- not run (composer install blocked by network restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691842ea73008326bd01bd984e7e6bc5)