### PR TITLE
Add km_maps field to valabilitati curse management

### DIFF
--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -32,6 +32,7 @@ class ValabilitateCursaRequest extends FormRequest
             'observatii' => ['nullable', 'string'],
             'km_bord_incarcare' => ['nullable', 'integer', 'min:0'],
             'km_bord_descarcare' => ['nullable', 'integer', 'min:0'],
+            'km_maps' => ['nullable', 'string', 'max:255'],
         ];
     }
 

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -26,6 +26,7 @@ class ValabilitateCursa extends Model
         'observatii',
         'km_bord_incarcare',
         'km_bord_descarcare',
+        'km_maps',
     ];
 
     protected $casts = [

--- a/database/migrations/2025_03_24_080000_add_km_maps_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_080000_add_km_maps_to_valabilitati_curse_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->string('km_maps')->nullable()->default('')->after('km_bord_descarcare');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn('km_maps');
+        });
+    }
+};

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -77,6 +77,7 @@
 
                             $createKmBordIncarcare = $isCreateActive ? old('km_bord_incarcare', '') : '';
                             $createKmBordDescarcare = $isCreateActive ? old('km_bord_descarcare', '') : '';
+                            $createKmMaps = $isCreateActive ? old('km_maps', '') : '';
                             $createDataDateValue = $isCreateActive ? old('data_cursa_date', '') : '';
                             $createDataTimeValue = $isCreateActive ? old('data_cursa_time', '') : '';
                             if ($isCreateActive) {
@@ -303,6 +304,23 @@
                                     {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
                             </div>
+                            <div class="col-md-4">
+                                <label for="cursa-create-km-maps" class="form-label">Km Maps</label>
+                                <input
+                                    type="text"
+                                    name="km_maps"
+                                    id="cursa-create-km-maps"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmMaps }}"
+                                    maxlength="255"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps') ? 'd-block' : '' }}"
+                                    data-error-for="km_maps"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_maps') : '' }}
+                                </div>
+                            </div>
                             <div class="col-12">
                                 <label for="cursa-create-observatii" class="form-label">Observații</label>
                                 <textarea
@@ -370,6 +388,10 @@
         $editKmBordDescarcare = $isEditing ? old('km_bord_descarcare', $cursa->km_bord_descarcare) : $cursa->km_bord_descarcare;
         if ($editKmBordDescarcare === null) {
             $editKmBordDescarcare = '';
+        }
+        $editKmMaps = $isEditing ? old('km_maps', $cursa->km_maps) : $cursa->km_maps;
+        if ($editKmMaps === null) {
+            $editKmMaps = '';
         }
         $editNrOrdine = $isEditing ? old('nr_ordine', $cursa->nr_ordine) : $cursa->nr_ordine;
         if ($editNrOrdine === null) {
@@ -617,6 +639,23 @@
                                     data-error-for="km_bord_descarcare"
                                 >
                                     {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}km-maps" class="form-label">Km Maps</label>
+                                <input
+                                    type="text"
+                                    name="km_maps"
+                                    id="{{ $editPrefix }}km-maps"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmMaps }}"
+                                    maxlength="255"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_maps') ? 'd-block' : '' }}"
+                                    data-error-for="km_maps"
+                                >
+                                    {{ $isEditing ? $errors->first('km_maps') : '' }}
                                 </div>
                             </div>
                             <div class="col-12">


### PR DESCRIPTION
## Summary
- add a km_maps column to the valabilitati_curse table with a nullable empty-string default
- allow ValabilitateCursa records to accept km_maps data through the model and request validation
- expose km_maps as a configurable field in the admin create/edit modals

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69184c5d6f488326bfe3730bd06fcdfe)