### PR TITLE
Allow nullable fields for valabilitati cursa groups

### DIFF
--- a/database/migrations/2025_03_24_100000_create_valabilitati_cursa_grupuri_table.php
+++ b/database/migrations/2025_03_24_100000_create_valabilitati_cursa_grupuri_table.php
@@ -14,8 +14,8 @@ return new class extends Migration
             $table->foreignId('valabilitate_id')
                 ->constrained('valabilitati')
                 ->cascadeOnDelete();
-            $table->string('nume');
-            $table->string('format_documente');
+            $table->string('nume')->nullable();
+            $table->string('format_documente')->nullable();
             $table->decimal('suma_incasata', 12, 2)->nullable();
             $table->decimal('suma_calculata', 12, 2)->nullable();
             $table->date('data_factura')->nullable();


### PR DESCRIPTION
## Summary
- allow the `nume` and `format_documente` columns on `valabilitati_cursa_grupuri` to be created as nullable so the migration matches the desired schema

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c22c5b9a083268d0e6a56db9a73bd)