### PR TITLE
Remove unused valabilitati curse filters

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -11,13 +11,10 @@ use App\Support\Valabilitati\ValabilitatiCurseFilterState;
 use App\Support\Valabilitati\ValabilitatiFilterState;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class ValabilitateCursaController extends Controller
@@ -28,17 +25,15 @@ class ValabilitateCursaController extends Controller
     {
         $this->authorize('view', $valabilitate);
 
-        $filters = $this->validateFilters($request);
-        $curse = $this->paginateCurse($request, $valabilitate, $filters);
+        $curse = $this->paginateCurse($request, $valabilitate);
 
-        ValabilitatiCurseFilterState::remember($request, $valabilitate, $this->filtersToQueryString($filters));
+        ValabilitatiCurseFilterState::remember($request, $valabilitate);
 
         $valabilitate->loadMissing(['sofer']);
 
         return view('valabilitati.curse.index', [
             'valabilitate' => $valabilitate,
             'curse' => $curse,
-            'filters' => $filters,
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitate, $curse),
             'backUrl' => ValabilitatiFilterState::route(),
             'tari' => $this->loadTari(),
@@ -49,10 +44,9 @@ class ValabilitateCursaController extends Controller
     {
         $this->authorize('view', $valabilitate);
 
-        $filters = $this->validateFilters($request);
-        $curse = $this->paginateCurse($request, $valabilitate, $filters);
+        $curse = $this->paginateCurse($request, $valabilitate);
 
-        ValabilitatiCurseFilterState::remember($request, $valabilitate, $this->filtersToQueryString($filters));
+        ValabilitatiCurseFilterState::remember($request, $valabilitate);
 
         return response()->json([
             'rows_html' => view('valabilitati.curse.partials.rows', [
@@ -133,79 +127,13 @@ class ValabilitateCursaController extends Controller
         return redirect(ValabilitatiCurseFilterState::route($valabilitate))->with('status', $message);
     }
 
-    private function validateFilters(Request $request): array
+    private function paginateCurse(Request $request, Valabilitate $valabilitate, ?array $query = null): LengthAwarePaginator
     {
-        return $this->parseFilters($request->only([
-            'localitate',
-            'cod_postal',
-            'data_start',
-            'data_end',
-        ]));
-    }
-
-    private function parseFilters(array $input): array
-    {
-        $validator = validator($input, [
-            'localitate' => ['nullable', 'string', 'max:255'],
-            'cod_postal' => ['nullable', 'string', 'max:255'],
-            'data_start' => ['nullable', 'date'],
-            'data_end' => ['nullable', 'date', 'after_or_equal:data_start'],
-        ]);
-
-        $validated = $validator->validate();
-
-        return [
-            'localitate' => trim((string) ($validated['localitate'] ?? '')),
-            'cod_postal' => trim((string) ($validated['cod_postal'] ?? '')),
-            'data_start' => $validated['data_start'] ?? null,
-            'data_end' => $validated['data_end'] ?? null,
-        ];
-    }
-
-    private function filtersToQueryString(array $filters): array
-    {
-        return array_filter($filters, static fn ($value) => $value !== null && $value !== '');
-    }
-
-    private function buildFilteredQuery(Valabilitate $valabilitate, array $filters): HasMany
-    {
-        $query = $valabilitate->curse()->with([
-            'incarcareTara',
-            'descarcareTara',
-        ]);
-
-        if ($filters['localitate'] !== '') {
-            $term = Str::lower($filters['localitate']);
-            $query->where(function (Builder $builder) use ($term): void {
-                $builder
-                    ->whereRaw('LOWER(incarcare_localitate) LIKE ?', ["%{$term}%"])
-                    ->orWhereRaw('LOWER(descarcare_localitate) LIKE ?', ["%{$term}%"]);
-            });
-        }
-
-        if ($filters['cod_postal'] !== '') {
-            $term = Str::lower($filters['cod_postal']);
-            $query->where(function (Builder $builder) use ($term): void {
-                $builder
-                    ->whereRaw('LOWER(incarcare_cod_postal) LIKE ?', ["%{$term}%"])
-                    ->orWhereRaw('LOWER(descarcare_cod_postal) LIKE ?', ["%{$term}%"]);
-            });
-        }
-
-        if ($filters['data_start']) {
-            $query->whereDate('data_cursa', '>=', $filters['data_start']);
-        }
-
-        if ($filters['data_end']) {
-            $query->whereDate('data_cursa', '<=', $filters['data_end']);
-        }
-
-        return $query;
-    }
-
-    private function paginateCurse(Request $request, Valabilitate $valabilitate, array $filters, ?array $query = null): LengthAwarePaginator
-    {
-        $paginator = $this->buildFilteredQuery($valabilitate, $filters)
+        $paginator = $valabilitate->curse()
+            ->with([
+                'incarcareTara',
+                'descarcareTara',
+            ])
             ->reorder()
             ->orderBy('nr_ordine')
             ->orderBy('data_cursa')
@@ -245,8 +173,7 @@ class ValabilitateCursaController extends Controller
     {
         $query = ValabilitatiCurseFilterState::get($valabilitate);
         $filtersRequest = Request::create('', 'GET', $query);
-        $filters = $this->parseFilters($query);
-        $curse = $this->paginateCurse($filtersRequest, $valabilitate, $filters, $query);
+        $curse = $this->paginateCurse($filtersRequest, $valabilitate, $query);
 
         return response()->json([
             'message' => $message,

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -3,73 +3,13 @@
 @section('content')
 <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
     <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
-        <div class="col-lg-2 mb-2 mb-lg-0">
+        <div class="col-12 col-lg-10 mb-2 mb-lg-0 d-flex align-items-center">
             <span class="badge culoare1 fs-5">
                 <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
                     <span><i class="fa-solid fa-route me-1"></i>Curse</span>
                     <small class="text-white-50">{{ $valabilitate->denumire }}</small>
                 </span>
             </span>
-        </div>
-        <div class="col-lg-8 mb-0" id="formularCurse">
-            <form class="needs-validation mb-lg-0" novalidate method="GET" action="{{ url()->current() }}">
-                <div class="row mb-1 custom-search-form justify-content-center align-items-end" id="datePicker">
-                    <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
-                        <input
-                            type="text"
-                            class="form-control rounded-3"
-                            id="filter-localitate"
-                            name="localitate"
-                            placeholder="Localitate încărcare/descărcare"
-                            value="{{ $filters['localitate'] }}"
-                        >
-                    </div>
-                    <div class="col-lg-2 col-md-6 mb-2 mb-lg-0">
-                        <input
-                            type="text"
-                            class="form-control rounded-3"
-                            id="filter-cod-postal"
-                            name="cod_postal"
-                            placeholder="Cod poștal"
-                            value="{{ $filters['cod_postal'] }}"
-                        >
-                    </div>
-                @php
-                    $dateRangeFilter = implode(',', array_filter([
-                        $filters['data_start'] ?? null,
-                        $filters['data_end'] ?? null,
-                    ]));
-                @endphp
-                    <div class="col-lg-2 col-md-6 mb-2 mb-lg-0">
-                        <label for="filter-data-interval" class="form-label mb-0 ps-3">Perioadă</label>
-                        <vue-datepicker-next
-                            id="filter-data-interval"
-                            data-veche="{{ $dateRangeFilter }}"
-                            tip="date"
-                            value-type="YYYY-MM-DD"
-                            format="DD.MM.YYYY"
-                            :latime="{ width: '100%' }"
-                            :range="true"
-                            range-start-name="data_start"
-                            range-end-name="data_end"
-                        ></vue-datepicker-next>
-                    </div>
-                    <div class="col-lg-2 col-md-3 mb-2 mb-md-0">
-                        <button class="btn btn-sm w-100 btn-primary text-white border border-dark rounded-3" type="submit">
-                            <i class="fas fa-search text-white me-1"></i>Caută
-                        </button>
-                    </div>
-                    <div class="col-lg-2 col-md-3">
-                        <a
-                            class="btn btn-sm w-100 btn-secondary text-white border border-dark rounded-3"
-                            href="{{ route('valabilitati.curse.index', $valabilitate) }}"
-                            role="button"
-                        >
-                            <i class="far fa-trash-alt text-white me-1"></i>Resetează
-                        </a>
-                    </div>
-                </div>
-            </form>
         </div>
         <div class="col-lg-2 text-lg-end mt-3 mt-lg-0">
             <div class="d-flex flex-column align-items-stretch align-items-lg-end gap-2">


### PR DESCRIPTION
## Summary
- remove the unused filter parsing logic from `ValabilitateCursaController`
- simplify pagination to always return the full list of curse now that the search form is gone

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918bf39c348832691b7d837b1a912f8)