### PR TITLE
Add grupuri management view and related updates

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -157,4 +157,9 @@ class ValabilitateCursaController extends Controller
     {
         return self::PER_PAGE;
     }
+
+    protected function displayGroupSummaryInResponses(): bool
+    {
+        return false;
+    }
 }

--- a/app/Http/Controllers/ValabilitateCursaGrupController.php
+++ b/app/Http/Controllers/ValabilitateCursaGrupController.php
@@ -6,15 +6,51 @@ use App\Http\Controllers\Concerns\HandlesValabilitatiCurseListings;
 use App\Http\Requests\ValabilitateCursaGrupRequest;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursaGrup;
+use App\Support\Valabilitati\ValabilitatiFilterState;
+use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class ValabilitateCursaGrupController extends Controller
 {
     use HandlesValabilitatiCurseListings;
 
     private const PER_PAGE = 20;
+
+    public function index(Request $request, Valabilitate $valabilitate): View
+    {
+        $this->authorize('view', $valabilitate);
+
+        $curse = $this->paginateCurse($request, $valabilitate);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum']);
+
+        $grupuriQuery = $valabilitate->cursaGrupuri()->withCount('curse')->orderBy('nume');
+        $grupuri = (clone $grupuriQuery)->paginate($this->perPage());
+        $valabilitate->setRelation('cursaGrupuri', $grupuriQuery->get());
+
+        $summary = $this->buildSummaryData($valabilitate, $curse);
+
+        $modalViewData = $this->buildModalViewData(
+            $valabilitate,
+            $curse,
+            true,
+            old('form_type'),
+            old('form_id')
+        );
+
+        $modalViewData['renderCurseModals'] = false;
+        $modalViewData['redirectTo'] = $request->fullUrl();
+
+        return view('valabilitati.grupuri.index', [
+            'valabilitate' => $valabilitate,
+            'grupuri' => $grupuri,
+            'summary' => $summary,
+            'backUrl' => ValabilitatiFilterState::route(),
+            'modalViewData' => $modalViewData,
+        ]);
+    }
 
     public function store(ValabilitateCursaGrupRequest $request, Valabilitate $valabilitate): JsonResponse|RedirectResponse
     {
@@ -45,6 +81,20 @@ class ValabilitateCursaGrupController extends Controller
 
         $this->authorize('update', $valabilitate);
 
+        if ($grup->curse()->exists()) {
+            $message = 'Grupul nu poate fi șters deoarece are curse asociate.';
+
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'message' => $message,
+                    'message_type' => 'error',
+                ]);
+            }
+
+            return redirect($this->resolveListingRedirectUrl($request, $valabilitate))
+                ->with('error', $message);
+        }
+
         $grup->delete();
 
         return $this->respondAfterMutation($request, $valabilitate, 'Grupul a fost șters.');
@@ -58,5 +108,16 @@ class ValabilitateCursaGrupController extends Controller
     protected function perPage(): int
     {
         return self::PER_PAGE;
+    }
+
+    protected function displayGroupSummaryInResponses(): bool
+    {
+        $redirectTo = request()->input('redirect_to');
+
+        if (is_string($redirectTo) && Str::contains($redirectTo, '/grupuri')) {
+            return true;
+        }
+
+        return request()->routeIs('valabilitati.grupuri.*');
     }
 }

--- a/app/Models/ValabilitateCursaGrup.php
+++ b/app/Models/ValabilitateCursaGrup.php
@@ -22,6 +22,16 @@ class ValabilitateCursaGrup extends Model
         '#DCFCE7' => 'Verde mentă',
         '#FFE4E6' => 'Trandafiriu',
         '#F5F5F4' => 'Gri cald',
+        '#FFF7ED' => 'Nisip cald',
+        '#F0ABFC' => 'Liliac vibrant',
+        '#C7D2FE' => 'Indigo pastel',
+        '#E0E7FF' => 'Lavandă rece',
+        '#FFD6A5' => 'Caisă pastel',
+        '#E2F0CB' => 'Verde lime',
+        '#D1FAE5' => 'Aqua pastel',
+        '#F0E5CF' => 'Bej catifelat',
+        '#F1F5F9' => 'Gri perlat',
+        '#FDE2FF' => 'Roz liliac',
     ];
 
     private const DOCUMENT_FORMATS = [

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -84,21 +84,42 @@
         }
     </style>
 
