### PR TITLE
Drop foreign key before altering divizie_id column

### DIFF
--- a/database/migrations/2025_05_10_000000_create_valabilitati_divizii_table_and_update_valabilitati_table.php
+++ b/database/migrations/2025_05_10_000000_create_valabilitati_divizii_table_and_update_valabilitati_table.php
@@ -76,7 +76,15 @@ return new class extends Migration {
         });
 
         if (DB::getDriverName() !== 'sqlite') {
+            Schema::table('valabilitati', function (Blueprint $table): void {
+                $table->dropForeign('valabilitati_divizie_id_foreign');
+            });
+
             DB::statement('ALTER TABLE valabilitati MODIFY divizie_id BIGINT UNSIGNED NOT NULL');
+
+            Schema::table('valabilitati', function (Blueprint $table): void {
+                $table->foreign('divizie_id')->references('id')->on('valabilitati_divizii');
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- drop the `valabilitati_divizie_id_foreign` constraint before altering `divizie_id`
- reapply the foreign key after enforcing the non-null, unsigned bigint definition so MySQL accepts the migration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4ef907948326aa90f8b5bf707a40)