### PR TITLE
Add Km gol column to curse table

### DIFF
--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -128,7 +128,7 @@
                                 <th colspan="2" class="text-center curse-nowrap">
                                     KM Bord (plecare / sosire)
                                 </th>
-                                <th rowspan="2" class="text-end curse-nowrap">KM Bord 2</th>
+                                <th colspan="2" class="text-center curse-nowrap">KM Bord 2</th>
                                 <th rowspan="2" class="text-end curse-nowrap">Sumă încasată</th>
                                 <th rowspan="2" class="text-end curse-nowrap">
                                     Diferența KM<br>(Bord – Maps)
@@ -138,6 +138,8 @@
                             <tr class="curse-data-header-bottom">
                                 <th class="text-end curse-nowrap">Plecare</th>
                                 <th class="text-end curse-nowrap">Sosire</th>
+                                <th class="text-end curse-nowrap">Km gol</th>
+                                <th class="text-end curse-nowrap">Km plin</th>
                             </tr>
                         </thead>
 
@@ -146,7 +148,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="11" class="text-center py-4">
+                                    <td colspan="12" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,3 +1,7 @@
+@php
+    $previousKmSosire = null;
+@endphp
+
 @foreach ($curse as $cursa)
     @php
         $dataTransport = $cursa->data_cursa?->format('d.m.Y H:i');
@@ -26,8 +30,10 @@
         $kmMapsDisplay = filled($cursa->km_maps) ? $cursa->km_maps : '—';
         $kmMapsValue = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
 
-        $kmBord2 = $kmPlecare !== null && $kmSosire !== null ? $kmSosire - $kmPlecare : null;
-        $kmDifference = $kmBord2 !== null && $kmMapsValue !== null ? $kmBord2 - $kmMapsValue : null;
+        // Km plin
+        $kmPlin = $kmPlecare !== null && $kmSosire !== null ? $kmSosire - $kmPlecare : null;
+        $kmGol = $previousKmSosire !== null && $kmPlecare !== null ? $previousKmSosire - $kmPlecare : null;
+        $kmDifference = $kmPlin !== null && $kmMapsValue !== null ? $kmPlin - $kmMapsValue : null;
 
         $diffClass = $kmDifference === null
             ? ''
@@ -114,9 +120,14 @@
             {{ $kmSosire !== null ? $kmSosire : '—' }}
         </td>
 
-        {{-- KM Bord 2 --}}
+        {{-- KM Bord 2 – Km gol --}}
         <td class="text-end text-nowrap align-middle">
-            {{ $kmBord2 !== null ? $kmBord2 : '—' }}
+            {{ $kmGol !== null ? $kmGol : '—' }}
+        </td>
+
+        {{-- KM Bord 2 – Km plin --}}
+        <td class="text-end text-nowrap align-middle">
+            {{ $kmPlin !== null ? $kmPlin : '—' }}
         </td>
 
         {{-- Sumă încasată – încă nu există în model, rămâne golă --}}
@@ -164,4 +175,8 @@
             </div>
         </td>
     </tr>
+
+    @php
+        $previousKmSosire = $kmSosire;
+    @endphp
 @endforeach


### PR DESCRIPTION
## Summary
- split the KM Bord 2 column into Km gol / Km plin subcolumns in the table header and empty-state row
- compute Km gol using the previous row's arrival reading and render both values for each course row

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aeda9d0288326aac0bffc30f8c113)