+    @php
+        $grupuriRoute = route('valabilitati.grupuri.index', $valabilitate);
+        $curseRoute = route('valabilitati.curse.index', $valabilitate);
+        $isGroupsContext = request()->routeIs('valabilitati.grupuri.*');
+    @endphp
     <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
-        <div class="row card-header align-items-center" style="border-radius: 40px 40px 0px 0px;">
-            <div class="col-lg-10 col-xl-10 mb-2 mb-lg-0">
+        <div class="row card-header align-items-center text-center text-lg-start" style="border-radius: 40px 40px 0px 0px;">
+            <div class="col-12 col-lg-4 mb-2 mb-lg-0">
                 <span class="badge culoare1 fs-5">
                     <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
                         <span>
                             <i class="fa-solid fa-route me-1"></i>Curse
-                            / 
+                            /
                             {{ $valabilitate->denumire }}
                         </span>
                     </span>
                 </span>
             </div>
-            <div class="col-lg-2 col-xl-2 text-lg-end mt-3 mt-lg-0">
-                <div class="d-flex align-items-stretch align-items-lg-end gap-2 flex-wrap justify-content-end">
+            <div class="col-12 col-lg-4 my-2 my-lg-0">
+                <div class="d-inline-flex justify-content-center gap-2">
+                    <a
+                        href="{{ $curseRoute }}"
+                        class="btn btn-sm {{ $isGroupsContext ? 'btn-outline-primary' : 'btn-primary text-white' }} border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-truck-fast me-1"></i>Curse
+                    </a>
+                    <a
+                        href="{{ $grupuriRoute }}"
+                        class="btn btn-sm {{ $isGroupsContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-layer-group me-1"></i>Grupuri
+                    </a>
+                </div>
+            </div>
+            <div class="col-12 col-lg-4 text-lg-end mt-3 mt-lg-0">
+                <div class="d-flex align-items-stretch align-items-lg-end gap-2 flex-wrap justify-content-center justify-content-lg-end">
                     <button
                         type="button"
                         class="btn btn-sm btn-outline-primary border border-dark rounded-3"
@@ -133,6 +154,7 @@
                 @include('valabilitati.curse.partials.summary', [
                     'valabilitate' => $valabilitate,
                     'summary' => $summary,
+                    'showGroupSummary' => false,
                 ])
             </div>
 
