### PR TITLE
Add divizie tariff modal on valabilitati

### DIFF
--- a/app/Http/Controllers/ValabilitatiDivizieController.php
+++ b/app/Http/Controllers/ValabilitatiDivizieController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ValabilitatiDivizie;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ValabilitatiDivizieController extends Controller
+{
+    public function show(ValabilitatiDivizie $divizie): JsonResponse
+    {
+        return response()->json([
+            'divizie' => $this->transformDivizie($divizie),
+        ]);
+    }
+
+    public function update(Request $request, ValabilitatiDivizie $divizie): JsonResponse
+    {
+        $validated = $this->validatePrices($request);
+
+        $divizie->update($validated);
+
+        return response()->json([
+            'message' => 'Tarifele diviziei au fost actualizate.',
+            'divizie' => $this->transformDivizie($divizie->fresh()),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validatePrices(Request $request): array
+    {
+        $validated = $request->validate([
+            'pret_km_gol' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'pret_km_plin' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'pret_km_cu_taxa' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+        ]);
+
+        return $this->formatPrices($validated);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private function formatPrices(array $values): array
+    {
+        foreach (['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa'] as $field) {
+            if (! array_key_exists($field, $values)) {
+                continue;
+            }
+
+            $values[$field] = $this->formatPrice($values[$field]);
+        }
+
+        return $values;
+    }
+
+    private function formatPrice(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return number_format((float) $value, 3, '.', '');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function transformDivizie(ValabilitatiDivizie $divizie): array
+    {
+        return [
+            'id' => $divizie->id,
+            'nume' => $divizie->nume,
+            'pret_km_gol' => $this->formatPrice($divizie->pret_km_gol),
+            'pret_km_plin' => $this->formatPrice($divizie->pret_km_plin),
+            'pret_km_cu_taxa' => $this->formatPrice($divizie->pret_km_cu_taxa),
+        ];
+    }
+}

--- a/app/Models/ValabilitatiDivizie.php
+++ b/app/Models/ValabilitatiDivizie.php
@@ -14,6 +14,15 @@ class ValabilitatiDivizie extends Model
 
     protected $fillable = [
         'nume',
+        'pret_km_gol',
+        'pret_km_plin',
+        'pret_km_cu_taxa',
+    ];
+
+    protected $casts = [
+        'pret_km_gol' => 'decimal:3',
+        'pret_km_plin' => 'decimal:3',
+        'pret_km_cu_taxa' => 'decimal:3',
     ];
 
     public function valabilitati(): HasMany

--- a/database/factories/ValabilitatiDivizieFactory.php
+++ b/database/factories/ValabilitatiDivizieFactory.php
@@ -16,6 +16,9 @@ class ValabilitatiDivizieFactory extends Factory
     {
         return [
             'nume' => fake()->unique()->company(),
+            'pret_km_gol' => fake()->randomFloat(3, 0, 10),
+            'pret_km_plin' => fake()->randomFloat(3, 0, 15),
+            'pret_km_cu_taxa' => fake()->randomFloat(3, 0, 20),
         ];
     }
 }

--- a/database/migrations/2025_05_15_000000_add_price_fields_to_valabilitati_divizii_table.php
+++ b/database/migrations/2025_05_15_000000_add_price_fields_to_valabilitati_divizii_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_divizii', function (Blueprint $table): void {
+            $table->decimal('pret_km_gol', 12, 3)->nullable()->after('nume');
+            $table->decimal('pret_km_plin', 12, 3)->nullable()->after('pret_km_gol');
+            $table->decimal('pret_km_cu_taxa', 12, 3)->nullable()->after('pret_km_plin');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_divizii', function (Blueprint $table): void {
+            $table->dropColumn([
+                'pret_km_gol',
+                'pret_km_plin',
+                'pret_km_cu_taxa',
+            ]);
+        });
+    }
+};

