### PR TITLE
Add zile calculate metadata to grupuri and improve curse groups

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -48,6 +48,7 @@ class ValabilitateCursaController extends Controller
             'backUrl' => ValabilitatiFilterState::route(),
             'summary' => $summary,
             'modalViewData' => $modalViewData,
+            'bulkAssignRoute' => route('valabilitati.curse.bulk-assign', $valabilitate),
         ]);
     }
 

--- a/app/Http/Requests/ValabilitateCursaGrupRequest.php
+++ b/app/Http/Requests/ValabilitateCursaGrupRequest.php
@@ -24,6 +24,7 @@ class ValabilitateCursaGrupRequest extends FormRequest
         return [
             'nume' => ['nullable', 'string', 'max:255'],
             'format_documente' => ['nullable', Rule::in(array_keys(ValabilitateCursaGrup::documentFormats()))],
+            'zile_calculate' => ['nullable', 'integer', 'min:0'],
             'suma_incasata' => ['nullable', 'numeric', 'min:0'],
             'suma_calculata' => ['nullable', 'numeric', 'min:0'],
             'data_factura' => ['nullable', 'date'],

--- a/app/Models/ValabilitateCursaGrup.php
+++ b/app/Models/ValabilitateCursaGrup.php
@@ -45,6 +45,7 @@ class ValabilitateCursaGrup extends Model
         'valabilitate_id',
         'nume',
         'format_documente',
+        'zile_calculate',
         'suma_incasata',
         'suma_calculata',
         'data_factura',
@@ -56,6 +57,7 @@ class ValabilitateCursaGrup extends Model
         'data_factura' => 'date',
         'suma_incasata' => 'decimal:2',
         'suma_calculata' => 'decimal:2',
+        'zile_calculate' => 'integer',
     ];
 
     public static function colorPalette(): array
@@ -85,6 +87,10 @@ class ValabilitateCursaGrup extends Model
 
     public function formatDocumenteLabel(): string
     {
+        if (! is_string($this->format_documente) || $this->format_documente === '') {
+            return 'Fără format';
+        }
+
         return self::DOCUMENT_FORMATS[$this->format_documente] ?? $this->format_documente;
     }
 }

--- a/database/migrations/2025_05_01_120000_add_zile_calculate_to_valabilitati_cursa_grupuri_table.php
+++ b/database/migrations/2025_05_01_120000_add_zile_calculate_to_valabilitati_cursa_grupuri_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('valabilitati_cursa_grupuri', function (Blueprint $table): void {
+            $table->unsignedInteger('zile_calculate')->nullable()->after('format_documente');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_cursa_grupuri', function (Blueprint $table): void {
+            $table->dropColumn('zile_calculate');
+        });
+    }
+};

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -65,15 +65,21 @@
         }
 
         .curse-group-heading th {
-            font-size: 0.8rem;
+            font-size: 0.85rem;
             text-transform: uppercase;
-            background-color: transparent;
+            background-color: rgba(0, 0, 0, 0.05);
             color: inherit;
         }
 
