### PR TITLE
Add name field to road taxes

### DIFF
--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\User;
+use App\Models\ValabilitateTaxaDrum;
 
 class Valabilitate extends Model
 {
@@ -46,6 +47,13 @@ class Valabilitate extends Model
     public function cursas(): HasMany
     {
         return $this->curse();
+    }
+
+    public function taxeDrum(): HasMany
+    {
+        return $this->hasMany(ValabilitateTaxaDrum::class)
+            ->orderBy('data')
+            ->orderBy('id');
     }
 
     public function syncSummary(): void

--- a/app/Models/ValabilitateTaxaDrum.php
+++ b/app/Models/ValabilitateTaxaDrum.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ValabilitateTaxaDrum extends Model
+{
+    use HasFactory;
+
+    protected $table = 'valabilitati_taxe_drum';
+
+    protected $fillable = [
+        'valabilitate_id',
+        'nume',
+        'tara',
+        'suma',
+        'moneda',
+        'data',
+        'observatii',
+    ];
+
+    protected $casts = [
+        'data' => 'date',
+        'suma' => 'decimal:2',
+    ];
+
+    public function valabilitate(): BelongsTo
+    {
+        return $this->belongsTo(Valabilitate::class);
+    }
+}

--- a/database/factories/ValabilitateTaxaDrumFactory.php
+++ b/database/factories/ValabilitateTaxaDrumFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Valabilitate;
+use App\Models\ValabilitateTaxaDrum;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\ValabilitateTaxaDrum>
+ */
+class ValabilitateTaxaDrumFactory extends Factory
+{
+    protected $model = ValabilitateTaxaDrum::class;
+
+    public function definition(): array
+    {
+        return [
+            'valabilitate_id' => Valabilitate::factory(),
+            'nume' => fake()->words(3, true),
+            'tara' => fake()->country(),
+            'suma' => fake()->randomFloat(2, 1, 500),
+            'moneda' => strtoupper(fake()->currencyCode()),
+            'data' => fake()->date(),
+            'observatii' => fake()->optional()->sentence(),
+        ];
+    }
+}

--- a/database/migrations/2025_03_20_000000_create_valabilitati_taxe_drum_table.php
+++ b/database/migrations/2025_03_20_000000_create_valabilitati_taxe_drum_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('valabilitati_taxe_drum', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('valabilitate_id')
+                ->constrained('valabilitati')
+                ->cascadeOnDelete();
+            $table->string('nume')->nullable();
+            $table->string('tara');
+            $table->decimal('suma', 10, 2);
+            $table->string('moneda', 10);
+            $table->date('data');
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('valabilitati_taxe_drum');
+    }
+};

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -331,10 +331,24 @@
                     return;
                 }
 
