### PR TITLE
Remove nr_ordine inputs from cursa forms

### DIFF
--- a/app/Http/Controllers/SoferValabilitateCursaController.php
+++ b/app/Http/Controllers/SoferValabilitateCursaController.php
@@ -50,7 +50,6 @@ class SoferValabilitateCursaController extends Controller
             'requiresTime' => $requiresTime,
             'lockTime' => $requiresTime,
             'romanianCountryIds' => $this->determineRomanianCountryIds($tari),
-            'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
         ]);
     }
 
@@ -74,7 +73,6 @@ class SoferValabilitateCursaController extends Controller
             'requiresTime' => $hasDateTime,
             'lockTime' => false,
             'romanianCountryIds' => $this->determineRomanianCountryIds($tari),
-            'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
         ]);
     }
 
@@ -82,7 +80,13 @@ class SoferValabilitateCursaController extends Controller
     {
         $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
 
-        $valabilitate->curse()->create($request->validated());
+        $data = $request->validated();
+
+        if (! array_key_exists('nr_ordine', $data)) {
+            $data['nr_ordine'] = $this->resolveNextNrOrdine($valabilitate);
+        }
+
+        $valabilitate->curse()->create($data);
 
         return redirect()
             ->route('sofer.valabilitati.show', $valabilitate)

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -42,7 +42,6 @@ class ValabilitateCursaController extends Controller
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitate, $curse),
             'backUrl' => ValabilitatiFilterState::route(),
             'tari' => $this->loadTari(),
-            'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
         ]);
     }
 
@@ -65,7 +64,6 @@ class ValabilitateCursaController extends Controller
                 'curse' => $curse,
                 'includeCreate' => false,
                 'tari' => $this->loadTari(),
-                'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($request, $valabilitate, $curse),
         ]);
@@ -75,7 +73,13 @@ class ValabilitateCursaController extends Controller
     {
         $this->authorize('update', $valabilitate);
 
-        $valabilitate->curse()->create($request->validated());
+        $data = $request->validated();
+
+        if (! array_key_exists('nr_ordine', $data)) {
+            $data['nr_ordine'] = $this->resolveNextNrOrdine($valabilitate);
+        }
+
+        $valabilitate->curse()->create($data);
 
         return $this->respondAfterMutation($request, $valabilitate, 'Cursa a fost adăugată cu succes.');
     }
@@ -257,7 +261,6 @@ class ValabilitateCursaController extends Controller
                 'formType' => old('form_type'),
                 'formId' => old('form_id'),
                 'tari' => $this->loadTari(),
-                'nextNrOrdine' => $this->resolveNextNrOrdine($valabilitate),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($filtersRequest, $valabilitate, $curse),
         ]);

--- a/app/Http/Requests/SoferValabilitateCursaRequest.php
+++ b/app/Http/Requests/SoferValabilitateCursaRequest.php
@@ -26,7 +26,7 @@ class SoferValabilitateCursaRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'nr_ordine' => ['required', 'integer', 'min:1'],
+            'nr_ordine' => ['sometimes', 'integer', 'min:1'],
             'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -20,7 +20,7 @@ class ValabilitateCursaRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'nr_ordine' => ['required', 'integer', 'min:1'],
+            'nr_ordine' => ['sometimes', 'integer', 'min:1'],
             'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],

--- a/resources/views/sofer/valabilitati/curse/create.blade.php
+++ b/resources/views/sofer/valabilitati/curse/create.blade.php
@@ -22,7 +22,6 @@
                 'requiresTime' => $requiresTime,
                 'lockTime' => $lockTime,
                 'romanianCountryIds' => $romanianCountryIds,
-                'nextNrOrdine' => $nextNrOrdine,
             ])
         </div>
     </div>

--- a/resources/views/sofer/valabilitati/curse/edit.blade.php
+++ b/resources/views/sofer/valabilitati/curse/edit.blade.php
@@ -23,7 +23,6 @@
                 'requiresTime' => $requiresTime,
                 'lockTime' => $lockTime,
                 'romanianCountryIds' => $romanianCountryIds,
-                'nextNrOrdine' => $nextNrOrdine,
             ])
         </div>
     </div>

--- a/resources/views/sofer/valabilitati/curse/partials/form.blade.php
+++ b/resources/views/sofer/valabilitati/curse/partials/form.blade.php
@@ -37,8 +37,6 @@
     }
 
     $requireTimeDefault = $requiresTime || $finalReturnValue === 1 || $lockTime;