--- a/resources/views/valabilitati/partials/divizie-prices-modal.blade.php
+++ b/resources/views/valabilitati/partials/divizie-prices-modal.blade.php
@@ -1,0 +1,96 @@
+<div
+    class="modal fade"
+    id="valabilitati-divizie-modal"
+    tabindex="-1"
+    aria-labelledby="valabilitati-divizie-modal-label"
+    aria-hidden="true"
+>
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="valabilitati-divizie-modal-label">
+                    Tarife divizie
+                    <span class="text-primary" data-divizie-name></span>
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Închide"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-danger d-none" role="alert" data-modal-alert></div>
+
+                <div class="d-flex flex-column align-items-center py-4 gap-2 d-none" data-modal-loading>
+                    <div class="spinner-border" role="status" aria-hidden="true"></div>
+                    <p class="text-muted mb-0">Se încarcă informațiile diviziei...</p>
+                </div>
+
+                <div class="d-none" data-modal-form-wrapper>
+                    <p class="text-muted">
+                        Introdu tarifele pe kilometru cu trei zecimale. Lasă câmpul gol dacă nu se aplică.
+                    </p>
+                    <form id="valabilitati-divizie-form" data-divizie-form novalidate>
+                        @csrf
+                        <div class="mb-3">
+                            <label for="divizie-pret-km-gol" class="form-label">Preț km gol</label>
+                            <div class="input-group">
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="divizie-pret-km-gol"
+                                    name="pret_km_gol"
+                                    step="0.001"
+                                    min="0"
+                                    data-format-decimal
+                                >
+                                <span class="input-group-text">/ km</span>
+                                <div class="invalid-feedback" data-error-for="pret_km_gol"></div>
+                            </div>
+                            <div class="form-text">Valoare cu până la trei zecimale.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="divizie-pret-km-plin" class="form-label">Preț km plin</label>
+                            <div class="input-group">
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="divizie-pret-km-plin"
+                                    name="pret_km_plin"
+                                    step="0.001"
+                                    min="0"
+                                    data-format-decimal
+                                >
+                                <span class="input-group-text">/ km</span>
+                                <div class="invalid-feedback" data-error-for="pret_km_plin"></div>
+                            </div>
+                            <div class="form-text">Valoare cu până la trei zecimale.</div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label for="divizie-pret-km-taxa" class="form-label">Preț km cu taxă</label>
+                            <div class="input-group">
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="divizie-pret-km-taxa"
+                                    name="pret_km_cu_taxa"
+                                    step="0.001"
+                                    min="0"
+                                    data-format-decimal
+                                >
+                                <span class="input-group-text">/ km</span>
+                                <div class="invalid-feedback" data-error-for="pret_km_cu_taxa"></div>
+                            </div>
+                            <div class="form-text">Valoare cu până la trei zecimale.</div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Închide</button>
+                <button type="submit" class="btn btn-primary" form="valabilitati-divizie-form" data-modal-submit>
+                    <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true" data-modal-submit-spinner></span>
+                    <span data-modal-submit-label>Salvează</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/valabilitati/partials/rows.blade.php
+++ b/resources/views/valabilitati/partials/rows.blade.php
@@ -11,7 +11,22 @@
         $statusClass = $isActive ? 'bg-success' : 'bg-secondary';
     @endphp
     <tr>