+        .curse-group-heading--emphasis th,
+        .curse-group-heading--emphasis td {
+            border-top: 2px solid rgba(0, 0, 0, 0.25);
+            border-bottom: 2px solid rgba(0, 0, 0, 0.25);
+            box-shadow: inset 0 0 0 999px rgba(255, 255, 255, 0.08);
+        }
+
         .curse-group-heading__meta {
-            font-size: 0.75rem;
-            color: #495057;
+            font-size: 0.8rem;
         }
 
         .curse-group-row {
@@ -252,7 +258,6 @@
                                     KM Bord (plecare / sosire)
                                 </th>
                                 <th colspan="2" class="text-center curse-nowrap">KM Bord 2</th>
-                                <th rowspan="2" class="text-end curse-nowrap">Sumă încasată</th>
                                 <th rowspan="2" class="text-end curse-nowrap">
                                     Diferența KM<br>(Bord – Maps)
                                 </th>
@@ -271,7 +276,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="13" class="text-center py-4">
+                                    <td colspan="12" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -837,6 +837,7 @@
         $isGroupCreateActive = $currentFormType === 'group-create';
         $groupCreateName = $isGroupCreateActive ? old('nume', '') : '';
         $groupCreateFormat = $isGroupCreateActive ? old('format_documente', '') : '';
+        $groupCreateZile = $isGroupCreateActive ? old('zile_calculate', '') : '';
         $groupCreateSumaIncasata = $isGroupCreateActive ? old('suma_incasata', '') : '';
         $groupCreateSumaCalculata = $isGroupCreateActive ? old('suma_calculata', '') : '';
         $groupCreateDataFactura = $isGroupCreateActive ? old('data_factura', '') : '';
@@ -898,6 +899,20 @@
                                 </select>
                                 <div class="invalid-feedback {{ $isGroupCreateActive && $errors->has('format_documente') ? 'd-block' : '' }}" data-error-for="format_documente">
                                     {{ $isGroupCreateActive ? $errors->first('format_documente') : '' }}
+                                </div>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="group-create-zile" class="form-label">Zile calculate</label>
+                                <input
+                                    type="number"
+                                    min="0"
+                                    id="group-create-zile"
+                                    name="zile_calculate"
+                                    class="form-control rounded-3 {{ $isGroupCreateActive && $errors->has('zile_calculate') ? 'is-invalid' : '' }}"
+                                    value="{{ $groupCreateZile }}"
+                                >
+                                <div class="invalid-feedback {{ $isGroupCreateActive && $errors->has('zile_calculate') ? 'd-block' : '' }}" data-error-for="zile_calculate">
+                                    {{ $isGroupCreateActive ? $errors->first('zile_calculate') : '' }}
                                 </div>
                             </div>
                             <div class="col-md-6">
@@ -1007,6 +1022,7 @@
             $isGroupEditActive = $currentFormType === 'group-edit' && $currentFormId === (int) $grup->id;
             $groupEditName = $isGroupEditActive ? old('nume', $grup->nume) : $grup->nume;
             $groupEditFormat = $isGroupEditActive ? old('format_documente', $grup->format_documente) : $grup->format_documente;
+            $groupEditZile = $isGroupEditActive ? old('zile_calculate', $grup->zile_calculate) : $grup->zile_calculate;
             $groupEditSumaIncasata = $isGroupEditActive ? old('suma_incasata', $grup->suma_incasata) : $grup->suma_incasata;
             $groupEditSumaCalculata = $isGroupEditActive ? old('suma_calculata', $grup->suma_calculata) : $grup->suma_calculata;
             $groupEditDataFactura = $isGroupEditActive
@@ -1072,6 +1088,20 @@
                                     </select>
                                     <div class="invalid-feedback {{ $isGroupEditActive && $errors->has('format_documente') ? 'd-block' : '' }}" data-error-for="format_documente">
                                         {{ $isGroupEditActive ? $errors->first('format_documente') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="group-edit-zile-{{ $grup->id }}" class="form-label">Zile calculate</label>
+                                    <input
+                                        type="number"
+                                        min="0"
+                                        id="group-edit-zile-{{ $grup->id }}"
+                                        name="zile_calculate"
+                                        class="form-control rounded-3 {{ $isGroupEditActive && $errors->has('zile_calculate') ? 'is-invalid' : '' }}"
+                                        value="{{ $groupEditZile }}"
+                                    >
+                                    <div class="invalid-feedback {{ $isGroupEditActive && $errors->has('zile_calculate') ? 'd-block' : '' }}" data-error-for="zile_calculate">
+                                        {{ $isGroupEditActive ? $errors->first('zile_calculate') : '' }}
                                     </div>
                                 </div>
                                 <div class="col-md-6">

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -86,19 +86,40 @@
         if ($isNewGroup) {
             $currentGroupKey = $groupKey;
         }
-        $groupSumDisplay = $isNewGroup && $group && $group->suma_incasata !== null
-            ? number_format((float) $group->suma_incasata, 2)
-            : '—';
+        $groupFinancialMeta = null;
+        if ($isNewGroup && $group) {
+            $incasata = $group->suma_incasata !== null ? number_format((float) $group->suma_incasata, 2) : null;
+            $calculata = $group->suma_calculata !== null ? number_format((float) $group->suma_calculata, 2) : null;
+            $diferenta = null;
+            if ($group->suma_incasata !== null || $group->suma_calculata !== null) {
+                $rawDiff = (float) ($group->suma_incasata ?? 0) - (float) ($group->suma_calculata ?? 0);
+                $diferenta = number_format($rawDiff, 2);
+            }
+            $zileCalculate = is_numeric($group->zile_calculate) ? (int) $group->zile_calculate : null;
+            $groupFinancialMeta = [
+                'suma_incasata' => $incasata,
+                'suma_calculata' => $calculata,
+                'diferenta' => $diferenta,
+                'zile_calculate' => $zileCalculate,
+            ];
+        }
     @endphp
 
     @if ($isNewGroup)
-        <tr class="curse-group-heading" style="background-color: {{ $groupColor }}; color: {{ $groupTextColor }};">
-            <th colspan="13">
-                <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2">
-                    <span class="fw-semibold">{{ $groupName }}</span>
-                    <span class="curse-group-heading__meta">
-                        Format: {{ $groupFormat }} | Factură: {{ $groupInvoice }}
-                    </span>
+        <tr class="curse-group-heading curse-group-heading--emphasis" style="background-color: {{ $groupColor }}; color: {{ $groupTextColor }};">
+            <th colspan="12">
+                <div class="d-flex flex-column flex-xl-row justify-content-between gap-3">
+                    <div class="fw-semibold fs-6 text-uppercase">{{ $groupName }}</div>
+                    <div class="d-flex flex-wrap gap-3 small curse-group-heading__meta">
+                        <span>Format: <strong>{{ $groupFormat }}</strong></span>
+                        <span>Factură: <strong>{{ $groupInvoice }}</strong></span>
+                        @if ($groupFinancialMeta)
+                            <span>Sumă încasată: <strong>{{ $groupFinancialMeta['suma_incasata'] ?? '—' }}</strong></span>
+                            <span>Sumă calculată: <strong>{{ $groupFinancialMeta['suma_calculata'] ?? '—' }}</strong></span>
+                            <span>Diferență: <strong>{{ $groupFinancialMeta['diferenta'] ?? '—' }}</strong></span>
+                            <span>Zile calculate: <strong>{{ $groupFinancialMeta['zile_calculate'] ?? '—' }}</strong></span>
+                        @endif
+                    </div>
                 </div>
             </th>
         </tr>
@@ -205,11 +226,6 @@
         {{-- KM Bord 2 – Km plin --}}
         <td class="text-end text-nowrap align-middle">
             {{ $kmPlin !== null ? $kmPlin : '—' }}
-        </td>
-
-        {{-- Sumă încasată --}}
-        <td class="text-end align-middle" style="background-color: {{ $group ? $groupColor : 'transparent' }};">
-            {{ $groupSumDisplay }}
         </td>
 
         {{-- Diferența KM (Bord – Maps) --}}

--- a/resources/views/valabilitati/grupuri/index.blade.php
+++ b/resources/views/valabilitati/grupuri/index.blade.php
@@ -130,6 +130,7 @@
                                 <th class="text-center curse-nowrap">#</th>
                                 <th>Grup</th>
                                 <th class="curse-nowrap">Format</th>
+                                <th class="text-center curse-nowrap">Zile calculate</th>
                                 <th>Factură</th>
                                 <th class="text-end curse-nowrap">Sumă încasată</th>
                                 <th class="text-end curse-nowrap">Sumă calculată</th>
@@ -155,6 +156,9 @@
                                         $diferenta = ($incasata ?? 0) - ($calculata ?? 0);
                                     }
                                     $canDelete = ($grup->curse_count ?? 0) === 0;
+                                    $zileCalculate = is_numeric($grup->zile_calculate)
+                                        ? (int) $grup->zile_calculate
+                                        : null;
                                 @endphp
                                 @php
                                     $rowColor = $grup->culoare_hex ?? '#ffffff';
@@ -164,6 +168,7 @@
                                     <td class="text-center fw-semibold">#{{ $rowIndex }}</td>
                                     <td class="fw-semibold">{{ $grup->nume ?? '—' }}</td>
                                     <td class="curse-nowrap">{{ $grup->formatDocumenteLabel() ?: '—' }}</td>
+                                    <td class="text-center">{{ $zileCalculate !== null ? $zileCalculate : '—' }}</td>
                                     <td>{{ $facturaLabel }}</td>
                                     <td class="text-end">{{ $incasata !== null ? number_format($incasata, 2) : '—' }}</td>
                                     <td class="text-end">{{ $calculata !== null ? number_format($calculata, 2) : '—' }}</td>
@@ -208,7 +213,7 @@
                                 </tr>
                             @empty
                                 <tr>
-                                    <td colspan="9" class="text-center py-4">
+                                    <td colspan="10" class="text-center py-4">
                                         Nu există grupuri definite pentru această valabilitate.
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary
- add support for the new `zile_calculate` attribute on curse groups, including validation, database migration, and UI updates
- fix crashes when the document format is not provided and surface all group metadata in the grouped rows on the curse listing
- remove the redundant "sumă încasată" column from the main curse table and ensure the bulk assign panel always knows its route

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c39cc0c648326bd2b89edae0e2c19)