-    $nextNrOrdine = isset($nextNrOrdine) ? (int) $nextNrOrdine : 1;
-    $nrOrdine = old('nr_ordine', optional($cursa)->nr_ordine ?? $nextNrOrdine);
     $nrCursa = old('nr_cursa', optional($cursa)->nr_cursa);
 @endphp
 
@@ -62,20 +60,6 @@
     <input type="hidden" name="final_return" value="{{ $finalReturnValue }}" data-final-return-input>
 
     <div class="row g-3">
-        <div class="col-12 col-md-6">
-            <label class="form-label small text-uppercase fw-semibold">Nr. ordine</label>
-            <input
-                type="number"
-                name="nr_ordine"
-                class="form-control form-control-sm @error('nr_ordine') is-invalid @enderror"
-                value="{{ $nrOrdine }}"
-                min="1"
-                step="1"
-            >
-            @error('nr_ordine')
-                <div class="invalid-feedback">{{ $message }}</div>
-            @enderror
-        </div>
         <div class="col-12 col-md-6">
             <label class="form-label small text-uppercase fw-semibold">Număr cursă</label>
             <input

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -169,7 +169,6 @@
         'formType' => old('form_type'),
         'formId' => old('form_id'),
         'tari' => $tari,
-        'nextNrOrdine' => $nextNrOrdine,
     ])
 </div>
 

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -2,7 +2,6 @@
     $currentFormType = $formType ?? old('form_type');
     $currentFormId = (int) ($formId ?? old('form_id'));
     $tariCollection = collect($tari ?? [])->keyBy('id');
-    $nextNrOrdine = max(1, (int) ($nextNrOrdine ?? 1));
     $resolveTaraName = static function ($id) use ($tariCollection) {
         if ($id === null || $id === '') {
             return '';
@@ -61,7 +60,6 @@
                     <input type="hidden" name="form_type" value="create">
                     <div class="modal-body">
                         @php
-                            $createNrOrdine = $isCreateActive ? old('nr_ordine', $nextNrOrdine) : $nextNrOrdine;
                             $createNrCursa = $isCreateActive ? old('nr_cursa', '') : '';
                             $createIncarcareTaraId = $isCreateActive ? old('incarcare_tara_id', '') : '';
                             $createIncarcareTaraText = $isCreateActive ? old('incarcare_tara_text', '') : '';
@@ -91,24 +89,6 @@
                             }
                         @endphp
                         <div class="row g-3">
-                            <div class="col-md-3">
-                                <label for="cursa-create-nr-ordine" class="form-label">Nr. ordine</label>
-                                <input
-                                    type="number"
-                                    name="nr_ordine"
-                                    id="cursa-create-nr-ordine"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('nr_ordine') ? 'is-invalid' : '' }}"
-                                    value="{{ $createNrOrdine }}"
-                                    min="1"
-                                    step="1"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isCreateActive && $errors->has('nr_ordine') ? 'd-block' : '' }}"
-                                    data-error-for="nr_ordine"
-                                >
-                                    {{ $isCreateActive ? $errors->first('nr_ordine') : '' }}
-                                </div>
-                            </div>
                             <div class="col-md-3">
                                 <label for="cursa-create-nr" class="form-label">Număr cursă</label>
                                 <input
@@ -393,10 +373,6 @@
         if ($editKmMaps === null) {
             $editKmMaps = '';
         }
-        $editNrOrdine = $isEditing ? old('nr_ordine', $cursa->nr_ordine) : $cursa->nr_ordine;
-        if ($editNrOrdine === null) {
-            $editNrOrdine = '';
-        }
         $editNrCursa = $isEditing ? old('nr_cursa', $cursa->nr_cursa) : $cursa->nr_cursa;
         if ($editNrCursa === null) {
             $editNrCursa = '';
@@ -428,24 +404,6 @@
                     <input type="hidden" name="form_id" value="{{ $cursa->id }}">
                     <div class="modal-body">
                         <div class="row g-3">
-                            <div class="col-md-3">
-                                <label for="{{ $editPrefix }}nr-ordine" class="form-label">Nr. ordine</label>
-                                <input
-                                    type="number"
-                                    name="nr_ordine"
-                                    id="{{ $editPrefix }}nr-ordine"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('nr_ordine') ? 'is-invalid' : '' }}"
-                                    value="{{ $editNrOrdine }}"
-                                    min="1"
-                                    step="1"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isEditing && $errors->has('nr_ordine') ? 'd-block' : '' }}"
-                                    data-error-for="nr_ordine"
-                                >
-                                    {{ $isEditing ? $errors->first('nr_ordine') : '' }}
-                                </div>
-                            </div>
                             <div class="col-md-3">
                                 <label for="{{ $editPrefix }}nr" class="form-label">Număr cursă</label>
                                 <input

