### PR TITLE
Add confirmation modal for road tax removal and prevent duplicate flashes

### DIFF
--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -86,7 +86,7 @@
     </div>
 
     <div class="card-body px-0 py-3">
-        @include('errors')
+        @include('errors', ['showSessionAlerts' => false])
         @if (session('status'))
             <div class="alert alert-success mx-3" role="alert">
                 {{ session('status') }}


### PR DESCRIPTION
## Summary
- show a Bootstrap confirmation modal before removing road tax entries in the valabilitate form
- avoid duplicate flash messages on the valabilitati index by disabling session alerts in the shared errors partial

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918dbe3efd88326857eebea6ad6a33a)