### PR TITLE
Add bulk assignment of curse to grupuri

### DIFF
--- a/app/Http/Requests/ValabilitateCursaBulkAssignRequest.php
+++ b/app/Http/Requests/ValabilitateCursaBulkAssignRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\Valabilitate;
+use App\Support\Valabilitati\ValabilitatiCurseFilterState;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+class ValabilitateCursaBulkAssignRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        return $valabilitate && $this->user()?->can('update', $valabilitate);
+    }
+
+    public function rules(): array
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        return [
+            'curse_ids' => ['required', 'array', 'min:1'],
+            'curse_ids.*' => [
+                'integer',
+                'distinct',
+                Rule::exists('valabilitati_curse', 'id')->where(function ($query) use ($valabilitate) {
+                    if ($valabilitate instanceof Valabilitate) {
+                        $query->where('valabilitate_id', $valabilitate->getKey());
+                    }
+                }),
+            ],
+            'cursa_grup_id' => [
+                'required',
+                'integer',
+                Rule::exists('valabilitati_cursa_grupuri', 'id')->where(function ($query) use ($valabilitate) {
+                    if ($valabilitate instanceof Valabilitate) {
+                        $query->where('valabilitate_id', $valabilitate->getKey());
+                    }
+                }),
+            ],
+        ];
+    }
+
+    protected function failedValidation(Validator $validator): void
+    {
+        if ($this->expectsJson()) {
+            parent::failedValidation($validator);
+
+            return;
+        }
+
+        $valabilitate = $this->route('valabilitate');
+
+        $response = redirect($this->resolveRedirectUrl($valabilitate))
+            ->withErrors($validator)
+            ->withInput($this->all());
+
+        throw new ValidationException($validator, $response);
+    }
+
+    private function resolveRedirectUrl(?Valabilitate $valabilitate): string
+    {
+        if ($valabilitate instanceof Valabilitate) {
+            return ValabilitatiCurseFilterState::route($valabilitate);
+        }
+
+        return url()->previous();
+    }
+}

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -89,6 +89,8 @@
         $grupuriRoute = route('valabilitati.grupuri.index', $valabilitate);
         $curseRoute = route('valabilitati.curse.index', $valabilitate);
         $isGroupsContext = request()->routeIs('valabilitati.grupuri.*');
+        $bulkAssignRoute = route('valabilitati.curse.bulk-assign', $valabilitate);
+        $hasGrupuri = $valabilitate->cursaGrupuri->count() > 0;
     @endphp
     <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
         <div class="row card-header align-items-center text-center text-lg-start" style="border-radius: 40px 40px 0px 0px;">
@@ -159,6 +161,59 @@
                 ])
             </div>
 
