### PR TITLE
Add Tech mail settings management

### DIFF
--- a/app/Http/Controllers/Tech/MailSettingsController.php
+++ b/app/Http/Controllers/Tech/MailSettingsController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Tech;
+
+use App\Http\Controllers\Controller;
+use App\Mail\TestMailConfiguration;
+use App\Support\MailSettings;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\View\View;
+use Throwable;
+
+class MailSettingsController extends Controller
+{
+    public function index(MailSettings $mailSettings): View
+    {
+        return view('tech.mail-settings.index', [
+            'mailSettings' => $mailSettings->get(),
+        ]);
+    }
+
+    public function update(Request $request, MailSettings $mailSettings): RedirectResponse
+    {
+        $data = $request->validate([
+            'mail_mailer' => ['required', 'string', 'max:50'],
+            'mail_host' => ['nullable', 'string', 'max:255'],
+            'mail_port' => ['nullable', 'integer', 'between:1,65535'],
+            'mail_username' => ['nullable', 'string', 'max:255'],
+            'mail_password' => ['nullable', 'string', 'max:255'],
+            'mail_encryption' => ['nullable', 'string', 'max:50'],
+            'mail_from_address' => ['required', 'email'],
+            'mail_from_name' => ['nullable', 'string', 'max:255'],
+            'mail_reply_to_address' => ['nullable', 'email'],
+            'mail_reply_to_name' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $mailSettings->update($data);
+
+        return redirect()
+            ->route('tech.mail-settings.index')
+            ->with('status', 'Setările de email au fost actualizate și vor fi folosite imediat.');
+    }
+
+    public function sendTest(Request $request, MailSettings $mailSettings): RedirectResponse
+    {
+        $data = $request->validate([
+            'test_recipient' => ['required', 'email'],
+            'test_subject' => ['nullable', 'string', 'max:255'],
+            'test_message' => ['nullable', 'string', 'max:5000'],
+        ]);
+
+        $subject = $data['test_subject'] ?: 'Test configurare email Maseco';
+        $messageBody = $data['test_message'] ?: 'Acesta este un email de test trimis din aplicația Maseco pentru a verifica configurarea SMTP.';
+
+        $mailSettings->applyToConfig();
+
+        try {
+            Mail::to($data['test_recipient'])->send(new TestMailConfiguration($subject, $messageBody));
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return redirect()
+                ->route('tech.mail-settings.index')
+                ->with('test_error', 'Trimiterea emailului de test a eșuat: ' . $exception->getMessage());
+        }
+
+        return redirect()
+            ->route('tech.mail-settings.index')
+            ->with('test_status', 'Emailul de test a fost trimis către ' . $data['test_recipient'] . '.');
+    }
+}

--- a/app/Mail/TestMailConfiguration.php
+++ b/app/Mail/TestMailConfiguration.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class TestMailConfiguration extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public string $messageBody;
+    public string $subjectLine;
+
+    public function __construct(string $subjectLine, string $messageBody)
+    {
+        $this->subjectLine = $subjectLine;
+        $this->messageBody = $messageBody;
+    }
+
+    public function build(): self
+    {
+        return $this->subject($this->subjectLine)
+            ->view('emails.test-mail-configuration')
+            ->with([
+                'body' => $this->messageBody,
+            ]);
+    }
+}

--- a/app/Models/SystemSetting.php
+++ b/app/Models/SystemSetting.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SystemSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Support\MailSettings;
 use Carbon\Carbon;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\ServiceProvider;
@@ -14,7 +15,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->singleton(MailSettings::class, function () {
+            return new MailSettings();
+        });
     }
 
     /**
@@ -32,5 +35,7 @@ class AppServiceProvider extends ServiceProvider
 
         // Use Bootstrap pagination views across the application
         Paginator::useBootstrapFive();
+
+        app(MailSettings::class)->applyToConfig();
     }
 }

--- a/app/Support/MailSettings.php
+++ b/app/Support/MailSettings.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\SystemSetting;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Schema;
+
+class MailSettings
+{
+    private const CACHE_KEY = 'system_settings.mail';
+
+    private const KEY_MAP = [
+        'mail_mailer' => 'MAIL_MAILER',
+        'mail_host' => 'MAIL_HOST',
+        'mail_port' => 'MAIL_PORT',
+        'mail_username' => 'MAIL_USERNAME',
+        'mail_password' => 'MAIL_PASSWORD',
+        'mail_encryption' => 'MAIL_ENCRYPTION',
+        'mail_from_address' => 'MAIL_FROM_ADDRESS',
+        'mail_from_name' => 'MAIL_FROM_NAME',
+        'mail_reply_to_address' => 'MAIL_REPLY_TO_ADDRESS',
+        'mail_reply_to_name' => 'MAIL_REPLY_TO_NAME',
+    ];
+
+    /**
+     * Retrieve the mail settings, falling back to config defaults.
+     */
+    public function get(): array
+    {
+        $settings = $this->defaults();
+
+        if (! Schema::hasTable('system_settings')) {
+            return $settings;
+        }
+
+        $stored = Cache::rememberForever(self::CACHE_KEY, function () {
+            return SystemSetting::whereIn('key', array_values(self::KEY_MAP))
+                ->pluck('value', 'key')
+                ->toArray();
+        });
+
+        foreach (self::KEY_MAP as $field => $key) {
+            if (array_key_exists($key, $stored) && $stored[$key] !== null) {
+                $settings[$field] = $stored[$key];
+            }
+        }
+
+        return $settings;
+    }
+
+    /**
+     * Persist settings coming from the form and refresh cache/config.
+     */
+    public function update(array $data): void
+    {
+        foreach (self::KEY_MAP as $field => $key) {
+            if (! array_key_exists($field, $data)) {
+                continue;
+            }
+
+            $value = $this->normalizeValue($data[$field]);
+
+            SystemSetting::updateOrCreate(
+                ['key' => $key],
+                ['value' => $value]
+            );
+        }
+
+        Cache::forget(self::CACHE_KEY);
+        $this->applyToConfig();
+    }
+
+    /**
+     * Push the stored values into Laravel's mail config at runtime.
+     */
+    public function applyToConfig(): void
+    {
+        if (! Schema::hasTable('system_settings')) {
+            return;
+        }
+
+        $settings = $this->get();
+
+        if (! empty($settings['mail_mailer'])) {
+            Config::set('mail.default', $settings['mail_mailer']);
+        }
+
+        Config::set('mail.mailers.smtp.host', $settings['mail_host']);
+        Config::set('mail.mailers.smtp.port', $settings['mail_port']);
+        Config::set('mail.mailers.smtp.username', $settings['mail_username']);
+        Config::set('mail.mailers.smtp.password', $settings['mail_password']);
+        Config::set('mail.mailers.smtp.encryption', $settings['mail_encryption']);
+
+        Config::set('mail.from', [
+            'address' => $settings['mail_from_address'],
+            'name' => $settings['mail_from_name'],
+        ]);
+
+        if (! empty($settings['mail_reply_to_address'])) {
+            Config::set('mail.reply_to', [
+                'address' => $settings['mail_reply_to_address'],
+                'name' => $settings['mail_reply_to_name'],
+            ]);
+        } else {
+            Config::set('mail.reply_to', null);
+        }
+    }
+
+    private function defaults(): array
+    {
+        return [
+            'mail_mailer' => config('mail.default'),
+            'mail_host' => config('mail.mailers.smtp.host'),
+            'mail_port' => config('mail.mailers.smtp.port'),
+            'mail_username' => config('mail.mailers.smtp.username'),
+            'mail_password' => config('mail.mailers.smtp.password'),
+            'mail_encryption' => config('mail.mailers.smtp.encryption'),
+            'mail_from_address' => config('mail.from.address'),
+            'mail_from_name' => config('mail.from.name'),
+            'mail_reply_to_address' => data_get(config('mail.reply_to'), 'address'),
+            'mail_reply_to_name' => data_get(config('mail.reply_to'), 'name'),
+        ];
+    }
+
+    private function normalizeValue(mixed $value): ?string
+    {
+        $value = is_string($value) ? trim($value) : $value;
+
+        if ($value === '' || $value === null) {
+            return null;
+        }
+
+        return (string) $value;
+    }
+}

