### PR TITLE
Add format documente support to valabilitati curse

### DIFF
--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -6,6 +6,7 @@ use App\Models\Valabilitate;
 use App\Support\Valabilitati\ValabilitatiCurseFilterState;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 class ValabilitateCursaRequest extends FormRequest
@@ -22,6 +23,7 @@ class ValabilitateCursaRequest extends FormRequest
         return [
             'nr_ordine' => ['sometimes', 'integer', 'min:1'],
             'nr_cursa' => ['nullable', 'string', 'max:255'],
+            'format_documente' => ['nullable', Rule::in(['Per post', 'Digital'])],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
             'incarcare_cod_postal' => ['nullable', 'string', 'max:255'],
             'incarcare_tara_id' => ['nullable', 'exists:tari,id'],
@@ -38,6 +40,11 @@ class ValabilitateCursaRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
+        $formatDocumente = $this->input('format_documente');
+        if ($formatDocumente !== null && trim((string) $formatDocumente) === '') {
+            $this->merge(['format_documente' => null]);
+        }
+
         $dateInput = $this->input('data_cursa_date');
         $timeInput = $this->input('data_cursa_time');
 

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -16,6 +16,7 @@ class ValabilitateCursa extends Model
         'valabilitate_id',
         'nr_ordine',
         'nr_cursa',
+        'format_documente',
         'incarcare_localitate',
         'incarcare_cod_postal',
         'incarcare_tara_id',

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -20,6 +20,7 @@ class ValabilitateCursaFactory extends Factory
             'valabilitate_id' => Valabilitate::factory(),
             'nr_ordine' => fake()->numberBetween(1, 20),
             'nr_cursa' => fake()->optional()->bothify('Cursa-###'),
+            'format_documente' => fake()->randomElement(['Per post', 'Digital']),
             'incarcare_localitate' => fake()->city(),
             'incarcare_cod_postal' => fake()->postcode(),
             'incarcare_tara_id' => Tara::factory(),

--- a/database/migrations/2025_03_24_090500_add_format_documente_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_090500_add_format_documente_to_valabilitati_curse_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->string('format_documente', 20)->nullable()->after('nr_cursa');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn('format_documente');
+        });
+    }
+};

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -119,6 +119,7 @@
                             <tr class="curse-data-header-top">
                                 <th rowspan="2" class="text-center curse-nowrap">#</th>
                                 <th rowspan="2" class="curse-nowrap">Nr. cursă</th>
+                                <th rowspan="2" class="text-center curse-nowrap">FrmDoc</th>
                                 <th rowspan="2">Cursa</th>
                                 <th rowspan="2" class="curse-nowrap">Dată transport</th>
                                 <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
@@ -143,7 +144,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="11" class="text-center py-4">
+                                    <td colspan="12" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -87,6 +87,7 @@
                                     $createDataTimeValue = $formatDateTimeValue($oldCombinedValue, 'H:i');
                                 }
                             }
+                            $createFormatDocumente = $isCreateActive ? old('format_documente', '') : '';
                         @endphp
                         <div class="row g-3">
                             <div class="col-md-3">
@@ -104,6 +105,24 @@
                                     data-error-for="nr_cursa"
                                 >
                                     {{ $isCreateActive ? $errors->first('nr_cursa') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <label for="cursa-create-format-documente" class="form-label">Format documente</label>
+                                <select
+                                    name="format_documente"
+                                    id="cursa-create-format-documente"
+                                    class="form-select bg-white rounded-3 {{ $isCreateActive && $errors->has('format_documente') ? 'is-invalid' : '' }}"
+                                >
+                                    <option value="">Selectează formatul</option>
+                                    <option value="Per post" @selected($createFormatDocumente === 'Per post')>Per post</option>
+                                    <option value="Digital" @selected($createFormatDocumente === 'Digital')>Digital</option>
+                                </select>
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('format_documente') ? 'd-block' : '' }}"
+                                    data-error-for="format_documente"
+                                >
+                                    {{ $isCreateActive ? $errors->first('format_documente') : '' }}
                                 </div>
                             </div>
                             <div class="col-md-3">
@@ -377,6 +396,11 @@
         if ($editNrCursa === null) {
             $editNrCursa = '';
         }
+        $baseFormatDocumente = $cursa->format_documente;
+        $editFormatDocumente = $isEditing ? old('format_documente', $baseFormatDocumente) : $baseFormatDocumente;
+        if ($editFormatDocumente === null) {
+            $editFormatDocumente = '';
+        }
     @endphp
     <div
         class="modal fade text-dark"