+            <div class="px-3 mb-3">
+                <div
+                    id="curse-bulk-assign-panel"
+                    class="border border-2 border-light-subtle rounded-3 p-3 bg-light"
+                    data-action="{{ $bulkAssignRoute }}"
+                    data-has-groups="{{ $hasGrupuri ? 'true' : 'false' }}"
+                >
+                    <div class="row g-3 align-items-end">
+                        <div class="col-12 col-lg">
+                            <label for="curse-bulk-group" class="form-label mb-1">Alege grupul</label>
+                            <select
+                                id="curse-bulk-group"
+                                class="form-select"
+                                @disabled(! $hasGrupuri)
+                            >
+                                <option value="">Selectează grupul</option>
+                                @foreach ($valabilitate->cursaGrupuri as $grup)
+                                    <option value="{{ $grup->id }}">{{ $grup->nume }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                        <div class="col-12 col-lg-auto">
+                            <button
+                                type="button"
+                                id="curse-bulk-submit"
+                                class="btn btn-primary text-white w-100"
+                                @disabled(! $hasGrupuri)
+                            >
+                                <span data-bulk-default-label>Adaugă cursele selectate în grup</span>
+                                <span class="d-none" data-bulk-loading-label>
+                                    <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                                    Se procesează...
+                                </span>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-2 mt-3">
+                        <div class="text-muted small">
+                            Curse selectate: <span id="curse-bulk-selected-count">0</span>
+                        </div>
+                        <div class="small text-secondary">
+                            Bifează cursele din tabel (prima coloană) înainte de a le adăuga într-un grup.
+                        </div>
+                    </div>
+                    <div id="curse-bulk-feedback" class="text-danger small mt-2 d-none"></div>
+                    @unless ($hasGrupuri)
+                        <div class="alert alert-warning mt-3 mb-0" role="alert" data-bulk-empty-warning>
+                            Creează mai întâi un grup pentru a putea adăuga cursele selectate.
+                        </div>
+                    @endunless
+                </div>
+            </div>
+
             <div id="curse-feedback" class="px-3"></div>
 
             <div class="px-3">
@@ -166,6 +221,19 @@
                     <table class="table table-sm curse-data-table align-middle">
                         <thead>
                             <tr class="curse-data-header-top">
+                                <th rowspan="2" class="text-center curse-nowrap align-middle">
+                                    <div class="form-check mb-0">
+                                        <input
+                                            type="checkbox"
+                                            class="form-check-input"
+                                            id="curse-table-select-all"
+                                            @disabled($curse->count() === 0)
+                                        >
+                                        <label class="visually-hidden" for="curse-table-select-all">
+                                            Selectează toate cursele afișate
+                                        </label>
+                                    </div>
+                                </th>
                                 <th rowspan="2" class="text-center curse-nowrap">#</th>
                                 <th rowspan="2" class="curse-nowrap">Nr. cursă</th>
                                 <th rowspan="2">Cursa</th>
@@ -194,7 +262,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="12" class="text-center py-4">
+                                    <td colspan="13" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>
@@ -239,6 +307,20 @@
                 const tableBody = document.getElementById('curse-table-body');
                 const feedbackContainer = document.getElementById('curse-feedback');
                 const summaryContainer = document.getElementById('curse-summary');
+                const bulkAssignPanel = document.getElementById('curse-bulk-assign-panel');
+                const bulkGroupSelect = document.getElementById('curse-bulk-group');
+                const bulkSubmitButton = document.getElementById('curse-bulk-submit');
+                const bulkSelectedCount = document.getElementById('curse-bulk-selected-count');
+                const bulkFeedback = document.getElementById('curse-bulk-feedback');
+                const bulkSelectAllCheckbox = document.getElementById('curse-table-select-all');
+                const bulkEmptyWarning = bulkAssignPanel
+                    ? bulkAssignPanel.querySelector('[data-bulk-empty-warning]')
+                    : null;
+                const bulkAssignState = {
+                    selected: new Set(),
+                    loading: false,
+                    hasGroups: bulkAssignPanel ? bulkAssignPanel.dataset.hasGroups === 'true' : false,
+                };
                 const COUNTRY_DATALIST_ID = 'valabilitati-curse-tari';
                 const countryState = {
                     mapByName: new Map(),
@@ -268,6 +350,358 @@
                     observer: null,
                     nextUrl: null,
                     loading: false,
+                };
+
+                const updateBulkAssignUi = () => {
+                    if (bulkSelectedCount) {
+                        bulkSelectedCount.textContent = String(bulkAssignState.selected.size);
+                    }
+
+                    if (bulkSubmitButton) {
+                        const hasGroupSelection = bulkGroupSelect && bulkGroupSelect.value !== '';
+                        const canSubmit =
+                            bulkAssignState.hasGroups &&
+                            hasGroupSelection &&
+                            bulkAssignState.selected.size > 0 &&
+                            !bulkAssignState.loading;
+                        bulkSubmitButton.disabled = !canSubmit;
+                    }
+
+                    if (bulkSelectAllCheckbox && tableBody) {
+                        const totalCheckboxes = tableBody.querySelectorAll('.curse-row-checkbox').length;
+                        bulkSelectAllCheckbox.disabled = totalCheckboxes === 0;
+                    }
+                };
+
+                const clearBulkAssignError = () => {
+                    if (!bulkFeedback) {
+                        return;
+                    }
+
+                    bulkFeedback.textContent = '';
+                    bulkFeedback.classList.add('d-none');
+                };
+
+                const showBulkAssignError = (message) => {
+                    if (!bulkFeedback) {
+                        return;
+                    }
+
+                    bulkFeedback.textContent = message;
+                    bulkFeedback.classList.remove('d-none');
+                };
+
+                const setBulkAssignLoading = (isLoading) => {
+                    bulkAssignState.loading = isLoading;
+
+                    if (bulkSubmitButton) {
+                        const defaultLabel = bulkSubmitButton.querySelector('[data-bulk-default-label]');
+                        const loadingLabel = bulkSubmitButton.querySelector('[data-bulk-loading-label]');
+                        if (defaultLabel && loadingLabel) {
+                            defaultLabel.classList.toggle('d-none', isLoading);
+                            loadingLabel.classList.toggle('d-none', !isLoading);
+                        }
+                    }
+
+                    updateBulkAssignUi();
+                };
+
+                const resetBulkSelection = (clearSet = false) => {
+                    if (clearSet) {
+                        bulkAssignState.selected.clear();
+                    }
+
+                    if (tableBody) {
+                        const checkboxes = tableBody.querySelectorAll('.curse-row-checkbox');
+                        checkboxes.forEach(checkbox => {
+                            checkbox.checked = false;
+                        });
+                    }
+
+                    if (bulkSelectAllCheckbox) {
+                        bulkSelectAllCheckbox.checked = false;
+                        bulkSelectAllCheckbox.indeterminate = false;
+                    }
+
+                    updateBulkAssignUi();
+                };
+
+                const refreshBulkSelectAllState = () => {
+                    if (!bulkSelectAllCheckbox || !tableBody) {
+                        return;
+                    }
+
+                    const checkboxes = Array.from(tableBody.querySelectorAll('.curse-row-checkbox'));
+                    const total = checkboxes.length;
+                    const checked = checkboxes.filter(cb => cb.checked).length;
+
+                    bulkSelectAllCheckbox.indeterminate = checked > 0 && checked < total;
+                    bulkSelectAllCheckbox.checked = total > 0 && checked === total;
+                    bulkSelectAllCheckbox.disabled = total === 0;
+                };
+
+                const bindBulkCheckboxes = () => {
+                    if (!tableBody) {
+                        return;
+                    }
+
+                    const checkboxes = tableBody.querySelectorAll('.curse-row-checkbox');
+                    checkboxes.forEach(checkbox => {
+                        if (checkbox.dataset.bulkBound === 'true') {
+                            return;
+                        }
+
+                        checkbox.addEventListener('change', () => {
+                            const id = checkbox.dataset.cursaId;
+                            if (!id) {
+                                return;
+                            }
+
+                            if (checkbox.checked) {
+                                bulkAssignState.selected.add(id);
+                            } else {
+                                bulkAssignState.selected.delete(id);
+                            }
+
+                            refreshBulkSelectAllState();
+                            updateBulkAssignUi();
+                        });
+
+                        checkbox.dataset.bulkBound = 'true';
+                    });
+
+                    refreshBulkSelectAllState();
+                };
+
+                const handleBulkSelectAllChange = (event) => {
+                    if (!tableBody) {
+                        return;
+                    }
+
+                    const shouldCheck = event.target.checked;
+
+                    if (bulkSelectAllCheckbox) {
+                        bulkSelectAllCheckbox.indeterminate = false;
+                    }
+
+                    const checkboxes = tableBody.querySelectorAll('.curse-row-checkbox');
+                    checkboxes.forEach(checkbox => {
+                        checkbox.checked = shouldCheck;
+                        const id = checkbox.dataset.cursaId;
+
+                        if (!id) {
+                            return;
+                        }
+
+                        if (shouldCheck) {
+                            bulkAssignState.selected.add(id);
+                        } else {
+                            bulkAssignState.selected.delete(id);
+                        }
+                    });
+
+                    updateBulkAssignUi();
+                };
+
+                const syncBulkGroupOptions = () => {
+                    if (!bulkGroupSelect) {
+                        return;
+                    }
+
+                    const sourceSelect = modalsContainer
+                        ? modalsContainer.querySelector('#cursa-create-grup')
+                        : null;
+
+                    if (!sourceSelect) {
+                        return;
+                    }
+
+                    const previousValue = bulkGroupSelect.value;
+                    const newOptions = Array.from(sourceSelect.options)
+                        .filter(option => option.value && option.value !== '')
+                        .map(option => ({
+                            value: option.value,
+                            label: (option.textContent || '').trim(),
+                        }));
+
+                    bulkGroupSelect.innerHTML = '';
+
+                    const placeholder = document.createElement('option');
+                    placeholder.value = '';
+                    placeholder.textContent = 'Selectează grupul';
+                    bulkGroupSelect.appendChild(placeholder);
+
+                    newOptions.forEach(option => {
+                        const opt = document.createElement('option');
+                        opt.value = option.value;
+                        opt.textContent = option.label || '—';
+                        if (previousValue && previousValue === option.value) {
+                            opt.selected = true;
+                        }
+                        bulkGroupSelect.appendChild(opt);
+                    });
+
+                    bulkAssignState.hasGroups = newOptions.length > 0;
+
+                    if (!bulkAssignState.hasGroups) {
+                        bulkGroupSelect.value = '';
+                    }
+
+                    if (bulkAssignPanel) {
+                        bulkAssignPanel.dataset.hasGroups = bulkAssignState.hasGroups ? 'true' : 'false';
+                    }
+
+                    if (bulkEmptyWarning) {
+                        bulkEmptyWarning.classList.toggle('d-none', bulkAssignState.hasGroups);
+                    }
+
+                    updateBulkAssignUi();
+                };
+
+                const extractFirstValidationMessage = (errors) => {
+                    if (!errors || typeof errors !== 'object') {
+                        return null;
+                    }
+
+                    for (const key of Object.keys(errors)) {
+                        const messages = errors[key];
+                        if (Array.isArray(messages) && messages.length > 0) {
+                            return messages[0];
+                        }
+                    }
+
+                    return null;
+                };
+
+                const handleBulkAssignSubmit = (event) => {
+                    event.preventDefault();
+
+                    if (!bulkAssignPanel || !bulkAssignState.hasGroups || bulkAssignState.loading) {
+                        return;
+                    }
+
+                    clearBulkAssignError();
+
+                    const action = bulkAssignPanel.dataset.action;
+                    const groupId = bulkGroupSelect ? bulkGroupSelect.value : '';
+                    const curseIds = Array.from(bulkAssignState.selected);
+
+                    if (!action) {
+                        return;
+                    }
+
+                    if (curseIds.length === 0) {
+                        showBulkAssignError('Selectează cel puțin o cursă.');
+                        updateBulkAssignUi();
+                        return;
+                    }
+
+                    if (!groupId) {
+                        showBulkAssignError('Alege grupul în care dorești să muți cursele.');
+                        updateBulkAssignUi();
+                        return;
+                    }
+
+                    const formData = new FormData();
+                    curseIds.forEach(id => formData.append('curse_ids[]', id));
+                    formData.append('cursa_grup_id', groupId);
+
+                    setBulkAssignLoading(true);
+
+                    const fetchOptions = {
+                        method: 'POST',
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'Accept': 'application/json',
+                        },
+                        credentials: 'same-origin',
+                        body: formData,
+                    };
+
+                    const csrfToken = resolveCsrfToken();
+                    if (csrfToken) {
+                        fetchOptions.headers['X-CSRF-TOKEN'] = csrfToken;
+                    }
+
+                    fetch(action, fetchOptions)
+                        .then(response => {
+                            if (response.status === 422) {
+                                return response.json().then(data => {
+                                    const message = extractFirstValidationMessage(data.errors || {});
+                                    if (message) {
+                                        showBulkAssignError(message);
+                                    }
+                                    throw new Error('validation');
+                                });
+                            }
+
+                            if (!response.ok) {
+                                return response.text().then(body => {
+                                    const error = new Error('request_failed');
+                                    error.status = response.status;
+                                    error.statusText = response.statusText;
+                                    error.body = body;
+                                    error.url = response.url;
+                                    throw error;
+                                });
+                            }
+
+                            return response.json();
+                        })
+                        .then(data => {
+                            processMutationResponse(data);
+                            clearBulkAssignError();
+
+                            if (data.message) {
+                                const alertMap = {
+                                    error: 'danger',
+                                    warning: 'warning',
+                                    success: 'success',
+                                };
+                                const alertType = alertMap[data.message_type] || 'success';
+                                showFeedback(data.message, alertType);
+                            }
+                        })
+                        .catch(error => {
+                            if (error && error.message === 'validation') {
+                                return;
+                            }
+
+                            console.error('Valabilități curse bulk assign error', error);
+
+                            const detailText = buildErrorDetails(error);
+                            const baseMessage = 'A apărut o eroare neașteptată. Reîncercați.';
+                            showFeedback(detailText ? `${baseMessage}${detailText}` : baseMessage, 'danger');
+                        })
+                        .finally(() => {
+                            setBulkAssignLoading(false);
+                            updateBulkAssignUi();
+                        });
+                };
+
+                const initBulkAssignControls = () => {
+                    if (!bulkAssignPanel) {
+                        return;
+                    }
+
+                    if (bulkGroupSelect) {
+                        bulkGroupSelect.addEventListener('change', () => {
+                            clearBulkAssignError();
+                            updateBulkAssignUi();
+                        });
+                    }
+
+                    if (bulkSubmitButton) {
+                        bulkSubmitButton.addEventListener('click', handleBulkAssignSubmit);
+                    }
+
+                    if (bulkSelectAllCheckbox) {
+                        bulkSelectAllCheckbox.addEventListener('change', handleBulkSelectAllChange);
+                    }
+
+                    bindBulkCheckboxes();
+                    syncBulkGroupOptions();
+                    updateBulkAssignUi();
                 };
 
                 const appendHtml = (container, html) => {
@@ -591,6 +1025,8 @@
                 }
 
                 function processMutationResponse(data) {
+                    resetBulkSelection(true);
+
                     if (data.table_html && tableBody) {
                         tableBody.innerHTML = data.table_html;
                     }
@@ -602,6 +1038,7 @@
                     if (modalsContainer && data.modals_html) {
                         modalsContainer.innerHTML = data.modals_html;
                         modalsContainer.dataset.activeModal = '';
+                        syncBulkGroupOptions();
                     }
 
                     const loadMoreTrigger = document.getElementById('curse-load-more-trigger');
@@ -611,6 +1048,9 @@
 
                     initCountryInputs();
                     initLoadMore();
+                    bindBulkCheckboxes();
+                    updateBulkAssignUi();
+                    clearBulkAssignError();
 
                     if (supportsAjax()) {
                         attachFormHandlers();
@@ -771,6 +1211,8 @@
                         .then(data => {
                             if (data.rows_html && tableBody) {
                                 appendHtml(tableBody, data.rows_html);
+                                bindBulkCheckboxes();
+                                updateBulkAssignUi();
                             }
 
                             if (data.modals_html && modalsContainer) {
@@ -886,6 +1328,7 @@
 
                 initCountryInputs();
                 initLoadMore();
+                initBulkAssignControls();
 
                 if (supportsAjax()) {
                     attachFormHandlers();

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -93,7 +93,7 @@
 
     @if ($isNewGroup)
         <tr class="curse-group-heading" style="background-color: {{ $groupColor }}; color: {{ $groupTextColor }};">
-            <th colspan="12">
+            <th colspan="13">
                 <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
                     <span class="fw-semibold">{{ $groupName }}</span>
                     <span class="curse-group-heading__meta">
@@ -104,7 +104,24 @@
         </tr>
     @endif
 
+    @php
+        $checkboxId = 'cursa-select-' . $cursa->id;
+    @endphp
     <tr @class(['curse-group-row' => (bool) $group]) style="background-color: {{ $group ? $groupColor : 'transparent' }}; color: {{ $group ? $groupTextColor : '#111' }};">
+        <td class="text-center align-middle">
+            <div class="form-check mb-0">
+                <input
+                    type="checkbox"
+                    class="form-check-input curse-row-checkbox"
+                    id="{{ $checkboxId }}"
+                    value="{{ $cursa->id }}"
+                    data-cursa-id="{{ $cursa->id }}"
+                >
+                <label class="visually-hidden" for="{{ $checkboxId }}">
+                    Selectează cursa #{{ $cursa->nr_ordine }}
+                </label>
+            </div>
+        </td>
         {{-- # + up/down controls --}}
         <td class="text-center fw-semibold">
             <div class="d-inline-flex align-items-center gap-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -364,6 +364,8 @@ Route::middleware(['auth'])->group(function () {
                 ->name('valabilitati.curse.index');
             Route::get('valabilitati/{valabilitate}/grupuri', [ValabilitateCursaGrupController::class, 'index'])
                 ->name('valabilitati.grupuri.index');
+            Route::post('valabilitati/{valabilitate}/curse/bulk-assign', [ValabilitateCursaController::class, 'bulkAssign'])
+                ->name('valabilitati.curse.bulk-assign');
             Route::post('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'store'])
                 ->name('valabilitati.curse.store');
             Route::put('valabilitati/{valabilitate}/curse/{cursa}', [ValabilitateCursaController::class, 'update'])


### PR DESCRIPTION
## Summary
- add a dedicated request + controller endpoint so multiple curse can be assigned to a grup in one action
- extend the curse listing UI with selection checkboxes, a bulk action panel, and the JavaScript needed to submit the assignment via AJAX

## Testing
- Not run (composer install requires a GitHub token in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c267cb7f483269ec6453683a0502e)