-        <td class="fw-semibold">{{ $valabilitate->divizie->nume ?? '—' }}</td>
+        <td class="fw-semibold">
+            @if ($valabilitate->divizie)
+                <button
+                    type="button"
+                    class="btn btn-link p-0 align-baseline text-decoration-none fw-semibold"
+                    data-divizie-prices-trigger
+                    data-divizie-name="{{ $valabilitate->divizie->nume }}"
+                    data-fetch-url="{{ route('valabilitati.divizii.show', $valabilitate->divizie) }}"
+                    data-update-url="{{ route('valabilitati.divizii.update', $valabilitate->divizie) }}"
+                >
+                    {{ $valabilitate->divizie->nume }}
+                </button>
+            @else
+                —
+            @endif
+        </td>
         <td class="text-nowrap">{{ $valabilitate->numar_auto }}</td>
         <td>{{ $valabilitate->sofer->name ?? '—' }}</td>
         <td class="text-nowrap">{{ optional($dataInceput)->format('d.m.Y') ?? '—' }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,7 @@ use App\Http\Controllers\SoferValabilitateCursaController;
 use App\Http\Controllers\ValabilitateController;
 use App\Http\Controllers\ValabilitateCursaController;
 use App\Http\Controllers\ValabilitateCursaGrupController;
+use App\Http\Controllers\ValabilitatiDivizieController;
 
 
 /*
@@ -351,6 +352,11 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware(['permission:valabilitati', 'role:super-admin,admin,dispecer'])->group(function () {
         Route::get('valabilitati/paginate', [ValabilitateController::class, 'paginate'])
             ->name('valabilitati.paginate');
+
+        Route::get('valabilitati/divizii/{divizie}', [ValabilitatiDivizieController::class, 'show'])
+            ->name('valabilitati.divizii.show');
+        Route::put('valabilitati/divizii/{divizie}', [ValabilitatiDivizieController::class, 'update'])
+            ->name('valabilitati.divizii.update');
 
         Route::get('valabilitati/create', [ValabilitateController::class, 'create'])
             ->name('valabilitati.create');

--- a/tests/Feature/Valabilitati/ValabilitatiDiviziePriceTest.php
+++ b/tests/Feature/Valabilitati/ValabilitatiDiviziePriceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Valabilitati;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\User;
+use App\Models\ValabilitatiDivizie;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ValabilitatiDiviziePriceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_fetch_divizie_prices(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $divizie = ValabilitatiDivizie::factory()->create([
+            'nume' => 'Divizie Test',
+            'pret_km_gol' => 1.234,
+            'pret_km_plin' => 2.345,
+            'pret_km_cu_taxa' => 3.456,
+        ]);
+
+        $response = $this->actingAs($user)->getJson(route('valabilitati.divizii.show', $divizie));
+
+        $response->assertOk();
+        $response->assertJsonPath('divizie.id', $divizie->id);
+        $response->assertJsonPath('divizie.nume', 'Divizie Test');
+        $response->assertJsonPath('divizie.pret_km_gol', '1.234');
+        $response->assertJsonPath('divizie.pret_km_plin', '2.345');
+        $response->assertJsonPath('divizie.pret_km_cu_taxa', '3.456');
+    }
+
+    public function test_user_can_update_divizie_prices(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $divizie = ValabilitatiDivizie::factory()->create([
+            'pret_km_gol' => null,
+            'pret_km_plin' => null,
+            'pret_km_cu_taxa' => null,
+        ]);
+
+        $payload = [
+            'pret_km_gol' => '10.123',
+            'pret_km_plin' => '20.456',
+            'pret_km_cu_taxa' => '30.789',
+        ];
+
+        $response = $this->actingAs($user)->putJson(route('valabilitati.divizii.update', $divizie), $payload);
+
+        $response->assertOk();
+        $response->assertJsonPath('divizie.pret_km_gol', '10.123');
+        $response->assertJsonPath('divizie.pret_km_plin', '20.456');
+        $response->assertJsonPath('divizie.pret_km_cu_taxa', '30.789');
+
+        $this->assertDatabaseHas('valabilitati_divizii', [
+            'id' => $divizie->id,
+            'pret_km_gol' => 10.123,
+            'pret_km_plin' => 20.456,
+            'pret_km_cu_taxa' => 30.789,
+        ]);
+    }
+
+    public function test_update_requires_numeric_values(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $divizie = ValabilitatiDivizie::factory()->create();
+
+        $response = $this->actingAs($user)->putJson(route('valabilitati.divizii.update', $divizie), [
+            'pret_km_gol' => 'invalid',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['pret_km_gol']);
+    }
+
+    private function createValabilitatiUser(): User
+    {
+        $user = User::factory()->create();
+
+        $permission = Permission::create([
+            'name' => 'Valabilități',
+            'slug' => 'access-valabilitati',
+            'module' => 'valabilitati',
+        ]);
+
+        $role = Role::create([
+            'name' => 'Administrator',
+            'slug' => 'admin',
+        ]);
+
+        $role->permissions()->syncWithoutDetaching([$permission->id]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated controller, routes, and schema support for storing per-divizie price fields with three-decimal precision
- extend the /valabilitati UI with a Bootstrap modal that lets users load and update divizie tariffs through AJAX, formatting the values to three decimals
- cover the new API with feature tests to verify fetching, updating, and validation of the new price fields

## Testing
- ⚠️ `php artisan test --filter=ValabilitatiDiviziePriceTest` *(fails because `composer install` cannot download dependencies in this environment: GitHub responds with CONNECT tunnel 403 errors)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dcd3b1618832682b1dc5d2b6753dd)