--- a/database/migrations/2025_03_24_110000_create_system_settings_table.php
+++ b/database/migrations/2025_03_24_110000_create_system_settings_table.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('system_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+
+        $now = now();
+        $mailSettings = [
+            'MAIL_MAILER' => env('MAIL_MAILER', config('mail.default')),
+            'MAIL_HOST' => env('MAIL_HOST', config('mail.mailers.smtp.host')),
+            'MAIL_PORT' => env('MAIL_PORT', config('mail.mailers.smtp.port')),
+            'MAIL_USERNAME' => env('MAIL_USERNAME', config('mail.mailers.smtp.username')),
+            'MAIL_PASSWORD' => env('MAIL_PASSWORD', config('mail.mailers.smtp.password')),
+            'MAIL_ENCRYPTION' => env('MAIL_ENCRYPTION', config('mail.mailers.smtp.encryption')),
+            'MAIL_FROM_ADDRESS' => env('MAIL_FROM_ADDRESS', config('mail.from.address')),
+            'MAIL_FROM_NAME' => env('MAIL_FROM_NAME', config('mail.from.name')),
+            'MAIL_REPLY_TO_ADDRESS' => env('MAIL_REPLY_TO_ADDRESS', data_get(config('mail.reply_to'), 'address')),
+            'MAIL_REPLY_TO_NAME' => env('MAIL_REPLY_TO_NAME', data_get(config('mail.reply_to'), 'name')),
+        ];
+
+        foreach ($mailSettings as $key => $value) {
+            DB::table('system_settings')->updateOrInsert(
+                ['key' => $key],
+                ['value' => $value, 'created_at' => $now, 'updated_at' => $now]
+            );
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('system_settings');
+    }
+};