@@ -419,6 +443,24 @@
                                     data-error-for="nr_cursa"
                                 >
                                     {{ $isEditing ? $errors->first('nr_cursa') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-3">
+                                <label for="{{ $editPrefix }}format-documente" class="form-label">Format documente</label>
+                                <select
+                                    name="format_documente"
+                                    id="{{ $editPrefix }}format-documente"
+                                    class="form-select bg-white rounded-3 {{ $isEditing && $errors->has('format_documente') ? 'is-invalid' : '' }}"
+                                >
+                                    <option value="">Selectează formatul</option>
+                                    <option value="Per post" @selected($editFormatDocumente === 'Per post')>Per post</option>
+                                    <option value="Digital" @selected($editFormatDocumente === 'Digital')>Digital</option>
+                                </select>
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('format_documente') ? 'd-block' : '' }}"
+                                    data-error-for="format_documente"
+                                >
+                                    {{ $isEditing ? $errors->first('format_documente') : '' }}
                                 </div>
                             </div>
                             <div class="col-md-3">

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -89,6 +89,17 @@
             {{ $cursa->nr_cursa ?: '—' }}
         </td>
 
+        {{-- Format documente --}}
+        <td class="text-center align-middle">
+            @if ($cursa->format_documente === 'Per post')
+                <i class="fa-solid fa-envelope text-danger" title="Documentele se trimit prin poștă"></i>
+            @elseif ($cursa->format_documente === 'Digital')
+                <i class="fa-solid fa-at text-success" title="Documentele se trimit digital"></i>
+            @else
+                —
+            @endif
+        </td>
+
         {{-- Cursa (descriere) --}}
         <td class="text-muted small align-middle">
             {{ $cursaDescriere }}

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -32,6 +32,7 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_cod_postal' => '410001',
             'descarcare_tara_id' => $descarcareTara->id,
             'descarcare_tara_text' => $descarcareTara->nume,
+            'format_documente' => 'Per post',
             'data_cursa_date' => '2025-05-01',
             'data_cursa_time' => '08:30',
             'observatii' => 'Livrare completă',
@@ -51,6 +52,7 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_localitate' => 'Oradea',
             'descarcare_cod_postal' => '410001',
             'descarcare_tara_id' => $descarcareTara->id,
+            'format_documente' => 'Per post',
             'data_cursa' => '2025-05-01 08:30:00',
             'observatii' => 'Livrare completă',
             'km_bord_incarcare' => 12345,
@@ -92,6 +94,7 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_cod_postal' => '800010',
             'descarcare_tara_id' => $newDescarcareTara->id,
             'descarcare_tara_text' => $newDescarcareTara->nume,
+            'format_documente' => 'Digital',
             'data_cursa_date' => '2025-05-05',
             'data_cursa_time' => '14:45',
             'observatii' => 'Actualizare detalii',
@@ -111,6 +114,7 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_localitate' => 'Galați',
             'descarcare_cod_postal' => '800010',
             'descarcare_tara_id' => $newDescarcareTara->id,
+            'format_documente' => 'Digital',
             'data_cursa' => '2025-05-05 14:45:00',
             'observatii' => 'Actualizare detalii',
             'km_bord_incarcare' => 98765,
@@ -141,6 +145,7 @@ class ValabilitateCursaTest extends TestCase
                 'descarcare_localitate' => 'Praga',
                 'descarcare_cod_postal' => '11000',
                 'descarcare_tara_id' => $newDescarcareTara->id,
+                'format_documente' => 'Per post',
                 'data_cursa_date' => '2025-05-10',
                 'data_cursa_time' => '11:15',
             ]);
@@ -162,6 +167,7 @@ class ValabilitateCursaTest extends TestCase
             'incarcare_localitate' => 'București',
             'descarcare_localitate' => 'Praga',
             'data_cursa' => '2025-05-10 11:15:00',
+            'format_documente' => 'Per post',
         ]);
     }
 
@@ -194,11 +200,14 @@ class ValabilitateCursaTest extends TestCase
             'descarcare_tara_id' => $descarcareTara->id,
             'km_bord_incarcare' => 15400,
             'km_bord_descarcare' => 15900,
+            'format_documente' => 'Per post',
         ]);
 
         $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
 
         $response->assertOk();
+        $response->assertSee('FrmDoc');
+        $response->assertSee('fa-solid fa-envelope text-danger', false);
         $response->assertSeeText('Timișoara');
         $response->assertSeeText('300001');
         $response->assertSeeText($incarcareTara->nume);


### PR DESCRIPTION
## Summary
- add a nullable `format_documente` column for valabilitati curse and validate it through the existing request/model layer
- expose a "Format documente" select in the admin create/edit modals and show the stored value via icons in the FrmDoc column of the main table
- refresh factories and feature tests to cover the new field

## Testing
- `php artisan test --filter=ValabilitateCursaTest` *(fails: composer install/vendor generation is blocked by repeated 403 errors when trying to download dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ae3c308a4832687e63b0b70d2397b)