--- a/tests/Feature/Sofer/SoferValabilitateCursaTest.php
+++ b/tests/Feature/Sofer/SoferValabilitateCursaTest.php
@@ -49,7 +49,6 @@ class SoferValabilitateCursaTest extends TestCase
             ->from(route('sofer.valabilitati.show', $valabilitate))
             ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
                 'form_type' => 'create',
-                'nr_ordine' => 1,
                 'incarcare_localitate' => 'Cluj',
                 'descarcare_localitate' => 'Berlin',
                 'descarcare_tara_id' => $descarcareTara->id,
@@ -77,7 +76,6 @@ class SoferValabilitateCursaTest extends TestCase
             ->actingAs($driver)
             ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
                 'form_type' => 'create',
-                'nr_ordine' => 1,
                 'incarcare_localitate' => 'Cluj',
                 'descarcare_localitate' => 'Budapesta',
                 'descarcare_tara_id' => $tara->id,
@@ -115,7 +113,6 @@ class SoferValabilitateCursaTest extends TestCase
             ->from(route('sofer.valabilitati.show', $valabilitate))
             ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
                 'form_type' => 'create',
-                'nr_ordine' => 2,
                 'descarcare_tara_id' => $romania->id,
                 'data_cursa_date' => '2025-06-10',
                 'final_return' => 1,
@@ -149,7 +146,6 @@ class SoferValabilitateCursaTest extends TestCase
             ->put(route('sofer.valabilitati.curse.update', [$valabilitate, $cursa]), [
                 'form_type' => 'edit',
                 'form_id' => $cursa->id,
-                'nr_ordine' => $cursa->nr_ordine,
                 'descarcare_tara_id' => $romania->id,
                 'data_cursa_date' => '2025-05-02',
                 'final_return' => 1,

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -24,7 +24,6 @@ class ValabilitateCursaTest extends TestCase
         $descarcareTara = Tara::factory()->create(['nume' => 'Ungaria']);
 
         $response = $this->actingAs($user)->post(route('valabilitati.curse.store', $valabilitate), [
-            'nr_ordine' => 1,
             'incarcare_localitate' => 'Cluj-Napoca',
             'incarcare_cod_postal' => '400000',
             'incarcare_tara_id' => $incarcareTara->id,
@@ -85,7 +84,6 @@ class ValabilitateCursaTest extends TestCase
         $newDescarcareTara = Tara::factory()->create(['nume' => 'Polonia']);
 
         $response = $this->actingAs($user)->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
-            'nr_ordine' => 2,
             'incarcare_localitate' => 'Iași',
             'incarcare_cod_postal' => '700505',
             'incarcare_tara_id' => $newIncarcareTara->id,
@@ -106,7 +104,7 @@ class ValabilitateCursaTest extends TestCase
 
         $this->assertDatabaseHas('valabilitati_curse', [
             'id' => $cursa->id,
-            'nr_ordine' => 2,
+            'nr_ordine' => 1,
             'incarcare_localitate' => 'Iași',
             'incarcare_cod_postal' => '700505',
             'incarcare_tara_id' => $newIncarcareTara->id,
@@ -137,7 +135,6 @@ class ValabilitateCursaTest extends TestCase
                 'Accept' => 'application/json',
             ])
             ->put(route('valabilitati.curse.update', [$cursa->valabilitate, $cursa]), [
-                'nr_ordine' => 4,
                 'incarcare_localitate' => 'București',
                 'incarcare_cod_postal' => '010101',
                 'incarcare_tara_id' => $newIncarcareTara->id,
@@ -161,7 +158,7 @@ class ValabilitateCursaTest extends TestCase
 
         $this->assertDatabaseHas('valabilitati_curse', [
             'id' => $cursa->id,
-            'nr_ordine' => 4,
+            'nr_ordine' => 3,
             'incarcare_localitate' => 'București',
             'descarcare_localitate' => 'Praga',
             'data_cursa' => '2025-05-10 11:15:00',


### PR DESCRIPTION
## Summary
- remove the nr_ordine inputs from the driver and admin cursa forms/modals so ordering is only handled via the dedicated controls
- relax the cursa request validation and auto-assign the next order number on create when the field is not submitted
- update the feature tests to reflect the implicit ordering behaviour

## Testing
- ⚠️ `./vendor/bin/phpunit` *(fails: phpunit binary missing because composer install cannot run without network access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69185f536c10832683cf0af9ff2037c2)