### PR TITLE
Show taxe de drum summary rows and sync totals

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -9,12 +9,15 @@ use App\Models\ValabilitateCursa;
 use App\Support\Valabilitati\ValabilitateCursaOrderer;
 use App\Support\Valabilitati\ValabilitatiCurseFilterState;
 use App\Support\Valabilitati\ValabilitatiFilterState;
+use Illuminate\Contracts\Pagination\CursorPaginator;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\Pagination\Paginator as BasePaginator;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
 
 class ValabilitateCursaController extends Controller
@@ -29,7 +32,8 @@ class ValabilitateCursaController extends Controller
 
         ValabilitatiCurseFilterState::remember($request, $valabilitate, []);
 
-        $valabilitate->loadMissing(['sofer']);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum']);
+        $summary = $this->buildSummaryData($valabilitate, $curse);
 
         return view('valabilitati.curse.index', [
             'valabilitate' => $valabilitate,
@@ -37,6 +41,7 @@ class ValabilitateCursaController extends Controller
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitate, $curse),
             'backUrl' => ValabilitatiFilterState::route(),
             'tari' => $this->loadTari(),
+            'summary' => $summary,
         ]);
     }
 
@@ -47,6 +52,8 @@ class ValabilitateCursaController extends Controller
         $curse = $this->paginateCurse($request, $valabilitate);
 
         ValabilitatiCurseFilterState::remember($request, $valabilitate, []);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum']);
+        $summary = $this->buildSummaryData($valabilitate, $curse);
 
         return response()->json([
             'rows_html' => view('valabilitati.curse.partials.rows', [
@@ -60,6 +67,7 @@ class ValabilitateCursaController extends Controller
                 'tari' => $this->loadTari(),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($request, $valabilitate, $curse),
+            'summary_html' => $this->renderSummaryHtml($valabilitate, $summary),
         ]);
     }
 
@@ -173,6 +181,8 @@ class ValabilitateCursaController extends Controller
         $query = ValabilitatiCurseFilterState::get($valabilitate);
         $filtersRequest = Request::create('', 'GET', $query);
         $curse = $this->paginateCurse($filtersRequest, $valabilitate, $query);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum']);
+        $summary = $this->buildSummaryData($valabilitate, $curse);
 
         return response()->json([
             'message' => $message,
@@ -189,6 +199,7 @@ class ValabilitateCursaController extends Controller
                 'tari' => $this->loadTari(),
             ])->render(),
             'next_url' => $this->buildNextPageUrl($filtersRequest, $valabilitate, $curse),
+            'summary_html' => $this->renderSummaryHtml($valabilitate, $summary),
         ]);
     }
 
@@ -197,6 +208,105 @@ class ValabilitateCursaController extends Controller
         $max = (int) $valabilitate->curse()->max('nr_ordine');
 
         return $max > 0 ? $max + 1 : 1;
+    }
+
+    private function buildSummaryData(Valabilitate $valabilitate, $curse): array
+    {
+        $curseCollection = $this->resolveCurseCollection($curse);
+
+        $kmPlecare = $curseCollection
+            ->pluck('km_bord_incarcare')
+            ->filter(static fn ($value) => $value !== null && $value !== '')
+            ->min();
+
+        $kmSosire = $curseCollection
+            ->pluck('km_bord_descarcare')
+            ->filter(static fn ($value) => $value !== null && $value !== '')
+            ->max();
+
+        $kmTotal = $kmPlecare !== null && $kmSosire !== null
+            ? (float) $kmSosire - (float) $kmPlecare
+            : null;
+
+        $totalKmMaps = $curseCollection
+            ->pluck('km_maps')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value)
+            ->sum();
+
+        $totalKmBord2 = $curseCollection
+            ->map(static function ($cursa) {
+                $start = $cursa->km_bord_incarcare !== null && $cursa->km_bord_incarcare !== ''
+                    ? (float) $cursa->km_bord_incarcare
+                    : null;
+                $end = $cursa->km_bord_descarcare !== null && $cursa->km_bord_descarcare !== ''
+                    ? (float) $cursa->km_bord_descarcare
+                    : null;
+
+                return $start !== null && $end !== null ? $end - $start : null;
+            })
+            ->filter(static fn ($value) => $value !== null)
+            ->sum();
+
+        $totalKmDiff = $curseCollection
+            ->map(static function ($cursa) {
+                $start = $cursa->km_bord_incarcare !== null && $cursa->km_bord_incarcare !== ''
+                    ? (float) $cursa->km_bord_incarcare
+                    : null;
+                $end = $cursa->km_bord_descarcare !== null && $cursa->km_bord_descarcare !== ''
+                    ? (float) $cursa->km_bord_descarcare
+                    : null;
+                $maps = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
+
+                $bord2 = $start !== null && $end !== null ? $end - $start : null;
+
+                return $bord2 !== null && $maps !== null ? $bord2 - $maps : null;
+            })
+            ->filter(static fn ($value) => $value !== null)
+            ->sum();
+
+        $dataInceput = $valabilitate->data_inceput;
+        $dataSfarsit = $valabilitate->data_sfarsit;
+        $totalZile = $dataInceput && $dataSfarsit
+            ? $dataInceput->diffInDays($dataSfarsit) + 1
+            : null;
+
+        return [
+            'kmPlecare' => $kmPlecare,
+            'kmSosire' => $kmSosire,
+            'kmTotal' => $kmTotal,
+            'totalKmMaps' => $totalKmMaps,
+            'totalKmBord2' => $totalKmBord2,
+            'totalKmDiff' => $totalKmDiff,
+            'totalZile' => $totalZile,
+        ];
+    }
+
+    private function resolveCurseCollection($curse): Collection
+    {
+        if ($curse instanceof Collection) {
+            return $curse;
+        }
+
+        if ($curse instanceof LengthAwarePaginator
+            || $curse instanceof BasePaginator
+            || $curse instanceof CursorPaginator) {
+            return collect($curse->items());
+        }
+
+        if (is_array($curse)) {
+            return collect($curse);
+        }
+
+        return collect();
+    }
+
+    private function renderSummaryHtml(Valabilitate $valabilitate, array $summary): string
+    {
+        return view('valabilitati.curse.partials.summary', [
+            'valabilitate' => $valabilitate,
+            'summary' => $summary,
+        ])->render();
     }
 
     private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -138,8 +138,12 @@
                         data-bs-target="#cursaEditModal{{ $cursa->id }}"
                         class="flex"
                         title="Modifică cursa"
