### PR TITLE
Show all driver valabilitati and adjust header

### DIFF
--- a/app/Http/Controllers/SoferDashboardController.php
+++ b/app/Http/Controllers/SoferDashboardController.php
@@ -13,10 +13,10 @@ class SoferDashboardController extends Controller
         $today = Carbon::today();
         $driver = $request->user();
 
-        $activeValabilitate = null;
+        $activeValabilitati = collect();
 
         if ($driver) {
-            $activeValabilitate = Valabilitate::query()
+            $activeValabilitati = Valabilitate::query()
                 ->select(['id', 'numar_auto', 'divizie_id', 'data_inceput', 'data_sfarsit'])
                 ->where('sofer_id', $driver->id)
                 ->whereDate('data_inceput', '<=', $today)
@@ -28,11 +28,11 @@ class SoferDashboardController extends Controller
                 ->with('divizie:id,nume')
                 ->withCount('curse')
                 ->orderByDesc('data_inceput')
-                ->first();
+                ->get();
         }
 
         return view('sofer.dashboard', [
-            'activeValabilitate' => $activeValabilitate,
+            'activeValabilitati' => $activeValabilitati,
         ]);
     }
 }

--- a/resources/views/sofer/dashboard.blade.php
+++ b/resources/views/sofer/dashboard.blade.php
@@ -10,15 +10,15 @@
         {{-- <p class="text-muted small mb-0">Consultați rapid documentele și termenele limită asociate flotei.</p> --}}
     </div>
 
-    @if ($activeValabilitate)
+    @forelse ($activeValabilitati as $valabilitate)
         <article class="card border-0 shadow-sm mb-4">
             <div class="card-body p-4 p-lg-5 text-center">
                 <div class="gap-2 mb-3">
                     <b class="h4 text-primary fw-bold">
-                        {{ $activeValabilitate->numar_auto ?? 'Fără număr' }}
+                        {{ $valabilitate->numar_auto ?? 'Fără număr' }}
                     </b>
                     <p class="text-muted mb-0">
-                        {{ $activeValabilitate->divizie->nume ?? 'Fără divizie' }}
+                        {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
                     </p>
                 </div>
 
@@ -26,19 +26,19 @@
                     <div class="col-12">
                         <p class="text-uppercase mb-1">Perioadă valabilitate</p>
                         <p class="h6 mb-0">
-                            {{ optional($activeValabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
+                            {{ optional($valabilitate->data_inceput)->format('d.m.Y') ?? '—' }}
                             <span class="text-muted">–</span>
-                            {{ optional($activeValabilitate->data_sfarsit)->format('d.m.Y') ?? 'Prezent' }}
+                            {{ optional($valabilitate->data_sfarsit)->format('d.m.Y') ?? 'Prezent' }}
                         </p>
                     </div>
                     <div class="col-12">
                         <p class="text-uppercase mb-1">Curse înregistrate:
                             <b>
-                                {{ $activeValabilitate->curse_count }}
+                                {{ $valabilitate->curse_count }}
                             </b>
                         </p>
                         <a
-                            href="{{ route('sofer.valabilitati.show', $activeValabilitate) }}"
+                            href="{{ route('sofer.valabilitati.show', $valabilitate) }}"
                             class="btn btn-primary px-4"
                         >
                             Gestionează cursele
@@ -47,7 +47,7 @@
                 </div>
             </div>
         </article>
-    @else
+    @empty
         <div class="card border-0 shadow-sm mb-4">
             <div class="card-body text-center py-5">
                 <i class="fa-solid fa-circle-check fa-3x text-success mb-3"></i>
@@ -55,7 +55,7 @@
                 <p class="text-muted small mb-0">Veți fi notificat de echipă atunci când apar documente noi.</p>
             </div>
         </div>
-    @endif
+    @endforelse
 
 </div>
 @endsection

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -19,8 +19,11 @@
 
             {{-- Title + label in the middle --}}
             <div class="flex-grow-1 mx-1 text-center">
-                <h1 class="sofer-header__title fw-bold mb-0 text-truncate">
-                    {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
+                <h1
+                    class="sofer-header__title fw-bold mb-0 text-truncate d-inline-flex align-items-center justify-content-center gap-2"
+                >
+                    <i class="fa-solid fa-car-side"></i>
+                    <span>{{ $valabilitate->numar_auto ?? 'Fără număr' }}</span>
                 </h1>
             </div>
 
@@ -34,17 +37,7 @@
             </a>
         </div>
 
-        {{-- Meta line: dates + număr auto --}}
-        <div class="sofer-header__meta small text-muted mt-2 text-center gap-2">
-            <span class="me-2">
-                <i class="fa-solid fa-building me-1"></i>
-                {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
-            </span>
-            <span class="">
-                <i class="fa-solid fa-car-side me-1"></i>
-                {{ $valabilitate->numar_auto ?? 'Fără număr' }}
-            </span>
-        </div>
+        {{-- Meta line removed as requested --}}
     </div>
 
     @if (session('status'))


### PR DESCRIPTION
## Summary
- update the driver dashboard controller/view to load every active valabilitate instead of only the latest record so the table now lists the complete set
- simplify the valabilitate header by centering the car identifier between the navigation buttons and removing the duplicated division labels

## Testing
- Not run (Composer install requires GitHub token in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dca3b3c088326a418eec91618a5ac)