### PR TITLE
Add valabilitati divisions relationship

### DIFF
--- a/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
+++ b/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
@@ -68,7 +68,7 @@ trait HandlesValabilitatiCurseListings
         $query = ValabilitatiCurseFilterState::get($valabilitate);
         $filtersRequest = Request::create('', 'GET', $query);
         $curse = $this->paginateCurse($filtersRequest, $valabilitate, $query);
-        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'cursaGrupuri']);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'cursaGrupuri', 'divizie']);
         $summary = $this->buildSummaryData($valabilitate, $curse);
 
         return response()->json([

--- a/app/Http/Controllers/SoferDashboardController.php
+++ b/app/Http/Controllers/SoferDashboardController.php
@@ -17,7 +17,7 @@ class SoferDashboardController extends Controller
 
         if ($driver) {
             $activeValabilitate = Valabilitate::query()
-                ->select(['id', 'numar_auto', 'denumire', 'data_inceput', 'data_sfarsit'])
+                ->select(['id', 'numar_auto', 'divizie_id', 'data_inceput', 'data_sfarsit'])
                 ->where('sofer_id', $driver->id)
                 ->whereDate('data_inceput', '<=', $today)
                 ->where(function ($query) use ($today) {
@@ -25,6 +25,7 @@ class SoferDashboardController extends Controller
                         ->whereNull('data_sfarsit')
                         ->orWhereDate('data_sfarsit', '>=', $today);
                 })
+                ->with('divizie:id,nume')
                 ->withCount('curse')
                 ->orderByDesc('data_inceput')
                 ->first();

--- a/app/Http/Controllers/SoferValabilitateCursaController.php
+++ b/app/Http/Controllers/SoferValabilitateCursaController.php
@@ -21,6 +21,7 @@ class SoferValabilitateCursaController extends Controller
         $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
 
         $valabilitate->load([
+            'divizie',
             'curse' => function ($query) {
                 $query->orderBy('nr_ordine')->orderBy('data_cursa');
             },
@@ -37,6 +38,7 @@ class SoferValabilitateCursaController extends Controller
     public function create(Request $request, Valabilitate $valabilitate): View
     {
         $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
+        $valabilitate->loadMissing('divizie');
 
         $tari = Tara::query()
             ->orderBy('nume')
@@ -56,6 +58,7 @@ class SoferValabilitateCursaController extends Controller
     public function edit(Request $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): View
     {
         $valabilitate = $this->ensureDriverOwnsValabilitate($request, $valabilitate);
+        $valabilitate->loadMissing('divizie');
         $this->ensureCursaBelongsToValabilitate($valabilitate, $cursa);
 
         $cursa->loadMissing(['incarcareTara', 'descarcareTara']);

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -30,7 +30,7 @@ class ValabilitateCursaController extends Controller
 
         ValabilitatiCurseFilterState::remember($request, $valabilitate, []);
 
-        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'cursaGrupuri']);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'cursaGrupuri', 'divizie']);
         $summary = $this->buildSummaryData($valabilitate, $curse);
 
         $modalViewData = $this->buildModalViewData(
@@ -59,7 +59,7 @@ class ValabilitateCursaController extends Controller
         $curse = $this->paginateCurse($request, $valabilitate);
 
         ValabilitatiCurseFilterState::remember($request, $valabilitate, []);
-        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'cursaGrupuri']);
+        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'cursaGrupuri', 'divizie']);
         $summary = $this->buildSummaryData($valabilitate, $curse);
 
         return response()->json([

--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use App\Models\User;
 use App\Models\ValabilitateTaxaDrum;
 use App\Models\ValabilitateCursaGrup;
+use App\Models\ValabilitatiDivizie;
 
 class Valabilitate extends Model
 {
@@ -19,7 +20,7 @@ class Valabilitate extends Model
     protected $fillable = [
         'numar_auto',
         'sofer_id',
-        'denumire',
+        'divizie_id',
         'data_inceput',
         'data_sfarsit',
     ];
@@ -32,6 +33,11 @@ class Valabilitate extends Model
     public function sofer(): BelongsTo
     {
         return $this->belongsTo(User::class, 'sofer_id');
+    }
+
+    public function divizie(): BelongsTo
+    {
+        return $this->belongsTo(ValabilitatiDivizie::class, 'divizie_id');
     }
 
     public function curse(): HasMany

--- a/app/Models/ValabilitatiDivizie.php
+++ b/app/Models/ValabilitatiDivizie.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ValabilitatiDivizie extends Model
+{
+    use HasFactory;
+
+    protected $table = 'valabilitati_divizii';
+
+    protected $fillable = [
+        'nume',
+    ];
+
+    public function valabilitati(): HasMany
+    {
+        return $this->hasMany(Valabilitate::class, 'divizie_id');
+    }
+}

--- a/database/factories/ValabilitateFactory.php
+++ b/database/factories/ValabilitateFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\User;
 use App\Models\Valabilitate;
+use App\Models\ValabilitatiDivizie;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -20,7 +21,7 @@ class ValabilitateFactory extends Factory
         return [
             'numar_auto' => strtoupper(fake()->bothify('??##???')),
             'sofer_id' => User::factory(),
-            'denumire' => fake()->words(3, true),
+            'divizie_id' => ValabilitatiDivizie::factory(),
             'data_inceput' => $startDate->format('Y-m-d'),
             'data_sfarsit' => fake()->boolean(40)
                 ? fake()->dateTimeBetween($startDate, '+2 months')->format('Y-m-d')

--- a/database/factories/ValabilitatiDivizieFactory.php
+++ b/database/factories/ValabilitatiDivizieFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ValabilitatiDivizie;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\ValabilitatiDivizie>
+ */
+class ValabilitatiDivizieFactory extends Factory
+{
+    protected $model = ValabilitatiDivizie::class;
+
+    public function definition(): array
+    {
+        return [
+            'nume' => fake()->unique()->company(),
+        ];
+    }
+}

--- a/database/migrations/2025_05_10_000000_create_valabilitati_divizii_table_and_update_valabilitati_table.php
+++ b/database/migrations/2025_05_10_000000_create_valabilitati_divizii_table_and_update_valabilitati_table.php
@@ -1,0 +1,114 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Carbon;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('valabilitati_divizii', function (Blueprint $table): void {
+            $table->id();
+            $table->string('nume')->unique();
+            $table->timestamps();
+        });
+
+        Schema::table('valabilitati', function (Blueprint $table): void {
+            $table->foreignId('divizie_id')
+                ->nullable()
+                ->after('sofer_id')
+                ->constrained('valabilitati_divizii');
+        });
+
+        DB::transaction(function (): void {
+            $now = Carbon::now();
+            $fallbackName = 'Nespecificat';
+            $divizieCache = [];
+
+            $valabilitati = DB::table('valabilitati')
+                ->select(['id', 'denumire'])
+                ->get();
+
+            foreach ($valabilitati as $valabilitate) {
+                $name = trim((string) ($valabilitate->denumire ?? ''));
+                if ($name === '') {
+                    $name = $fallbackName;
+                }
+
+                if (! array_key_exists($name, $divizieCache)) {
+                    $existingId = DB::table('valabilitati_divizii')
+                        ->where('nume', $name)
+                        ->value('id');
+
+                    if ($existingId) {
+                        $divizieCache[$name] = $existingId;
+                    } else {
+                        $divizieCache[$name] = DB::table('valabilitati_divizii')->insertGetId([
+                            'nume' => $name,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ]);
+                    }
+                }
+
+                DB::table('valabilitati')
+                    ->where('id', $valabilitate->id)
+                    ->update(['divizie_id' => $divizieCache[$name]]);
+            }
+
+            if (! array_key_exists($fallbackName, $divizieCache)) {
+                $divizieCache[$fallbackName] = DB::table('valabilitati_divizii')->insertGetId([
+                    'nume' => $fallbackName,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+
+            DB::table('valabilitati')
+                ->whereNull('divizie_id')
+                ->update(['divizie_id' => $divizieCache[$fallbackName]]);
+        });
+
+        Schema::table('valabilitati', function (Blueprint $table): void {
+            $table->dropColumn('denumire');
+        });
+
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement('ALTER TABLE valabilitati MODIFY divizie_id BIGINT UNSIGNED NOT NULL');
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati', function (Blueprint $table): void {
+            $table->string('denumire')->nullable()->after('sofer_id');
+        });
+
+        DB::transaction(function (): void {
+            $valabilitati = DB::table('valabilitati')
+                ->leftJoin('valabilitati_divizii', 'valabilitati_divizii.id', '=', 'valabilitati.divizie_id')
+                ->select(['valabilitati.id', 'valabilitati_divizii.nume as divizie_nume'])
+                ->get();
+
+            foreach ($valabilitati as $valabilitate) {
+                $name = trim((string) ($valabilitate->divizie_nume ?? ''));
+
+                DB::table('valabilitati')
+                    ->where('id', $valabilitate->id)
+                    ->update(['denumire' => $name !== '' ? $name : 'Nespecificat']);
+            }
+        });
+
+        if (DB::getDriverName() !== 'sqlite') {
+            DB::statement('ALTER TABLE valabilitati MODIFY denumire VARCHAR(255) NOT NULL');
+        }
+
+        Schema::table('valabilitati', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('divizie_id');
+        });
+
+        Schema::dropIfExists('valabilitati_divizii');
+    }
+};

--- a/resources/views/sofer/dashboard.blade.php
+++ b/resources/views/sofer/dashboard.blade.php
@@ -17,6 +17,9 @@
                     <b class="h4 text-primary fw-bold">
                         {{ $activeValabilitate->numar_auto ?? 'Fără număr' }}
                     </b>
+                    <p class="text-muted mb-0">
+                        {{ $activeValabilitate->divizie->nume ?? 'Fără divizie' }}
+                    </p>
                 </div>
 
                 <div class="row g-4 align-items-center">

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -16,7 +16,7 @@
             {{-- Title + label in the middle --}}
             <div class="flex-grow-1 mx-1 text-center">
                 <h1 class="sofer-header__title fw-bold mb-0 text-truncate">
-                    {{ $valabilitate->denumire }}
+                    {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
                 </h1>
             </div>
 
@@ -32,6 +32,10 @@
 
         {{-- Meta line: dates + număr auto --}}
         <div class="sofer-header__meta small text-muted mt-2 text-center gap-2">
+            <span class="me-2">
+                <i class="fa-solid fa-building me-1"></i>
+                {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
+            </span>
             <span class="">
                 <i class="fa-solid fa-car-side me-1"></i>
                 {{ $valabilitate->numar_auto ?? 'Fără număr' }}

--- a/resources/views/valabilitati/create.blade.php
+++ b/resources/views/valabilitati/create.blade.php
@@ -24,6 +24,7 @@
             'submitLabel' => 'Salvează',
             'backUrl' => $backUrl ?? route('valabilitati.index'),
             'soferi' => $soferi,
+            'divizii' => $divizii,
         ])
     </div>
 </div>

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -105,7 +105,7 @@
                         <span>
                             <i class="fa-solid fa-route me-1"></i>Curse
                             /
-                            {{ $valabilitate->denumire }}
+                            {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
                         </span>
                     </span>
                 </span>

--- a/resources/views/valabilitati/edit.blade.php
+++ b/resources/views/valabilitati/edit.blade.php
@@ -25,6 +25,7 @@
             'submitLabel' => 'Salvează modificările',
             'backUrl' => $backUrl ?? route('valabilitati.index'),
             'soferi' => $soferi,
+            'divizii' => $divizii,
         ])
     </div>
 </div>

--- a/resources/views/valabilitati/grupuri/index.blade.php
+++ b/resources/views/valabilitati/grupuri/index.blade.php
@@ -78,7 +78,7 @@
                         <span>
                             <i class="fa-solid fa-layer-group me-1"></i>Grupuri
                             /
-                            {{ $valabilitate->denumire }}
+                            {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
                         </span>
                     </span>
                 </span>

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -20,7 +20,7 @@
                         <input type="text" class="form-control rounded-3" id="filter-sofer" name="sofer" placeholder="Șofer" value="{{ $filters['sofer'] }}">
                     </div>
                     <div class="col-lg-3 col-md-6 mb-2 mb-lg-0">
-                        <input type="text" class="form-control rounded-3" id="filter-denumire" name="denumire" placeholder="Denumire" value="{{ $filters['denumire'] }}">
+                        <input type="text" class="form-control rounded-3" id="filter-divizie" name="divizie" placeholder="Divizie" value="{{ $filters['divizie'] }}">
                     </div>
                 @php
                     $inceputRangeFilter = implode(',', array_filter([
@@ -103,7 +103,7 @@
             <table class="table table-sm table-striped table-hover rounded align-middle">
                 <thead class="text-white rounded culoare2">
                     <tr>
-                        <th>Denumire</th>
+                        <th>Divizie</th>
                         <th>Număr auto</th>
                         <th>Șofer</th>
                         <th>Început</th>

--- a/resources/views/valabilitati/partials/delete-modal.blade.php
+++ b/resources/views/valabilitati/partials/delete-modal.blade.php
@@ -46,15 +46,15 @@
 
                     deleteForm.setAttribute('action', action);
 
-                    const denumire = trigger.getAttribute('data-delete-denumire') || '';
+                    const divizie = trigger.getAttribute('data-delete-divizie') || '';
                     const numarAuto = trigger.getAttribute('data-delete-numar-auto') || '';
 
                     if (messageElement) {
                         let message = 'Sigur ștergi valabilitatea?';
-                        if (denumire && numarAuto) {
-                            message = `Sigur ștergi valabilitatea „${denumire}” pentru „${numarAuto}”?`;
-                        } else if (denumire) {
-                            message = `Sigur ștergi valabilitatea „${denumire}”?`;
+                        if (divizie && numarAuto) {
+                            message = `Sigur ștergi valabilitatea pentru divizia „${divizie}” și numărul „${numarAuto}”?`;
+                        } else if (divizie) {
+                            message = `Sigur ștergi valabilitatea pentru divizia „${divizie}”?`;
                         } else if (numarAuto) {
                             message = `Sigur ștergi valabilitatea pentru „${numarAuto}”?`;
                         }

--- a/resources/views/valabilitati/partials/form.blade.php
+++ b/resources/views/valabilitati/partials/form.blade.php
@@ -4,6 +4,7 @@
     $submitLabel = $submitLabel ?? 'Salvează';
     $formAction = $action ?? '';
     $soferi = $soferi ?? [];
+    $divizii = $divizii ?? [];
 @endphp
 
 <form action="{{ $formAction }}" method="POST" class="needs-validation" novalidate>
@@ -14,17 +15,26 @@
 
     <div class="row g-3 mb-3">
         <div class="col-md-6">
-            <label for="valabilitate-denumire" class="form-label">Denumire<span class="text-danger">*</span></label>
-            <input
-                type="text"
-                name="denumire"
-                id="valabilitate-denumire"
-                class="form-control bg-white rounded-3 @error('denumire') is-invalid @enderror"
-                value="{{ old('denumire', optional($valabilitate)->denumire) }}"
-                autocomplete="off"
+            <label for="valabilitate-divizie" class="form-label">Divizie<span class="text-danger">*</span></label>
+            <select
+                name="divizie_id"
+                id="valabilitate-divizie"
+                class="form-select bg-white rounded-3 @error('divizie_id') is-invalid @enderror"
                 required
             >
-            @error('denumire')
+                <option value="">Selectează divizie</option>
+                @foreach ($divizii as $divizieId => $divizieNume)
+                    <option value="{{ $divizieId }}" @selected((int) old('divizie_id', optional($valabilitate)->divizie_id) === (int) $divizieId)>
+                        {{ $divizieNume }}
+                    </option>
+                @endforeach
+                @if ($valabilitate && $valabilitate->divizie && ! array_key_exists($valabilitate->divizie_id, $divizii))
+                    <option value="{{ $valabilitate->divizie_id }}" selected>
+                        {{ $valabilitate->divizie->nume }}
+                    </option>
+                @endif
+            </select>
+            @error('divizie_id')
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>

--- a/resources/views/valabilitati/partials/rows.blade.php
+++ b/resources/views/valabilitati/partials/rows.blade.php
@@ -11,7 +11,7 @@
         $statusClass = $isActive ? 'bg-success' : 'bg-secondary';
     @endphp
     <tr>
-        <td class="fw-semibold">{{ $valabilitate->denumire }}</td>
+        <td class="fw-semibold">{{ $valabilitate->divizie->nume ?? '—' }}</td>
         <td class="text-nowrap">{{ $valabilitate->numar_auto }}</td>
         <td>{{ $valabilitate->sofer->name ?? '—' }}</td>
         <td class="text-nowrap">{{ optional($dataInceput)->format('d.m.Y') ?? '—' }}</td>
@@ -46,7 +46,7 @@
                         class="flex"
                         data-valabilitate-delete
                         data-delete-url="{{ route('valabilitati.destroy', $valabilitate) }}"
-                        data-delete-denumire="{{ $valabilitate->denumire }}"
+                        data-delete-divizie="{{ $valabilitate->divizie->nume ?? '' }}"
                         data-delete-numar-auto="{{ $valabilitate->numar_auto }}"
                         title="Șterge valabilitatea"
                     >

--- a/resources/views/valabilitati/show.blade.php
+++ b/resources/views/valabilitati/show.blade.php
@@ -24,7 +24,7 @@
                     class="btn btn-sm btn-danger text-white border border-dark rounded-3"
                     data-valabilitate-delete
                     data-delete-url="{{ route('valabilitati.destroy', $valabilitate) }}"
-                    data-delete-denumire="{{ $valabilitate->denumire }}"
+                    data-delete-divizie="{{ $valabilitate->divizie->nume ?? '' }}"
                     data-delete-numar-auto="{{ $valabilitate->numar_auto }}"
                 >
                     <i class="fa-solid fa-trash-can text-white me-1"></i>Șterge
@@ -46,7 +46,7 @@
             <div class="col-md-6">
                 <div class="border rounded-3 p-3 h-100">
                     <h6 class="text-muted text-uppercase mb-2">Informații generale</h6>
-                    <p class="mb-1"><strong>Denumire:</strong> {{ $valabilitate->denumire }}</p>
+                    <p class="mb-1"><strong>Divizie:</strong> {{ $valabilitate->divizie->nume ?? '—' }}</p>
                     <p class="mb-1"><strong>Număr auto:</strong> {{ $valabilitate->numar_auto }}</p>
                     <p class="mb-0"><strong>Șofer:</strong> {{ $valabilitate->sofer->name ?? '—' }}</p>
                 </div>

--- a/tests/Feature/Valabilitati/ValabilitateFilterTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateFilterTest.php
@@ -6,6 +6,7 @@ use App\Models\Permission;
 use App\Models\Role;
 use App\Models\User;
 use App\Models\Valabilitate;
+use App\Models\ValabilitatiDivizie;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -17,20 +18,24 @@ class ValabilitateFilterTest extends TestCase
     {
         $user = $this->createValabilitatiUser();
 
+        $matchingDivizie = ValabilitatiDivizie::factory()->create(['nume' => 'Divizie potrivită']);
+        $beforeDivizie = ValabilitatiDivizie::factory()->create(['nume' => 'Înainte de interval']);
+        $afterDivizie = ValabilitatiDivizie::factory()->create(['nume' => 'După interval']);
+
         $matching = Valabilitate::factory()->create([
-            'denumire' => 'Valabilitate potrivită',
+            'divizie_id' => $matchingDivizie->id,
             'data_inceput' => '2025-01-15',
             'data_sfarsit' => '2025-02-12',
         ]);
 
         Valabilitate::factory()->create([
-            'denumire' => 'Înainte de interval',
+            'divizie_id' => $beforeDivizie->id,
             'data_inceput' => '2025-01-05',
             'data_sfarsit' => '2025-02-12',
         ]);
 
         Valabilitate::factory()->create([
-            'denumire' => 'După interval',
+            'divizie_id' => $afterDivizie->id,
             'data_inceput' => '2025-01-18',
             'data_sfarsit' => '2025-02-25',
         ]);
@@ -43,23 +48,26 @@ class ValabilitateFilterTest extends TestCase
         ]));
 
         $response->assertOk();
-        $response->assertSeeText($matching->denumire);
-        $response->assertDontSeeText('Înainte de interval');
-        $response->assertDontSeeText('După interval');
+        $response->assertSeeText($matchingDivizie->nume);
+        $response->assertDontSeeText($beforeDivizie->nume);
+        $response->assertDontSeeText($afterDivizie->nume);
     }
 
     public function test_legacy_interval_parameters_are_supported(): void
     {
         $user = $this->createValabilitatiUser();
 
+        $insideDivizie = ValabilitatiDivizie::factory()->create(['nume' => 'Compatibil Legacy']);
+        $outsideDivizie = ValabilitatiDivizie::factory()->create(['nume' => 'În afara Legacy']);
+
         $inside = Valabilitate::factory()->create([
-            'denumire' => 'Compatibil Legacy',
+            'divizie_id' => $insideDivizie->id,
             'data_inceput' => '2025-03-10',
             'data_sfarsit' => '2025-03-20',
         ]);
 
         Valabilitate::factory()->create([
-            'denumire' => 'În afara Legacy',
+            'divizie_id' => $outsideDivizie->id,
             'data_inceput' => '2025-03-25',
             'data_sfarsit' => '2025-03-28',
         ]);
@@ -70,8 +78,8 @@ class ValabilitateFilterTest extends TestCase
         ]));
 
         $response->assertOk();
-        $response->assertSeeText($inside->denumire);
-        $response->assertDontSeeText('În afara Legacy');
+        $response->assertSeeText($insideDivizie->nume);
+        $response->assertDontSeeText($outsideDivizie->nume);
     }
 
     private function createValabilitatiUser(): User

--- a/tests/Feature/Valabilitati/ValabilitateRoadTaxesFrontendTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateRoadTaxesFrontendTest.php
@@ -7,6 +7,7 @@ use App\Models\Role;
 use App\Models\User;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateTaxaDrum;
+use App\Models\ValabilitatiDivizie;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -18,8 +19,9 @@ class ValabilitateRoadTaxesFrontendTest extends TestCase
     {
         $user = $this->createValabilitatiUser();
 
+        $divizie = ValabilitatiDivizie::factory()->create(['nume' => 'Valabilitate modal']);
         $valabilitate = Valabilitate::factory()->create([
-            'denumire' => 'Valabilitate modal',
+            'divizie_id' => $divizie->id,
         ]);
 
         ValabilitateTaxaDrum::factory()->create([
@@ -66,8 +68,9 @@ class ValabilitateRoadTaxesFrontendTest extends TestCase
     {
         $user = $this->createValabilitatiUser();
 
+        $divizie = ValabilitatiDivizie::factory()->create(['nume' => 'Valabilitate vizualizare']);
         $valabilitate = Valabilitate::factory()->create([
-            'denumire' => 'Valabilitate vizualizare',
+            'divizie_id' => $divizie->id,
         ]);
 
         ValabilitateTaxaDrum::factory()->create([

--- a/tests/Feature/Valabilitati/ValabilitateRoadTaxesTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateRoadTaxesTest.php
@@ -7,6 +7,7 @@ use App\Models\Role;
 use App\Models\User;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateTaxaDrum;
+use App\Models\ValabilitatiDivizie;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -18,11 +19,12 @@ class ValabilitateRoadTaxesTest extends TestCase
     {
         $user = $this->createValabilitatiUser();
         $driver = User::factory()->create();
+        $divizie = ValabilitatiDivizie::factory()->create(['nume' => 'Divizie Taxe']);
 
         $payload = [
             'numar_auto' => 'B-99-XYZ',
             'sofer_id' => $driver->id,
-            'denumire' => 'Valabilitate cu taxe',
+            'divizie_id' => $divizie->id,
             'data_inceput' => '2025-03-01',
             'data_sfarsit' => '2025-03-31',
             'taxe_drum' => [
@@ -91,7 +93,7 @@ class ValabilitateRoadTaxesTest extends TestCase
         $payload = [
             'numar_auto' => $valabilitate->numar_auto,
             'sofer_id' => $valabilitate->sofer_id,
-            'denumire' => 'Actualizare taxe',
+            'divizie_id' => $valabilitate->divizie_id,
             'data_inceput' => $valabilitate->data_inceput?->format('Y-m-d') ?? '2025-03-01',
             'data_sfarsit' => $valabilitate->data_sfarsit?->format('Y-m-d'),
             'taxe_drum' => [
@@ -138,7 +140,7 @@ class ValabilitateRoadTaxesTest extends TestCase
         $payload = [
             'numar_auto' => $valabilitate->numar_auto,
             'sofer_id' => $valabilitate->sofer_id,
-            'denumire' => $valabilitate->denumire,
+            'divizie_id' => $valabilitate->divizie_id,
             'data_inceput' => $valabilitate->data_inceput?->format('Y-m-d') ?? '2025-03-01',
             'data_sfarsit' => $valabilitate->data_sfarsit?->format('Y-m-d'),
             'taxe_drum' => [],


### PR DESCRIPTION
## Summary
- add the new `valabilitati_divizii` table and migrate existing `valabilitati` rows to reference it through a foreign key
- update the Valabilitate models, controllers, factories, tests, and Blade templates to use the new `divizie` relationship everywhere
- refresh the `/valabilitati` and driver-facing views so division names are loaded from the related table and selectable when editing or creating entries

## Testing
- ❌ `php artisan test --filter=Valabilitati` *(fails immediately because `vendor/autoload.php` is missing; `composer install` requires a GitHub token and aborts with HTTP 403 during package download)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c46a5f9688326aeab2d2d82c53ffc)