+                const toBracketNotation = field =>
+                    field
+                        .split('.')
+                        .map((segment, index) => (index === 0 ? segment : `[${segment}]`))
+                        .join('');
+
                 Object.entries(errors).forEach(([field, messages]) => {
-                    const inputs = form.querySelectorAll(`[name="${field}"]`);
-                    inputs.forEach(input => {
-                        input.classList.add('is-invalid');
+                    const selectors = [field];
+
+                    if (field.includes('.')) {
+                        selectors.push(toBracketNotation(field));
+                    }
+
+                    selectors.forEach(name => {
+                        const inputs = form.querySelectorAll(`[name="${name}"]`);
+                        inputs.forEach(input => {
+                            input.classList.add('is-invalid');
+                        });
                     });
 
                     const feedback = form.querySelector(`[data-error-for="${field}"]`);
@@ -379,6 +393,10 @@
                 if (modalsContainer && data.modals_html) {
                     modalsContainer.innerHTML = data.modals_html;
                     modalsContainer.dataset.activeModal = '';
+
+                    if (typeof window.initializeRoadTaxCollections === 'function') {
+                        window.initializeRoadTaxCollections(modalsContainer);
+                    }
                 }
 
                 const loadMoreTrigger = document.getElementById('valabilitati-load-more-trigger');
@@ -555,6 +573,10 @@
 
                         if (data.modals_html && modalsContainer) {
                             appendHtml(modalsContainer, data.modals_html);
+
+                            if (typeof window.initializeRoadTaxCollections === 'function') {
+                                window.initializeRoadTaxCollections(modalsContainer);
+                            }
                         }
 
                         loadState.nextUrl = data.next_url || null;

--- a/resources/views/valabilitati/partials/modals.blade.php
+++ b/resources/views/valabilitati/partials/modals.blade.php
@@ -97,6 +97,12 @@
                                 </div>
                             </div>
                         </div>
+
+                        @include('valabilitati.partials.road-taxes-form', [
+                            'entries' => $isCreateActive ? old('taxe_drum', []) : [],
+                            'formPrefix' => 'valabilitate-create-',
+                            'isActive' => $isCreateActive,
+                        ])
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
@@ -212,6 +218,12 @@
                                 </div>
                             </div>
                         </div>
+
+                        @include('valabilitati.partials.road-taxes-form', [
+                            'entries' => $isEditing ? old('taxe_drum', $valabilitate->taxeDrum->toArray()) : $valabilitate->taxeDrum,
+                            'formPrefix' => $editPrefix,
+                            'isActive' => $isEditing,
+                        ])
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
@@ -248,3 +260,5 @@
         </div>
     </div>
 @endforeach
+
+@include('valabilitati.partials.road-taxes-script')

--- a/resources/views/valabilitati/partials/road-taxes-form.blade.php
+++ b/resources/views/valabilitati/partials/road-taxes-form.blade.php
@@ -1,0 +1,249 @@
+@php
+    $fieldName = $fieldName ?? 'taxe_drum';
+    $formPrefix = $formPrefix ?? '';
+    $isActive = $isActive ?? false;
+
+    $normalizedEntries = collect($entries ?? [])->map(function ($entry) {
+        if ($entry instanceof \App\Models\ValabilitateTaxaDrum) {
+            return [
+                'nume' => $entry->nume ?? '',
+                'tara' => $entry->tara ?? '',
+                'suma' => number_format((float) $entry->suma, 2, '.', ''),
+                'moneda' => $entry->moneda ?? '',
+                'data' => optional($entry->data)->format('Y-m-d') ?? '',
+                'observatii' => $entry->observatii ?? '',
+            ];
+        }
+
+        return [
+            'nume' => $entry['nume'] ?? '',
+            'tara' => $entry['tara'] ?? '',
+            'suma' => isset($entry['suma']) && $entry['suma'] !== null ? (string) $entry['suma'] : '',
+            'moneda' => $entry['moneda'] ?? '',
+            'data' => $entry['data'] ?? '',
+            'observatii' => $entry['observatii'] ?? '',
+        ];
+    })->values();
+
+    $entriesCount = $normalizedEntries->count();
+    $generalErrorKey = $fieldName;
+    $generalHasError = $isActive && $errors->has($generalErrorKey);
+    $idPrefix = $formPrefix . 'taxe-drum-';
+@endphp
+
+<div class="mb-4" data-road-tax-wrapper>
+    <div class="d-flex flex-column flex-lg-row justify-content-lg-between align-items-lg-center gap-2">
+        <label class="form-label mb-0">Taxe de drum</label>
+        <button type="button" class="btn btn-sm btn-outline-primary" data-road-tax-add>
+            <i class="fa-solid fa-plus me-1"></i>Adaugă taxă de drum
+        </button>
+    </div>
+    <div class="invalid-feedback {{ $generalHasError ? 'd-block' : '' }}" data-error-for="{{ $generalErrorKey }}">
+        {{ $generalHasError ? $errors->first($generalErrorKey) : '' }}
+    </div>
+
+    <div
+        class="road-tax-collection mt-3"
+        data-next-index="{{ $entriesCount }}"
+        data-field-name="{{ $fieldName }}"
+        data-id-prefix="{{ $idPrefix }}"
+    >
+        <p class="text-muted fst-italic road-tax-empty {{ $entriesCount ? 'd-none' : '' }}">
+            Nu există taxe de drum adăugate.
+        </p>
+        <div class="road-tax-items">
+            @foreach ($normalizedEntries as $index => $taxa)
+                @php
+                    $fieldPrefix = $fieldName . '[' . $index . ']';
+                    $errorPrefix = $fieldName . '.' . $index . '.';
+                    $rowIdPrefix = $idPrefix . $index . '-';
+
+                    $numeErrorKey = $errorPrefix . 'nume';
+                    $taraErrorKey = $errorPrefix . 'tara';
+                    $sumaErrorKey = $errorPrefix . 'suma';
+                    $monedaErrorKey = $errorPrefix . 'moneda';
+                    $dataErrorKey = $errorPrefix . 'data';
+                    $observatiiErrorKey = $errorPrefix . 'observatii';
+
+                    $numeHasError = $isActive && $errors->has($numeErrorKey);
+                    $taraHasError = $isActive && $errors->has($taraErrorKey);
+                    $sumaHasError = $isActive && $errors->has($sumaErrorKey);
+                    $monedaHasError = $isActive && $errors->has($monedaErrorKey);
+                    $dataHasError = $isActive && $errors->has($dataErrorKey);
+                    $observatiiHasError = $isActive && $errors->has($observatiiErrorKey);
+                @endphp
+                <div class="card mb-3 road-tax-entry" data-index="{{ $index }}">
+                    <div class="card-body pb-0">
+                        <div class="row g-3 align-items-end">
+                            <div class="col-md-3">
+                                <label for="{{ $rowIdPrefix }}nume" class="form-label">Nume</label>
+                                <input
+                                    type="text"
+                                    name="{{ $fieldPrefix }}[nume]"
+                                    id="{{ $rowIdPrefix }}nume"
+                                    class="form-control bg-white rounded-3 {{ $numeHasError ? 'is-invalid' : '' }}"
+                                    value="{{ $taxa['nume'] }}"
+                                    autocomplete="off"
+                                >
+                                <div class="invalid-feedback {{ $numeHasError ? 'd-block' : '' }}" data-error-for="{{ $numeErrorKey }}">
+                                    {{ $numeHasError ? $errors->first($numeErrorKey) : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-2">
+                                <label for="{{ $rowIdPrefix }}tara" class="form-label">Țară<span class="text-danger">*</span></label>
+                                <input
+                                    type="text"
+                                    name="{{ $fieldPrefix }}[tara]"
+                                    id="{{ $rowIdPrefix }}tara"
+                                    class="form-control bg-white rounded-3 {{ $taraHasError ? 'is-invalid' : '' }}"
+                                    value="{{ $taxa['tara'] }}"
+                                    autocomplete="off"
+                                >
+                                <div class="invalid-feedback {{ $taraHasError ? 'd-block' : '' }}" data-error-for="{{ $taraErrorKey }}">
+                                    {{ $taraHasError ? $errors->first($taraErrorKey) : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-2">
+                                <label for="{{ $rowIdPrefix }}suma" class="form-label">Sumă<span class="text-danger">*</span></label>
+                                <input
+                                    type="text"
+                                    name="{{ $fieldPrefix }}[suma]"
+                                    id="{{ $rowIdPrefix }}suma"
+                                    class="form-control bg-white rounded-3 {{ $sumaHasError ? 'is-invalid' : '' }}"
+                                    value="{{ $taxa['suma'] }}"
+                                    autocomplete="off"
+                                    inputmode="decimal"
+                                >
+                                <div class="invalid-feedback {{ $sumaHasError ? 'd-block' : '' }}" data-error-for="{{ $sumaErrorKey }}">
+                                    {{ $sumaHasError ? $errors->first($sumaErrorKey) : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-2">
+                                <label for="{{ $rowIdPrefix }}moneda" class="form-label">Monedă<span class="text-danger">*</span></label>
+                                <input
+                                    type="text"
+                                    name="{{ $fieldPrefix }}[moneda]"
+                                    id="{{ $rowIdPrefix }}moneda"
+                                    class="form-control bg-white rounded-3 text-uppercase {{ $monedaHasError ? 'is-invalid' : '' }}"
+                                    value="{{ $taxa['moneda'] }}"
+                                    autocomplete="off"
+                                >
+                                <div class="invalid-feedback {{ $monedaHasError ? 'd-block' : '' }}" data-error-for="{{ $monedaErrorKey }}">
+                                    {{ $monedaHasError ? $errors->first($monedaErrorKey) : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-2">
+                                <label for="{{ $rowIdPrefix }}data" class="form-label">Dată<span class="text-danger">*</span></label>
+                                <input
+                                    type="date"
+                                    name="{{ $fieldPrefix }}[data]"
+                                    id="{{ $rowIdPrefix }}data"
+                                    class="form-control bg-white rounded-3 {{ $dataHasError ? 'is-invalid' : '' }}"
+                                    value="{{ $taxa['data'] }}"
+                                >
+                                <div class="invalid-feedback {{ $dataHasError ? 'd-block' : '' }}" data-error-for="{{ $dataErrorKey }}">
+                                    {{ $dataHasError ? $errors->first($dataErrorKey) : '' }}
+                                </div>
+                            </div>
+                            <div class="col-12 col-md-1 text-md-end">
+                                <button type="button" class="btn btn-outline-danger btn-sm" data-road-tax-remove>
+                                    <i class="fa-solid fa-trash-can me-1"></i>Șterge
+                                </button>
+                            </div>
+                            <div class="col-12">
+                                <label for="{{ $rowIdPrefix }}observatii" class="form-label">Observații</label>
+                                <textarea
+                                    name="{{ $fieldPrefix }}[observatii]"
+                                    id="{{ $rowIdPrefix }}observatii"
+                                    class="form-control bg-white rounded-3 {{ $observatiiHasError ? 'is-invalid' : '' }}"
+                                    rows="2"
+                                >{{ $taxa['observatii'] }}</textarea>
+                                <div class="invalid-feedback {{ $observatiiHasError ? 'd-block' : '' }}" data-error-for="{{ $observatiiErrorKey }}">
+                                    {{ $observatiiHasError ? $errors->first($observatiiErrorKey) : '' }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+        <template class="road-tax-template">
+            <div class="card mb-3 road-tax-entry" data-index="__INDEX__">
+                <div class="card-body pb-0">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-md-3">
+                            <label for="{{ $idPrefix }}__INDEX__-nume" class="form-label">Nume</label>
+                            <input
+                                type="text"
+                                name="{{ $fieldName }}[__INDEX__][nume]"
+                                id="{{ $idPrefix }}__INDEX__-nume"
+                                class="form-control bg-white rounded-3"
+                                autocomplete="off"
+                            >
+                            <div class="invalid-feedback" data-error-for="{{ $fieldName }}.__INDEX__.nume"></div>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="{{ $idPrefix }}__INDEX__-tara" class="form-label">Țară<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="{{ $fieldName }}[__INDEX__][tara]"
+                                id="{{ $idPrefix }}__INDEX__-tara"
+                                class="form-control bg-white rounded-3"
+                                autocomplete="off"
+                            >
+                            <div class="invalid-feedback" data-error-for="{{ $fieldName }}.__INDEX__.tara"></div>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="{{ $idPrefix }}__INDEX__-suma" class="form-label">Sumă<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="{{ $fieldName }}[__INDEX__][suma]"
+                                id="{{ $idPrefix }}__INDEX__-suma"
+                                class="form-control bg-white rounded-3"
+                                autocomplete="off"
+                                inputmode="decimal"
+                            >
+                            <div class="invalid-feedback" data-error-for="{{ $fieldName }}.__INDEX__.suma"></div>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="{{ $idPrefix }}__INDEX__-moneda" class="form-label">Monedă<span class="text-danger">*</span></label>
+                            <input
+                                type="text"
+                                name="{{ $fieldName }}[__INDEX__][moneda]"
+                                id="{{ $idPrefix }}__INDEX__-moneda"
+                                class="form-control bg-white rounded-3 text-uppercase"
+                                autocomplete="off"
+                            >
+                            <div class="invalid-feedback" data-error-for="{{ $fieldName }}.__INDEX__.moneda"></div>
+                        </div>
+                        <div class="col-md-2">
+                            <label for="{{ $idPrefix }}__INDEX__-data" class="form-label">Dată<span class="text-danger">*</span></label>
+                            <input
+                                type="date"
+                                name="{{ $fieldName }}[__INDEX__][data]"
+                                id="{{ $idPrefix }}__INDEX__-data"
+                                class="form-control bg-white rounded-3"
+                            >
+                            <div class="invalid-feedback" data-error-for="{{ $fieldName }}.__INDEX__.data"></div>
+                        </div>
+                        <div class="col-12 col-md-1 text-md-end">
+                            <button type="button" class="btn btn-outline-danger btn-sm" data-road-tax-remove>
+                                <i class="fa-solid fa-trash-can me-1"></i>Șterge
+                            </button>
+                        </div>
+                        <div class="col-12">
+                            <label for="{{ $idPrefix }}__INDEX__-observatii" class="form-label">Observații</label>
+                            <textarea
+                                name="{{ $fieldName }}[__INDEX__][observatii]"
+                                id="{{ $idPrefix }}__INDEX__-observatii"
+                                class="form-control bg-white rounded-3"
+                                rows="2"
+                            ></textarea>
+                            <div class="invalid-feedback" data-error-for="{{ $fieldName }}.__INDEX__.observatii"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
+</div>

--- a/resources/views/valabilitati/partials/road-taxes-script.blade.php
+++ b/resources/views/valabilitati/partials/road-taxes-script.blade.php
@@ -1,0 +1,163 @@
+@once
+    @push('page-scripts')
+        <script>
+            (function () {
+                function escapeRegExp(value) {
+                    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                }
+
+                function updateEmptyState(collection) {
+                    const itemsContainer = collection.querySelector('.road-tax-items');
+                    const emptyState = collection.querySelector('.road-tax-empty');
+
+                    if (!itemsContainer || !emptyState) {
+                        return;
+                    }
+
+                    const hasItems = itemsContainer.querySelector('.road-tax-entry') !== null;
+                    emptyState.classList.toggle('d-none', hasItems);
+                }
+
+                function renumberEntries(collection) {
+                    const items = collection.querySelectorAll('.road-tax-entry');
+                    const fieldName = collection.dataset.fieldName || 'taxe_drum';
+                    const idPrefix = collection.dataset.idPrefix || 'taxe-drum-';
+                    const namePattern = new RegExp(`${escapeRegExp(fieldName)}\[\\d+\]`);
+                    const errorPattern = new RegExp(`${escapeRegExp(fieldName)}\\.\\d+`);
+                    const idPattern = new RegExp(`${escapeRegExp(idPrefix)}\\d+`);
+
+                    items.forEach((entry, index) => {
+                        entry.dataset.index = String(index);
+
+                        entry.querySelectorAll('[name]').forEach(element => {
+                            const name = element.getAttribute('name');
+                            if (!name) {
+                                return;
+                            }
+
+                            element.setAttribute('name', name.replace(namePattern, `${fieldName}[${index}]`));
+                        });
+
+                        entry.querySelectorAll('[id]').forEach(element => {
+                            const id = element.getAttribute('id');
+                            if (!id || !idPattern.test(id)) {
+                                return;
+                            }
+
+                            element.setAttribute('id', id.replace(idPattern, `${idPrefix}${index}`));
+                        });
+
+                        entry.querySelectorAll('label[for]').forEach(label => {
+                            const target = label.getAttribute('for');
+                            if (!target || !idPattern.test(target)) {
+                                return;
+                            }
+
+                            label.setAttribute('for', target.replace(idPattern, `${idPrefix}${index}`));
+                        });
+
+                        entry.querySelectorAll('[data-error-for]').forEach(element => {
+                            const field = element.getAttribute('data-error-for');
+                            if (!field) {
+                                return;
+                            }
+
+                            element.setAttribute('data-error-for', field.replace(errorPattern, `${fieldName}.${index}`));
+                        });
+                    });
+
+                    collection.dataset.nextIndex = String(items.length);
+                }
+
+                function updateCollection(collection) {
+                    renumberEntries(collection);
+                    updateEmptyState(collection);
+                }
+
+                function addEntry(collection) {
+                    const template = collection.querySelector('template.road-tax-template');
+                    const itemsContainer = collection.querySelector('.road-tax-items');
+                    if (!template || !itemsContainer) {
+                        return;
+                    }
+
+                    const nextIndex = Number(collection.dataset.nextIndex || itemsContainer.children.length);
+                    const wrapper = document.createElement('div');
+                    wrapper.innerHTML = template.innerHTML.replace(/__INDEX__/g, String(nextIndex));
+                    const entry = wrapper.firstElementChild;
+
+                    if (!entry) {
+                        return;
+                    }
+
+                    itemsContainer.appendChild(entry);
+                    collection.dataset.nextIndex = String(nextIndex + 1);
+                    updateEmptyState(collection);
+                }
+
+                function handleAddButton(event) {
+                    const button = event.currentTarget;
+                    const wrapper = button.closest('[data-road-tax-wrapper]');
+                    if (!wrapper) {
+                        return;
+                    }
+
+                    const collection = wrapper.querySelector('.road-tax-collection');
+                    if (!collection) {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    addEntry(collection);
+                }
+
+                function handleCollectionClick(event) {
+                    const removeTrigger = event.target.closest('[data-road-tax-remove]');
+                    if (!removeTrigger) {
+                        return;
+                    }
+
+                    const collection = event.currentTarget;
+                    const entry = removeTrigger.closest('.road-tax-entry');
+                    if (!entry) {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    entry.remove();
+                    updateCollection(collection);
+                }
+
+                function initializeCollection(collection) {
+                    if (collection.dataset.initialized === 'true') {
+                        return;
+                    }
+
+                    collection.addEventListener('click', handleCollectionClick);
+                    updateCollection(collection);
+
+                    const wrapper = collection.closest('[data-road-tax-wrapper]');
+                    if (wrapper) {
+                        const addButton = wrapper.querySelector('[data-road-tax-add]');
+                        if (addButton && addButton.dataset.roadTaxBound !== 'true') {
+                            addButton.addEventListener('click', handleAddButton);
+                            addButton.dataset.roadTaxBound = 'true';
+                        }
+                    }
+
+                    collection.dataset.initialized = 'true';
+                }
+
+                window.initializeRoadTaxCollections = function (root) {
+                    const context = root instanceof Element ? root : document;
+                    const collections = context.querySelectorAll('.road-tax-collection');
+                    collections.forEach(collection => initializeCollection(collection));
+                };
+
+                document.addEventListener('DOMContentLoaded', () => {
+                    window.initializeRoadTaxCollections();
+                });
+            })();
+        </script>
+    @endpush
+@endonce

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -73,6 +73,43 @@
                 </div>
             </div>
         </div>
+
+        <div class="mt-4">
+            <div class="border rounded-3 p-3">
+                <h6 class="text-muted text-uppercase mb-2">Taxe de drum</h6>
+
+                @if ($valabilitate->taxeDrum->isEmpty())
+                    <p class="mb-0 text-muted">Nu există taxe de drum înregistrate.</p>
+                @else
+                    <div class="table-responsive">
+                        <table class="table table-sm align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Nume</th>
+                                    <th>Țară</th>
+                                    <th class="text-end">Sumă</th>
+                                    <th>Monedă</th>
+                                    <th>Dată</th>
+                                    <th>Observații</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($valabilitate->taxeDrum as $taxa)
+                                    <tr>
+                                        <td>{{ $taxa->nume ?? '—' }}</td>
+                                        <td>{{ $taxa->tara }}</td>
+                                        <td class="text-end">{{ number_format((float) $taxa->suma, 2, ',', '.') }}</td>
+                                        <td>{{ $taxa->moneda }}</td>
+                                        <td>{{ optional($taxa->data)->format('d.m.Y') ?? '—' }}</td>
+                                        <td>{{ $taxa->observatii ?? '—' }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+        </div>
     </div>
 </div>
 

--- a/tests/Feature/Valabilitati/ValabilitateRoadTaxesFrontendTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateRoadTaxesFrontendTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\Valabilitati;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateTaxaDrum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ValabilitateRoadTaxesFrontendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_edit_modal_prefills_existing_road_taxes(): void
+    {
+        $user = $this->createValabilitatiUser();
+
+        $valabilitate = Valabilitate::factory()->create([
+            'denumire' => 'Valabilitate modal',
+        ]);
+
+        ValabilitateTaxaDrum::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'nume' => 'Rovinietă',
+            'tara' => 'România',
+            'suma' => 123.45,
+            'moneda' => 'RON',
+            'data' => '2025-03-01',
+            'observatii' => 'Vignetă',
+        ]);
+
+        ValabilitateTaxaDrum::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'nume' => 'Autostradă Austria',
+            'tara' => 'Austria',
+            'suma' => 78.9,
+            'moneda' => 'HUF',
+            'data' => '2025-03-05',
+            'observatii' => 'Autostradă',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.index'));
+
+        $response->assertOk();
+        $response->assertSee('Adaugă taxă de drum', false);
+        $response->assertSee('name="taxe_drum[0][nume]"', false);
+        $response->assertSee('value="Rovinietă"', false);
+        $response->assertSee('name="taxe_drum[0][tara]"', false);
+        $response->assertSee('value="România"', false);
+        $response->assertSee('value="123.45"', false);
+        $response->assertSee('value="RON"', false);
+        $response->assertSee('value="2025-03-01"', false);
+        $response->assertSee('Vignetă', false);
+        $response->assertSee('name="taxe_drum[1][nume]"', false);
+        $response->assertSee('value="Autostradă Austria"', false);
+        $response->assertSee('name="taxe_drum[1][tara]"', false);
+        $response->assertSee('value="Austria"', false);
+        $response->assertSee('value="HUF"', false);
+        $response->assertSee('value="2025-03-05"', false);
+    }
+
+    public function test_show_page_displays_road_taxes_table(): void
+    {
+        $user = $this->createValabilitatiUser();
+
+        $valabilitate = Valabilitate::factory()->create([
+            'denumire' => 'Valabilitate vizualizare',
+        ]);
+
+        ValabilitateTaxaDrum::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'nume' => 'Rovinietă',
+            'tara' => 'România',
+            'suma' => 123.45,
+            'moneda' => 'RON',
+            'data' => '2025-03-01',
+            'observatii' => 'Vignetă',
+        ]);
+
+        ValabilitateTaxaDrum::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'nume' => 'Vignetă Ungaria',
+            'tara' => 'Ungaria',
+            'suma' => 67.89,
+            'moneda' => 'EUR',
+            'data' => '2025-03-10',
+            'observatii' => null,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.show', $valabilitate));
+
+        $response->assertOk();
+        $response->assertSeeText('Taxe de drum');
+        $response->assertSeeText('Rovinietă');
+        $response->assertSeeText('România');
+        $response->assertSeeText('Vignetă Ungaria');
+        $response->assertSeeText('Ungaria');
+        $response->assertSeeText('123,45');
+        $response->assertSeeText('67,89');
+        $response->assertSeeText('RON');
+        $response->assertSeeText('EUR');
+        $response->assertDontSeeText('Nu există taxe de drum înregistrate.');
+    }
+
+    private function createValabilitatiUser(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::create([
+            'name' => 'Valabilități',
+            'slug' => 'access-valabilitati',
+            'module' => 'valabilitati',
+        ]);
+
+        $role = Role::create([
+            'name' => 'Administrator',
+            'slug' => 'admin',
+        ]);
+
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+}

--- a/tests/Feature/Valabilitati/ValabilitateRoadTaxesTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateRoadTaxesTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Tests\Feature\Valabilitati;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\Valabilitate;
+use App\Models\ValabilitateTaxaDrum;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ValabilitateRoadTaxesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_store_valabilitate_with_road_taxes_via_json(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $driver = User::factory()->create();
+
+        $payload = [
+            'numar_auto' => 'B-99-XYZ',
+            'sofer_id' => $driver->id,
+            'denumire' => 'Valabilitate cu taxe',
+            'data_inceput' => '2025-03-01',
+            'data_sfarsit' => '2025-03-31',
+            'taxe_drum' => [
+                [
+                    'nume' => 'Rovinietă România',
+                    'tara' => 'România',
+                    'suma' => '123.45',
+                    'moneda' => 'RON',
+                    'data' => '2025-03-05',
+                    'observatii' => 'Taxă vignetă',
+                ],
+                [
+                    'nume' => 'Vignetă Ungaria',
+                    'tara' => 'Ungaria',
+                    'suma' => '67,89',
+                    'moneda' => 'eur',
+                    'data' => '2025-03-10',
+                    'observatii' => '',
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)->postJson(route('valabilitati.store'), $payload);
+
+        $response->assertOk();
+        $response->assertJsonPath('valabilitate.taxe_drum.0.nume', 'Rovinietă România');
+        $response->assertJsonPath('valabilitate.taxe_drum.0.tara', 'România');
+        $response->assertJsonPath('valabilitate.taxe_drum.0.suma', '123.45');
+        $response->assertJsonPath('valabilitate.taxe_drum.0.moneda', 'RON');
+        $response->assertJsonPath('valabilitate.taxe_drum.1.nume', 'Vignetă Ungaria');
+        $response->assertJsonPath('valabilitate.taxe_drum.1.moneda', 'EUR');
+        $response->assertJsonPath('valabilitate.taxe_drum.1.suma', '67.89');
+        $response->assertJsonPath('valabilitate.taxe_drum.1.observatii', null);
+
+        $valabilitateId = $response->json('valabilitate.id');
+        $this->assertNotNull($valabilitateId);
+
+        $this->assertDatabaseHas('valabilitati_taxe_drum', [
+            'valabilitate_id' => $valabilitateId,
+            'nume' => 'Rovinietă România',
+            'tara' => 'România',
+            'suma' => '123.45',
+            'moneda' => 'RON',
+            'observatii' => 'Taxă vignetă',
+        ]);
+
+        $this->assertDatabaseHas('valabilitati_taxe_drum', [
+            'valabilitate_id' => $valabilitateId,
+            'nume' => 'Vignetă Ungaria',
+            'tara' => 'Ungaria',
+            'suma' => '67.89',
+            'moneda' => 'EUR',
+            'observatii' => null,
+        ]);
+    }
+
+    public function test_update_replaces_existing_road_taxes(): void
+    {
+        $user = $this->createValabilitatiUser();
+
+        $valabilitate = Valabilitate::factory()->create();
+        ValabilitateTaxaDrum::factory()->count(2)->create([
+            'valabilitate_id' => $valabilitate->id,
+        ]);
+
+        $payload = [
+            'numar_auto' => $valabilitate->numar_auto,
+            'sofer_id' => $valabilitate->sofer_id,
+            'denumire' => 'Actualizare taxe',
+            'data_inceput' => $valabilitate->data_inceput?->format('Y-m-d') ?? '2025-03-01',
+            'data_sfarsit' => $valabilitate->data_sfarsit?->format('Y-m-d'),
+            'taxe_drum' => [
+                [
+                    'nume' => 'Taxă Bulgaria',
+                    'tara' => 'Bulgaria',
+                    'suma' => '45.50',
+                    'moneda' => 'BGN',
+                    'data' => '2025-04-12',
+                    'observatii' => 'Noul tarif',
+                ],
+            ],
+        ];
+
+        $response = $this->actingAs($user)->putJson(route('valabilitati.update', $valabilitate), $payload);
+
+        $response->assertOk();
+        $response->assertJsonCount(1, 'valabilitate.taxe_drum');
+        $response->assertJsonPath('valabilitate.taxe_drum.0.nume', 'Taxă Bulgaria');
+        $response->assertJsonPath('valabilitate.taxe_drum.0.tara', 'Bulgaria');
+        $response->assertJsonPath('valabilitate.taxe_drum.0.suma', '45.50');
+
+        $this->assertDatabaseHas('valabilitati_taxe_drum', [
+            'valabilitate_id' => $valabilitate->id,
+            'nume' => 'Taxă Bulgaria',
+            'tara' => 'Bulgaria',
+            'suma' => '45.50',
+            'moneda' => 'BGN',
+            'observatii' => 'Noul tarif',
+        ]);
+
+        $this->assertEquals(1, ValabilitateTaxaDrum::where('valabilitate_id', $valabilitate->id)->count());
+    }
+
+    public function test_update_can_remove_all_road_taxes(): void
+    {
+        $user = $this->createValabilitatiUser();
+
+        $valabilitate = Valabilitate::factory()->create();
+        ValabilitateTaxaDrum::factory()->count(2)->create([
+            'valabilitate_id' => $valabilitate->id,
+        ]);
+
+        $payload = [
+            'numar_auto' => $valabilitate->numar_auto,
+            'sofer_id' => $valabilitate->sofer_id,
+            'denumire' => $valabilitate->denumire,
+            'data_inceput' => $valabilitate->data_inceput?->format('Y-m-d') ?? '2025-03-01',
+            'data_sfarsit' => $valabilitate->data_sfarsit?->format('Y-m-d'),
+            'taxe_drum' => [],
+        ];
+
+        $response = $this->actingAs($user)->putJson(route('valabilitati.update', $valabilitate), $payload);
+
+        $response->assertOk();
+        $response->assertJsonCount(0, 'valabilitate.taxe_drum');
+
+        $this->assertDatabaseMissing('valabilitati_taxe_drum', [
+            'valabilitate_id' => $valabilitate->id,
+        ]);
+    }
+
+    private function createValabilitatiUser(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::create([
+            'name' => 'Valabilități',
+            'slug' => 'access-valabilitati',
+            'module' => 'valabilitati',
+        ]);
+
+        $role = Role::create([
+            'name' => 'Administrator',
+            'slug' => 'admin',
+        ]);
+
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- add an optional `nume` attribute to road taxes across the migration, model, factory, and API validation/sanitization
- surface the new field in the valabilitati forms and show view so users can capture and review the tax name first
- refresh backend and frontend feature tests to assert the `nume` payloads and rendered values

## Testing
- php -l app/Http/Controllers/ValabilitateController.php
- php -l app/Models/ValabilitateTaxaDrum.php
- php -l database/factories/ValabilitateTaxaDrumFactory.php
- php -l database/migrations/2025_03_20_000000_create_valabilitati_taxe_drum_table.php
- php -l tests/Feature/Valabilitati/ValabilitateRoadTaxesTest.php
- php -l tests/Feature/Valabilitati/ValabilitateRoadTaxesFrontendTest.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918b3aa8f688326bf17625b932f9379)