+                        aria-label="Modifică cursa"
                     >
-                        <span class="badge bg-primary">Modifică</span>
+                        <span class="badge bg-primary d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                            <i class="fa-solid fa-pen-to-square"></i>
+                        </span>
+                        <span class="visually-hidden">Modifică</span>
                     </a>
                 </div>
                 <div class="ms-1">
@@ -149,8 +153,12 @@
                         data-bs-target="#cursaDeleteModal{{ $cursa->id }}"
                         class="flex"
                         title="Șterge cursa"
+                        aria-label="Șterge cursa"
                     >
-                        <span class="badge bg-danger">Șterge</span>
+                        <span class="badge bg-danger d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                            <i class="fa-solid fa-trash"></i>
+                        </span>
+                        <span class="visually-hidden">Șterge</span>
                     </a>
                 </div>
             </div>

--- a/resources/views/valabilitati/curse/partials/summary.blade.php
+++ b/resources/views/valabilitati/curse/partials/summary.blade.php
@@ -1,0 +1,66 @@
+<table class="curse-summary-table">
+    <tr>
+        <th class="curse-summary-title">
+            {{ $valabilitate->numar_auto ?? '—' }}
+        </th>
+        <th colspan="2" class="curse-summary-driver">
+            {{ $valabilitate->sofer->name ?? '—' }}
+        </th>
+    </tr>
+    @php($taxeDrum = $valabilitate->taxeDrum ?? collect())
+    @foreach ($taxeDrum as $taxa)
+        <tr>
+            <td colspan="6" class="text-start">
+                Taxă de drum: {{ $taxa->nume ?? '—' }}
+            </td>
+        </tr>
+    @endforeach
+    <tr>
+        <th class="curse-summary-label">Dată plecare</th>
+        <td class="curse-nowrap">
+            {{ optional($valabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
+        </td>
+
+        <th class="text-end curse-summary-label">KM plecare</th>
+        <td class="text-end curse-nowrap">
+            {{ $summary['kmPlecare'] !== null ? $summary['kmPlecare'] : '—' }}
+        </td>
+
+        <th class="text-end curse-summary-label">KM Maps total</th>
+        <td class="text-end curse-nowrap">
+            {{ $summary['totalKmMaps'] ? $summary['totalKmMaps'] : '—' }}
+        </td>
+    </tr>
+    <tr>
+        <th class="curse-summary-label">Dată sosire</th>
+        <td class="curse-nowrap">
+            {{ optional($valabilitate->data_sfarsit)->format('d.m.Y') ?? '—' }}
+        </td>
+
+        <th class="text-end curse-summary-label">KM sosire</th>
+        <td class="text-end curse-nowrap">
+            {{ $summary['kmSosire'] !== null ? $summary['kmSosire'] : '—' }}
+        </td>
+
+        <th class="text-end curse-summary-label">KM Bord 2 total</th>
+        <td class="text-end curse-nowrap">
+            {{ $summary['totalKmBord2'] ? $summary['totalKmBord2'] : '—' }}
+        </td>
+    </tr>
+    <tr>
+        <th class="curse-summary-label">Total zile</th>
+        <td class="curse-nowrap">
+            {{ $summary['totalZile'] !== null ? $summary['totalZile'] : '—' }}
+        </td>
+
+        <th class="text-end curse-summary-label">KM total (plecare → sosire)</th>
+        <td class="text-end curse-nowrap">
+            {{ $summary['kmTotal'] !== null ? $summary['kmTotal'] : '—' }}
+        </td>
+
+        <th class="text-end curse-summary-label">Diferență totală (Bord–Maps)</th>
+        <td class="text-end curse-nowrap">
+            {{ $summary['totalKmDiff'] ? $summary['totalKmDiff'] : '—' }}
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
## Summary
- render the curse summary band through a reusable partial so the server can return updated markup
- include each Valabilitate "taxă de drum" directly under the car/driver row in that summary table
- have the controller preload the needed relations, compute the summary metrics in PHP, and expose the partial HTML over AJAX so the frontend can refresh it after mutations
- swap the textual Modifică/Șterge badges for Font Awesome icons with accessible labels

## Testing
- Not run (vendor dependencies are missing and `composer install` requires a GitHub token in this environment).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691acfe60f848326a88a9cf0156ab15f)