@@ -674,7 +696,13 @@
                             closeModal(modalElement);
 
                             if (data.message) {
-                                showFeedback(data.message, 'success');
+                                const alertMap = {
+                                    error: 'danger',
+                                    warning: 'warning',
+                                    success: 'success',
+                                };
+                                const alertType = alertMap[data.message_type] || 'success';
+                                showFeedback(data.message, alertType);
                             }
                         })
                         .catch(error => {

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -129,7 +129,7 @@
         </td>
 
         {{-- Cursa (descriere) --}}
-        <td class="text-muted small align-middle">
+        <td class="small align-middle">
             {{ $cursaDescriere }}
         </td>
 
@@ -164,7 +164,7 @@
         </td>
 
         {{-- Sumă încasată --}}
-        <td class="text-end align-middle">
+        <td class="text-end align-middle" style="background-color: {{ $group ? $groupColor : 'transparent' }};">
             {{ $groupSumDisplay }}
         </td>
 

--- a/resources/views/valabilitati/curse/partials/summary.blade.php
+++ b/resources/views/valabilitati/curse/partials/summary.blade.php
@@ -66,9 +66,10 @@
         </td>
     </tr>
     @php
+        $showGroupSummary = $showGroupSummary ?? request()->routeIs('valabilitati.grupuri.*');
         $groupFinancials = collect($summary['groupFinancials'] ?? []);
     @endphp
-    @if ($groupFinancials->isNotEmpty())
+    @if ($showGroupSummary && $groupFinancials->isNotEmpty())
         <tr>
             <th colspan="6" class="curse-summary-label text-center">Situație pe grupuri</th>
         </tr>

--- a/resources/views/valabilitati/grupuri/index.blade.php
+++ b/resources/views/valabilitati/grupuri/index.blade.php
@@ -1,0 +1,210 @@
+@extends('layouts.app')
+
+@section('content')
+    <style>
+        .curse-summary-table,
+        .curse-data-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.875rem;
+        }
+
+        .curse-summary-table th,
+        .curse-summary-table td,
+        .curse-data-table th,
+        .curse-data-table td {
+            border: 1px solid #000000ff;
+            padding: 0.4rem 0.6rem;
+            line-height: 1.1;
+            vertical-align: middle;
+        }
+
+        .curse-data-table thead th {
+            background-color: #f8f9fa;
+            font-weight: 600;
+            text-transform: uppercase;
+            font-size: 0.75rem;
+        }
+
+        .curse-data-table tbody tr:nth-child(even) {
+            background-color: #fcfcfc;
+        }
+
+        .curse-data-table tbody tr:hover {
+            background-color: #f1f3f5;
+        }
+
+        .curse-nowrap {
+            white-space: nowrap;
+        }
+    </style>
+
+    @php
+        $grupuriRoute = route('valabilitati.grupuri.index', $valabilitate);
+        $curseRoute = route('valabilitati.curse.index', $valabilitate);
+    @endphp
+
+    <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+        <div class="row card-header align-items-center text-center text-lg-start" style="border-radius: 40px 40px 0px 0px;">
+            <div class="col-12 col-lg-4 mb-2 mb-lg-0">
+                <span class="badge culoare1 fs-5">
+                    <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
+                        <span>
+                            <i class="fa-solid fa-layer-group me-1"></i>Grupuri
+                            /
+                            {{ $valabilitate->denumire }}
+                        </span>
+                    </span>
+                </span>
+            </div>
+            <div class="col-12 col-lg-4 my-2 my-lg-0">
+                <div class="d-inline-flex justify-content-center gap-2">
+                    <a
+                        href="{{ $curseRoute }}"
+                        class="btn btn-sm btn-outline-primary border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-truck-fast me-1"></i>Curse
+                    </a>
+                    <a
+                        href="{{ $grupuriRoute }}"
+                        class="btn btn-sm btn-primary text-white border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-layer-group me-1"></i>Grupuri
+                    </a>
+                </div>
+            </div>
+            <div class="col-12 col-lg-4 text-lg-end mt-3 mt-lg-0">
+                <div class="d-flex align-items-stretch align-items-lg-end gap-2 flex-wrap justify-content-center justify-content-lg-end">
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-outline-primary border border-dark rounded-3"
+                        data-bs-toggle="modal"
+                        data-bs-target="#cursaGroupCreateModal"
+                    >
+                        <i class="fa-solid fa-plus me-1"></i>Crează grup
+                    </button>
+                    <a
+                        href="{{ $backUrl }}"
+                        class="btn btn-sm btn-outline-secondary border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-list me-1"></i>Înapoi la valabilități
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div class="card-body px-0 py-3">
+            @include('errors')
+
+            <div id="curse-summary" class="px-3 mb-3">
+                @include('valabilitati.curse.partials.summary', [
+                    'valabilitate' => $valabilitate,
+                    'summary' => $summary,
+                    'showGroupSummary' => true,
+                ])
+            </div>
+
+            <div class="px-3">
+                <div class="table-responsive">
+                    <table class="table table-sm curse-data-table align-middle">
+                        <thead>
+                            <tr>
+                                <th class="text-center curse-nowrap">#</th>
+                                <th>Grup</th>
+                                <th class="curse-nowrap">Format</th>
+                                <th>Factură</th>
+                                <th class="text-end curse-nowrap">Sumă încasată</th>
+                                <th class="text-end curse-nowrap">Sumă calculată</th>
+                                <th class="text-end curse-nowrap">Diferență</th>
+                                <th class="text-center curse-nowrap">Curse atașate</th>
+                                <th class="text-end curse-nowrap">Acțiuni</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($grupuri as $grup)
+                                @php
+                                    $rowIndex = ($grupuri->firstItem() ?? 1) + $loop->index;
+                                    $facturaLabel = $grup->numar_factura ?: '—';
+                                    if ($grup->data_factura) {
+                                        $facturaLabel = $facturaLabel === '—'
+                                            ? optional($grup->data_factura)->format('d.m.Y')
+                                            : $facturaLabel . ' / ' . optional($grup->data_factura)->format('d.m.Y');
+                                    }
+                                    $incasata = $grup->suma_incasata !== null ? (float) $grup->suma_incasata : null;
+                                    $calculata = $grup->suma_calculata !== null ? (float) $grup->suma_calculata : null;
+                                    $diferenta = null;
+                                    if ($incasata !== null || $calculata !== null) {
+                                        $diferenta = ($incasata ?? 0) - ($calculata ?? 0);
+                                    }
+                                    $canDelete = ($grup->curse_count ?? 0) === 0;
+                                @endphp
+                                <tr style="background-color: {{ $grup->culoare_hex ?? '#ffffff' }}; color: #111;">
+                                    <td class="text-center fw-semibold">#{{ $rowIndex }}</td>
+                                    <td class="fw-semibold">{{ $grup->nume }}</td>
+                                    <td class="curse-nowrap">{{ $grup->formatDocumenteLabel() }}</td>
+                                    <td>{{ $facturaLabel }}</td>
+                                    <td class="text-end">{{ $incasata !== null ? number_format($incasata, 2) : '—' }}</td>
+                                    <td class="text-end">{{ $calculata !== null ? number_format($calculata, 2) : '—' }}</td>
+                                    <td class="text-end">{{ $diferenta !== null ? number_format($diferenta, 2) : '—' }}</td>
+                                    <td class="text-center">{{ $grup->curse_count ?? 0 }}</td>
+                                    <td class="text-end">
+                                        <div class="d-flex gap-2 justify-content-end">
+                                            <a
+                                                href="#"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#cursaGroupEditModal{{ $grup->id }}"
+                                                class="flex"
+                                                title="Editează grupul"
+                                                aria-label="Editează grupul"
+                                            >
+                                                <span class="badge bg-primary d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                                                    <i class="fa-solid fa-pen-to-square"></i>
+                                                </span>
+                                                <span class="visually-hidden">Editează</span>
+                                            </a>
+                                            @if ($canDelete)
+                                                <a
+                                                    href="#"
+                                                    data-bs-toggle="modal"
+                                                    data-bs-target="#cursaGroupDeleteModal{{ $grup->id }}"
+                                                    class="flex"
+                                                    title="Șterge grupul"
+                                                    aria-label="Șterge grupul"
+                                                >
+                                                    <span class="badge bg-danger d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                                                        <i class="fa-solid fa-trash"></i>
+                                                    </span>
+                                                    <span class="visually-hidden">Șterge</span>
+                                                </a>
+                                            @else
+                                                <span class="badge bg-secondary" title="Grupul are curse atașate" aria-label="Grup blocat">
+                                                    <i class="fa-solid fa-lock"></i>
+                                                </span>
+                                            @endif
+                                        </div>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="9" class="text-center py-4">
+                                        Nu există grupuri definite pentru această valabilitate.
+                                    </td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            @if ($grupuri instanceof \Illuminate\Contracts\Pagination\LengthAwarePaginator && $grupuri->hasPages())
+                <div class="px-3 mt-3">
+                    {{ $grupuri->withQueryString()->links() }}
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <div id="curse-modals" data-active-modal="{{ session('curse.modal') }}">
+        @include('valabilitati.curse.partials.modals', $modalViewData)
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -362,6 +362,8 @@ Route::middleware(['auth'])->group(function () {
                 ->name('valabilitati.curse.paginate');
             Route::get('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'index'])
                 ->name('valabilitati.curse.index');
+            Route::get('valabilitati/{valabilitate}/grupuri', [ValabilitateCursaGrupController::class, 'index'])
+                ->name('valabilitati.grupuri.index');
             Route::post('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'store'])
                 ->name('valabilitati.curse.store');
             Route::put('valabilitati/{valabilitate}/curse/{cursa}', [ValabilitateCursaController::class, 'update'])


### PR DESCRIPTION
## Summary
- add a dedicated `/valabilitati/{valabilitate}/grupuri` page so grupuri can be reviewed and managed outside the curse list, complete with pagination, alerts, and modal reuse
- refresh the curse list header, summary, and AJAX feedback so navigation between Curse/Grupuri is clearer and server responses can express success/error states
- expand the grup color palette, switch the color inputs to dropdowns, and block deletions when curse records are attached

## Testing
- `php artisan test` *(fails: vendor/autoload.php is missing in the test container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4aaed9ec8326a0d4b3f85802a703)