--- a/resources/views/emails/test-mail-configuration.blade.php
+++ b/resources/views/emails/test-mail-configuration.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ro">
+<head>
+    <meta charset="UTF-8">
+    <title>Email de test</title>
+</head>
+<body>
+    <p>{!! nl2br(e($body)) !!}</p>
+</body>
+</html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -168,6 +168,11 @@
                                                 <i class="fa-solid fa-user-secret me-1"></i>Impersonare utilizatori
                                             </a>
                                         </li>
+                                        <li>
+                                            <a class="dropdown-item" href="{{ route('tech.mail-settings.index') }}">
+                                                <i class="fa-solid fa-envelope-circle-check me-1"></i>Configurare email
+                                            </a>
+                                        </li>
                                     @endcan
                                     @can('access-tech')
                                         @if (auth()->user()?->hasRole('super-admin'))

--- a/resources/views/tech/mail-settings/index.blade.php
+++ b/resources/views/tech/mail-settings/index.blade.php
@@ -1,0 +1,196 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="container py-4">
+        <div class="row justify-content-center">
+            <div class="col-lg-10 col-xl-8">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                    <h1 class="h4 mb-0">
+                        <i class="fa-solid fa-envelope-circle-check me-2"></i>
+                        Configurare email
+                    </h1>
+                </div>
+
+                @if (session('status'))
+                    <div class="alert alert-success" role="alert">
+                        {{ session('status') }}
+                    </div>
+                @endif
+
+                @if (session('test_status'))
+                    <div class="alert alert-info" role="alert">
+                        {{ session('test_status') }}
+                    </div>
+                @endif
+
+                @if (session('test_error'))
+                    <div class="alert alert-danger" role="alert">
+                        {{ session('test_error') }}
+                    </div>
+                @endif
+
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <i class="fa-solid fa-gears me-1"></i>
+                        Setări SMTP
+                    </div>
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('tech.mail-settings.update') }}" novalidate>
+                            @csrf
+                            <div class="mb-3">
+                                <label for="mail_mailer" class="form-label">Mailer implicit</label>
+                                <input type="text" class="form-control @error('mail_mailer') is-invalid @enderror"
+                                       id="mail_mailer" name="mail_mailer" value="{{ old('mail_mailer', $mailSettings['mail_mailer']) }}"
+                                       required>
+                                @error('mail_mailer')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="row g-3">
+                                <div class="col-md-8">
+                                    <label for="mail_host" class="form-label">Host</label>
+                                    <input type="text" class="form-control @error('mail_host') is-invalid @enderror"
+                                           id="mail_host" name="mail_host" value="{{ old('mail_host', $mailSettings['mail_host']) }}">
+                                    @error('mail_host')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="mail_port" class="form-label">Port</label>
+                                    <input type="number" class="form-control @error('mail_port') is-invalid @enderror"
+                                           id="mail_port" name="mail_port" value="{{ old('mail_port', $mailSettings['mail_port']) }}"
+                                           min="1" max="65535">
+                                    @error('mail_port')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row g-3 mt-1">
+                                <div class="col-md-6">
+                                    <label for="mail_username" class="form-label">Utilizator</label>
+                                    <input type="text" class="form-control @error('mail_username') is-invalid @enderror"
+                                           id="mail_username" name="mail_username" value="{{ old('mail_username', $mailSettings['mail_username']) }}">
+                                    @error('mail_username')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="mail_password" class="form-label">Parolă</label>
+                                    <input type="text" class="form-control @error('mail_password') is-invalid @enderror"
+                                           id="mail_password" name="mail_password" value="{{ old('mail_password', $mailSettings['mail_password']) }}">
+                                    @error('mail_password')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="mb-3 mt-3">
+                                <label for="mail_encryption" class="form-label">Tip criptare</label>
+                                <input type="text" class="form-control @error('mail_encryption') is-invalid @enderror"
+                                       id="mail_encryption" name="mail_encryption" value="{{ old('mail_encryption', $mailSettings['mail_encryption']) }}">
+                                @error('mail_encryption')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="row g-3">
+                                <div class="col-md-6">
+                                    <label for="mail_from_address" class="form-label">From address</label>
+                                    <input type="email" class="form-control @error('mail_from_address') is-invalid @enderror"
+                                           id="mail_from_address" name="mail_from_address" value="{{ old('mail_from_address', $mailSettings['mail_from_address']) }}"
+                                           required>
+                                    @error('mail_from_address')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="mail_from_name" class="form-label">From name</label>
+                                    <input type="text" class="form-control @error('mail_from_name') is-invalid @enderror"
+                                           id="mail_from_name" name="mail_from_name" value="{{ old('mail_from_name', $mailSettings['mail_from_name']) }}">
+                                    @error('mail_from_name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="row g-3 mt-1">
+                                <div class="col-md-6">
+                                    <label for="mail_reply_to_address" class="form-label">Reply-to address</label>
+                                    <input type="email" class="form-control @error('mail_reply_to_address') is-invalid @enderror"
+                                           id="mail_reply_to_address" name="mail_reply_to_address"
+                                           value="{{ old('mail_reply_to_address', $mailSettings['mail_reply_to_address']) }}">
+                                    @error('mail_reply_to_address')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="mail_reply_to_name" class="form-label">Reply-to name</label>
+                                    <input type="text" class="form-control @error('mail_reply_to_name') is-invalid @enderror"
+                                           id="mail_reply_to_name" name="mail_reply_to_name"
+                                           value="{{ old('mail_reply_to_name', $mailSettings['mail_reply_to_name']) }}">
+                                    @error('mail_reply_to_name')
+                                        <div class="invalid-feedback">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <div class="d-flex justify-content-end mt-4">
+                                <button type="submit" class="btn btn-primary">
+                                    <i class="fa-solid fa-floppy-disk me-1"></i>
+                                    Salvează setările
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-header">
+                        <i class="fa-solid fa-paper-plane me-1"></i>
+                        Trimite email de test
+                    </div>
+                    <div class="card-body">
+                        <form method="POST" action="{{ route('tech.mail-settings.test') }}" novalidate>
+                            @csrf
+                            <div class="mb-3">
+                                <label for="test_recipient" class="form-label">Destinatar</label>
+                                <input type="email" class="form-control @error('test_recipient') is-invalid @enderror"
+                                       id="test_recipient" name="test_recipient"
+                                       value="{{ old('test_recipient') }}" required>
+                                @error('test_recipient')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+                            <div class="mb-3">
+                                <label for="test_subject" class="form-label">Subiect</label>
+                                <input type="text" class="form-control @error('test_subject') is-invalid @enderror"
+                                       id="test_subject" name="test_subject" value="{{ old('test_subject') }}"
+                                       placeholder="Test configurare email Maseco">
+                                @error('test_subject')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+                            <div class="mb-3">
+                                <label for="test_message" class="form-label">Mesaj</label>
+                                <textarea class="form-control @error('test_message') is-invalid @enderror" id="test_message"
+                                          name="test_message" rows="4" placeholder="Acesta este un email de test...">{{ old('test_message') }}</textarea>
+                                @error('test_message')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div class="d-flex justify-content-end">
+                                <button type="submit" class="btn btn-outline-secondary">
+                                    <i class="fa-solid fa-paper-plane me-1"></i>
+                                    Trimite email de test
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ use App\Http\Controllers\Service\GestiunePieseController;
 use App\Http\Controllers\Service\ServiceMasiniController;
 use App\Http\Controllers\Service\ServiceSheetController;
 use App\Http\Controllers\Tech\ImpersonationController;
+use App\Http\Controllers\Tech\MailSettingsController;
 use App\Http\Controllers\Tech\CronJobLogController;
 use App\Http\Controllers\Tech\MigrationCenterController;
 use App\Http\Controllers\Tech\SeederCenterController;
@@ -124,6 +125,9 @@ Route::middleware(['auth'])->group(function () {
             Route::middleware('can:access-tech-impersonation')->group(function () {
                 Route::get('impersonation', [ImpersonationController::class, 'index'])->name('impersonation.index');
                 Route::post('impersonation', [ImpersonationController::class, 'store'])->name('impersonation.start');
+                Route::get('mail-settings', [MailSettingsController::class, 'index'])->name('mail-settings.index');
+                Route::post('mail-settings', [MailSettingsController::class, 'update'])->name('mail-settings.update');
+                Route::post('mail-settings/test', [MailSettingsController::class, 'sendTest'])->name('mail-settings.test');
             });
 
             Route::middleware('role:super-admin')->group(function () {

--- a/tests/Feature/MailSettingsTest.php
+++ b/tests/Feature/MailSettingsTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Mail\TestMailConfiguration;
+use App\Models\Role;
+use App\Models\SystemSetting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class MailSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_super_admin_can_view_mail_settings_screen(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+
+        $response = $this->actingAs($superAdmin)->get(route('tech.mail-settings.index'));
+
+        $response->assertOk();
+        $response->assertSee('Configurare email');
+    }
+
+    public function test_user_four_can_view_mail_settings_screen(): void
+    {
+        $user = User::factory()->create(['id' => 4]);
+
+        $response = $this->actingAs($user)->get(route('tech.mail-settings.index'));
+
+        $response->assertOk();
+    }
+
+    public function test_regular_user_cannot_view_mail_settings_screen(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(route('tech.mail-settings.index'));
+
+        $response->assertForbidden();
+    }
+
+    public function test_updating_mail_settings_persists_values_and_updates_config(): void
+    {
+        $superAdmin = $this->createSuperAdmin();
+
+        $payload = [
+            'mail_mailer' => 'smtp',
+            'mail_host' => 'smtp.mailtrap.io',
+            'mail_port' => 2525,
+            'mail_username' => 'demo-user',
+            'mail_password' => 'demo-pass',
+            'mail_encryption' => 'tls',
+            'mail_from_address' => 'noreply@example.com',
+            'mail_from_name' => 'Maseco QA',
+            'mail_reply_to_address' => 'support@example.com',
+            'mail_reply_to_name' => 'Support',
+        ];
+
+        $response = $this->actingAs($superAdmin)->post(route('tech.mail-settings.update'), $payload);
+
+        $response->assertRedirect(route('tech.mail-settings.index'));
+        $response->assertSessionHas('status');
+
+        $this->assertSame('smtp', SystemSetting::where('key', 'MAIL_MAILER')->value('value'));
+        $this->assertSame('smtp.mailtrap.io', SystemSetting::where('key', 'MAIL_HOST')->value('value'));
+        $this->assertSame('2525', SystemSetting::where('key', 'MAIL_PORT')->value('value'));
+        $this->assertSame('demo-user', config('mail.mailers.smtp.username'));
+        $this->assertSame('demo-pass', config('mail.mailers.smtp.password'));
+        $this->assertSame('noreply@example.com', config('mail.from.address'));
+        $this->assertSame('Support', data_get(config('mail.reply_to'), 'name'));
+    }
+
+    public function test_send_test_email_dispatches_message(): void
+    {
+        Mail::fake();
+        $superAdmin = $this->createSuperAdmin();
+
+        $payload = [
+            'test_recipient' => 'qa@example.com',
+            'test_subject' => 'Verificare SMTP',
+            'test_message' => 'Mesaj de test.',
+        ];
+
+        $response = $this->actingAs($superAdmin)->post(route('tech.mail-settings.test'), $payload);
+
+        $response->assertRedirect(route('tech.mail-settings.index'));
+        $response->assertSessionHas('test_status');
+
+        Mail::assertSent(TestMailConfiguration::class, function (TestMailConfiguration $mail) {
+            return $mail->hasTo('qa@example.com')
+                && $mail->subjectLine === 'Verificare SMTP'
+                && $mail->messageBody === 'Mesaj de test.';
+        });
+    }
+
+    private function createSuperAdmin(): User
+    {
+        $role = Role::firstOrCreate(
+            ['slug' => 'super-admin'],
+            [
+                'name' => 'Super Admin',
+                'description' => 'Full access to the technical toolbox.',
+            ]
+        );
+
+        $user = User::factory()->create();
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- persist the SMTP-related environment values inside a new `system_settings` table and hydrate Laravel's mail config from a dedicated support class during boot
- add the Tech → Configurare email page so super-admins and user #4 can update the settings and send test messages through a new controller, Blade view, and mailable
- extend the tech routes, navigation, and feature coverage to protect the new page and assert that updates/test sends behave correctly

## Testing
- Not run (composer install was blocked by GitHub 403 responses, so the PHPUnit suite could not be executed)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad80048f88326b34c17ca2063b484)