### PR TITLE
Sync valabilitati permission for dispecer role

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -109,6 +109,7 @@ return [
             'rapoarte',
             'statii-peco',
             'masini-valabilitati',
+            'valabilitati',
         ],
         'mecanic' => [
             'service-masini',

--- a/database/migrations/2025_03_24_090000_add_valabilitati_permission_to_dispecer.php
+++ b/database/migrations/2025_03_24_090000_add_valabilitati_permission_to_dispecer.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (! Schema::hasTable('permissions') || ! Schema::hasTable('roles') || ! Schema::hasTable('permission_role')) {
+            return;
+        }
+
+        $permissionId = DB::table('permissions')
+            ->where('module', 'valabilitati')
+            ->value('id');
+
+        $roleId = DB::table('roles')
+            ->where('slug', 'dispecer')
+            ->value('id');
+
+        if (! $permissionId || ! $roleId) {
+            return;
+        }
+
+        $now = now();
+
+        DB::table('permission_role')->updateOrInsert(
+            [
+                'role_id' => (int) $roleId,
+                'permission_id' => (int) $permissionId,
+            ],
+            [
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('permissions') || ! Schema::hasTable('roles') || ! Schema::hasTable('permission_role')) {
+            return;
+        }
+
+        $permissionId = DB::table('permissions')
+            ->where('module', 'valabilitati')
+            ->value('id');
+
+        $roleId = DB::table('roles')
+            ->where('slug', 'dispecer')
+            ->value('id');
+
+        if (! $permissionId || ! $roleId) {
+            return;
+        }
+
+        DB::table('permission_role')
+            ->where('permission_id', (int) $permissionId)
+            ->where('role_id', (int) $roleId)
+            ->delete();
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -343,7 +343,7 @@ Route::middleware(['auth'])->group(function () {
             ->parameters(['masini-valabilitati' => 'masinaValabilitati']);
     });
 
-    Route::middleware(['permission:valabilitati', 'role:super-admin,admin'])->group(function () {
+    Route::middleware(['permission:valabilitati', 'role:super-admin,admin,dispecer'])->group(function () {
         Route::get('valabilitati/paginate', [ValabilitateController::class, 'paginate'])
             ->name('valabilitati.paginate');
 


### PR DESCRIPTION
## Summary
- add a data migration that syncs the `valabilitati` permission onto the `dispecer` role so existing databases inherit the new access rule automatically

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae08610b48326a06343b566051efc)