### PR TITLE
Add Flash-specific kilometer tracking fields

### DIFF
--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -36,6 +36,11 @@ class ValabilitateCursaRequest extends FormRequest
             'km_bord_incarcare' => ['nullable', 'integer', 'min:0'],
             'km_bord_descarcare' => ['nullable', 'integer', 'min:0'],
             'km_maps' => ['nullable', 'string', 'max:255'],
+            'km_maps_gol' => ['nullable', 'numeric', 'min:0'],
+            'km_maps_plin' => ['nullable', 'numeric', 'min:0'],
+            'km_cu_taxa' => ['nullable', 'numeric', 'min:0'],
+            'km_flash_gol' => ['nullable', 'numeric', 'min:0'],
+            'km_flash_plin' => ['nullable', 'numeric', 'min:0'],
             'cursa_grup_id' => [
                 'nullable',
                 Rule::exists('valabilitati_cursa_grupuri', 'id')->where(function ($query) use ($valabilitate) {

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -29,6 +29,11 @@ class ValabilitateCursa extends Model
         'km_bord_incarcare',
         'km_bord_descarcare',
         'km_maps',
+        'km_maps_gol',
+        'km_maps_plin',
+        'km_cu_taxa',
+        'km_flash_gol',
+        'km_flash_plin',
     ];
 
     protected $casts = [
@@ -37,6 +42,11 @@ class ValabilitateCursa extends Model
         'data_cursa' => 'datetime',
         'km_bord_incarcare' => 'integer',
         'km_bord_descarcare' => 'integer',
+        'km_maps_gol' => 'integer',
+        'km_maps_plin' => 'integer',
+        'km_cu_taxa' => 'integer',
+        'km_flash_gol' => 'integer',
+        'km_flash_plin' => 'integer',
     ];
 
     public function incarcareTara(): BelongsTo

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -30,6 +30,12 @@ class ValabilitateCursaFactory extends Factory
             'observatii' => fake()->optional()->sentence(),
             'km_bord_incarcare' => fake()->numberBetween(0, 500000),
             'km_bord_descarcare' => fake()->numberBetween(0, 500000),
+            'km_maps' => (string) fake()->numberBetween(0, 5000),
+            'km_maps_gol' => fake()->numberBetween(0, 5000),
+            'km_maps_plin' => fake()->numberBetween(0, 5000),
+            'km_cu_taxa' => fake()->numberBetween(0, 5000),
+            'km_flash_gol' => fake()->numberBetween(0, 5000),
+            'km_flash_plin' => fake()->numberBetween(0, 5000),
         ];
     }
 }

--- a/database/migrations/2025_03_24_081000_add_flash_km_fields_to_valabilitati_curse_table.php
+++ b/database/migrations/2025_03_24_081000_add_flash_km_fields_to_valabilitati_curse_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->unsignedInteger('km_maps_gol')->nullable()->after('km_maps');
+            $table->unsignedInteger('km_maps_plin')->nullable()->after('km_maps_gol');
+            $table->unsignedInteger('km_cu_taxa')->nullable()->after('km_maps_plin');
+            $table->unsignedInteger('km_flash_gol')->nullable()->after('km_cu_taxa');
+            $table->unsignedInteger('km_flash_plin')->nullable()->after('km_flash_gol');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_curse', function (Blueprint $table): void {
+            $table->dropColumn([
+                'km_maps_gol',
+                'km_maps_plin',
+                'km_cu_taxa',
+                'km_flash_gol',
+                'km_flash_plin',
+            ]);
+        });
+    }
+};

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -96,6 +96,7 @@
         $curseRoute = route('valabilitati.curse.index', $valabilitate);
         $isGroupsContext = request()->routeIs('valabilitati.grupuri.*');
         $hasGrupuri = $valabilitate->cursaGrupuri->count() > 0;
+        $isFlashDivision = optional($valabilitate->divizie)->id === 1;
     @endphp
     <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
         <div class="row card-header align-items-center text-center text-lg-start" style="border-radius: 40px 40px 0px 0px;">
@@ -200,21 +201,37 @@
                                 <th rowspan="2" class="curse-nowrap">Nr. cursă</th>
                                 <th rowspan="2">Cursa</th>
                                 <th rowspan="2" class="curse-nowrap">Dată transport</th>
-                                <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
-                                <th colspan="2" class="text-center curse-nowrap">
-                                    KM Bord (plecare / sosire)
-                                </th>
-                                <th colspan="2" class="text-center curse-nowrap">KM Bord 2</th>
-                                <th rowspan="2" class="text-end curse-nowrap">
-                                    Diferența KM<br>(Bord – Maps)
-                                </th>
+                                @if ($isFlashDivision)
+                                    <th colspan="2" class="text-center curse-nowrap">KM Maps</th>
+                                    <th rowspan="2" class="text-end curse-nowrap">KM cu taxă</th>
+                                    <th colspan="2" class="text-center curse-nowrap">KM Flash</th>
+                                    <th colspan="2" class="text-center curse-nowrap">Diferența KM<br>(Maps – Flash)</th>
+                                @else
+                                    <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
+                                    <th colspan="2" class="text-center curse-nowrap">
+                                        KM Bord (plecare / sosire)
+                                    </th>
+                                    <th colspan="2" class="text-center curse-nowrap">KM Bord 2</th>
+                                    <th rowspan="2" class="text-end curse-nowrap">
+                                        Diferența KM<br>(Bord – Maps)
+                                    </th>
+                                @endif
                                 <th rowspan="2" class="text-end curse-nowrap">Acțiuni</th>
                             </tr>
                             <tr class="curse-data-header-bottom">
-                                <th class="text-end curse-nowrap">Plecare</th>
-                                <th class="text-end curse-nowrap">Sosire</th>
-                                <th class="text-end curse-nowrap">Km gol</th>
-                                <th class="text-end curse-nowrap">Km plin</th>
+                                @if ($isFlashDivision)
+                                    <th class="text-end curse-nowrap">Km gol</th>
+                                    <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap">Km gol</th>
+                                    <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap">Km gol</th>
+                                    <th class="text-end curse-nowrap">Km plin</th>
+                                @else
+                                    <th class="text-end curse-nowrap">Plecare</th>
+                                    <th class="text-end curse-nowrap">Sosire</th>
+                                    <th class="text-end curse-nowrap">Km gol</th>
+                                    <th class="text-end curse-nowrap">Km plin</th>
+                                @endif
                             </tr>
                         </thead>
 
@@ -223,7 +240,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="12" class="text-center py-4">
+                                    <td colspan="{{ $isFlashDivision ? 13 : 12 }}" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -8,6 +8,7 @@
     $renderCurseModals = ($renderCurseModals ?? true) === true;
     $renderGroupModals = ($renderGroupModals ?? true) === true;
     $redirectTo = $redirectTo ?? '';
+    $isFlashDivision = optional($valabilitate->divizie)->id === 1;
     $normalizeColorHex = static function ($value): string {
         if (! is_string($value) || $value === '') {
             return '';
@@ -179,6 +180,11 @@
                             $createKmBordIncarcare = $isCreateActive ? old('km_bord_incarcare', '') : '';
                             $createKmBordDescarcare = $isCreateActive ? old('km_bord_descarcare', '') : '';
                             $createKmMaps = $isCreateActive ? old('km_maps', '') : '';
+                            $createKmMapsGol = $isCreateActive ? old('km_maps_gol', '') : '';
+                            $createKmMapsPlin = $isCreateActive ? old('km_maps_plin', '') : '';
+                            $createKmCuTaxa = $isCreateActive ? old('km_cu_taxa', '') : '';
+                            $createKmFlashGol = $isCreateActive ? old('km_flash_gol', '') : '';
+                            $createKmFlashPlin = $isCreateActive ? old('km_flash_plin', '') : '';
                             $createDataDateValue = $isCreateActive ? old('data_cursa_date', '') : '';
                             $createDataTimeValue = $isCreateActive ? old('data_cursa_time', '') : '';
                             if ($isCreateActive) {
@@ -404,6 +410,98 @@
                                     {{ $isCreateActive ? $errors->first('km_maps') : '' }}
                                 </div>
                             </div>
+                            @if ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-maps-gol" class="form-label">Km Maps gol</label>
+                                    <input
+                                        type="number"
+                                        name="km_maps_gol"
+                                        id="cursa-create-km-maps-gol"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps_gol') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmMapsGol }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps_gol') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps_gol"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_maps_gol') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-maps-plin" class="form-label">Km Maps plin</label>
+                                    <input
+                                        type="number"
+                                        name="km_maps_plin"
+                                        id="cursa-create-km-maps-plin"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps_plin') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmMapsPlin }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps_plin') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps_plin"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_maps_plin') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-cu-taxa" class="form-label">Km cu taxă</label>
+                                    <input
+                                        type="number"
+                                        name="km_cu_taxa"
+                                        id="cursa-create-km-cu-taxa"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_cu_taxa') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmCuTaxa }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_cu_taxa') ? 'd-block' : '' }}"
+                                        data-error-for="km_cu_taxa"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_cu_taxa') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-flash-gol" class="form-label">Km Flash gol</label>
+                                    <input
+                                        type="number"
+                                        name="km_flash_gol"
+                                        id="cursa-create-km-flash-gol"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_flash_gol') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmFlashGol }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_flash_gol') ? 'd-block' : '' }}"
+                                        data-error-for="km_flash_gol"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_flash_gol') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-flash-plin" class="form-label">Km Flash plin</label>
+                                    <input
+                                        type="number"
+                                        name="km_flash_plin"
+                                        id="cursa-create-km-flash-plin"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_flash_plin') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmFlashPlin }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_flash_plin') ? 'd-block' : '' }}"
+                                        data-error-for="km_flash_plin"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_flash_plin') : '' }}
+                                    </div>
+                                </div>
+                            @endif
                             <div class="col-12">
                                 <label for="cursa-create-grup" class="form-label">Grup cursă</label>
                                 <select
@@ -497,6 +595,26 @@
         $editKmMaps = $isEditing ? old('km_maps', $cursa->km_maps) : $cursa->km_maps;
         if ($editKmMaps === null) {
             $editKmMaps = '';
+        }
+        $editKmMapsGol = $isEditing ? old('km_maps_gol', $cursa->km_maps_gol) : $cursa->km_maps_gol;
+        if ($editKmMapsGol === null) {
+            $editKmMapsGol = '';
+        }
+        $editKmMapsPlin = $isEditing ? old('km_maps_plin', $cursa->km_maps_plin) : $cursa->km_maps_plin;
+        if ($editKmMapsPlin === null) {
+            $editKmMapsPlin = '';
+        }
+        $editKmCuTaxa = $isEditing ? old('km_cu_taxa', $cursa->km_cu_taxa) : $cursa->km_cu_taxa;
+        if ($editKmCuTaxa === null) {
+            $editKmCuTaxa = '';
+        }
+        $editKmFlashGol = $isEditing ? old('km_flash_gol', $cursa->km_flash_gol) : $cursa->km_flash_gol;
+        if ($editKmFlashGol === null) {
+            $editKmFlashGol = '';
+        }
+        $editKmFlashPlin = $isEditing ? old('km_flash_plin', $cursa->km_flash_plin) : $cursa->km_flash_plin;
+        if ($editKmFlashPlin === null) {
+            $editKmFlashPlin = '';
         }
         $editNrCursa = $isEditing ? old('nr_cursa', $cursa->nr_cursa) : $cursa->nr_cursa;
         if ($editNrCursa === null) {
@@ -746,6 +864,98 @@
                                     {{ $isEditing ? $errors->first('km_maps') : '' }}
                                 </div>
                             </div>
+                            @if ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-maps-gol" class="form-label">Km Maps gol</label>
+                                    <input
+                                        type="number"
+                                        name="km_maps_gol"
+                                        id="{{ $editPrefix }}km-maps-gol"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps_gol') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmMapsGol }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps_gol') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps_gol"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_maps_gol') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-maps-plin" class="form-label">Km Maps plin</label>
+                                    <input
+                                        type="number"
+                                        name="km_maps_plin"
+                                        id="{{ $editPrefix }}km-maps-plin"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps_plin') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmMapsPlin }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps_plin') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps_plin"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_maps_plin') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-cu-taxa" class="form-label">Km cu taxă</label>
+                                    <input
+                                        type="number"
+                                        name="km_cu_taxa"
+                                        id="{{ $editPrefix }}km-cu-taxa"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_cu_taxa') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmCuTaxa }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_cu_taxa') ? 'd-block' : '' }}"
+                                        data-error-for="km_cu_taxa"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_cu_taxa') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-flash-gol" class="form-label">Km Flash gol</label>
+                                    <input
+                                        type="number"
+                                        name="km_flash_gol"
+                                        id="{{ $editPrefix }}km-flash-gol"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_flash_gol') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmFlashGol }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_flash_gol') ? 'd-block' : '' }}"
+                                        data-error-for="km_flash_gol"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_flash_gol') : '' }}
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-flash-plin" class="form-label">Km Flash plin</label>
+                                    <input
+                                        type="number"
+                                        name="km_flash_plin"
+                                        id="{{ $editPrefix }}km-flash-plin"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_flash_plin') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmFlashPlin }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_flash_plin') ? 'd-block' : '' }}"
+                                        data-error-for="km_flash_plin"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_flash_plin') : '' }}
+                                    </div>
+                                </div>
+                            @endif
                             <div class="col-12">
                                 <label for="{{ $editPrefix }}grup" class="form-label">Grup cursă</label>
                                 <select

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,4 +1,6 @@
 @php
+    $isFlashDivision = optional($valabilitate->divizie)->id === 1;
+    $tableColumnCount = $isFlashDivision ? 13 : 12;
     $previousKmSosire = null;
     $currentGroupKey = '__none__';
     $resolveRowTextColor = static function ($value): string {
@@ -56,15 +58,33 @@
 
         $kmMapsDisplay = filled($cursa->km_maps) ? $cursa->km_maps : '—';
         $kmMapsValue = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
+        $kmMapsGolValue = is_numeric($cursa->km_maps_gol) ? (float) $cursa->km_maps_gol : null;
+        $kmMapsPlinValue = is_numeric($cursa->km_maps_plin) ? (float) $cursa->km_maps_plin : null;
+        $kmFlashGolValue = is_numeric($cursa->km_flash_gol) ? (float) $cursa->km_flash_gol : null;
+        $kmFlashPlinValue = is_numeric($cursa->km_flash_plin) ? (float) $cursa->km_flash_plin : null;
+        $kmCuTaxaValue = is_numeric($cursa->km_cu_taxa) ? (float) $cursa->km_cu_taxa : null;
 
         // Km plin
         $kmPlin = $kmPlecare !== null && $kmSosire !== null ? $kmSosire - $kmPlecare : null;
         $kmGol = $previousKmSosire !== null && $kmPlecare !== null ? $kmPlecare - $previousKmSosire : null;
         $kmDifference = $kmPlin !== null && $kmMapsValue !== null ? $kmPlin - $kmMapsValue : null;
 
+        $kmMapsFlashGolDiff = $kmMapsGolValue !== null && $kmFlashGolValue !== null
+            ? $kmMapsGolValue - $kmFlashGolValue
+            : null;
+        $kmMapsFlashPlinDiff = $kmMapsPlinValue !== null && $kmFlashPlinValue !== null
+            ? $kmMapsPlinValue - $kmFlashPlinValue
+            : null;
+
         $diffClass = $kmDifference === null
             ? ''
             : ($kmDifference < 0 ? 'text-danger' : ($kmDifference > 0 ? 'text-success' : ''));
+        $diffFlashGolClass = $kmMapsFlashGolDiff === null
+            ? ''
+            : ($kmMapsFlashGolDiff < 0 ? 'text-danger' : ($kmMapsFlashGolDiff > 0 ? 'text-success' : ''));
+        $diffFlashPlinClass = $kmMapsFlashPlinDiff === null
+            ? ''
+            : ($kmMapsFlashPlinDiff < 0 ? 'text-danger' : ($kmMapsFlashPlinDiff > 0 ? 'text-success' : ''));
 
         $canMoveUp = ! $loop->first;
         $canMoveDown = ! $loop->last;
@@ -107,7 +127,7 @@
 
     @if ($isNewGroup)
         <tr class="curse-group-heading curse-group-heading--emphasis" style="background-color: {{ $groupColor }}; color: {{ $groupTextColor }};">
-            <th colspan="12">
+            <th colspan="{{ $tableColumnCount }}">
                 <div class="d-flex flex-column flex-xl-row justify-content-between gap-3">
                     <div class="fw-semibold fs-6 text-uppercase">{{ $groupName }}</div>
                     <div class="d-flex flex-wrap gap-3 small curse-group-heading__meta">
@@ -203,35 +223,66 @@
             {{ $dataTransport ?: '—' }}
         </td>
 
-        {{-- KM Maps --}}
-        <td class="text-end text-nowrap align-middle">
-            {{ $kmMapsDisplay }}
-        </td>
+        @if ($isFlashDivision)
+            {{-- KM Maps gol/plin --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmMapsGolValue !== null ? $kmMapsGolValue : '—' }}
+            </td>
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmMapsPlinValue !== null ? $kmMapsPlinValue : '—' }}
+            </td>
 
-        {{-- KM Plecare --}}
-        <td class="text-end text-nowrap align-middle">
-            {{ $kmPlecare !== null ? $kmPlecare : '—' }}
-        </td>
+            {{-- KM cu taxă --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmCuTaxaValue !== null ? $kmCuTaxaValue : '—' }}
+            </td>
 
-        {{-- KM Sosire --}}
-        <td class="text-end text-nowrap align-middle">
-            {{ $kmSosire !== null ? $kmSosire : '—' }}
-        </td>
+            {{-- KM Flash gol/plin --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmFlashGolValue !== null ? $kmFlashGolValue : '—' }}
+            </td>
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmFlashPlinValue !== null ? $kmFlashPlinValue : '—' }}
+            </td>
 
-        {{-- KM Bord 2 – Km gol --}}
-        <td class="text-end text-nowrap align-middle">
-            {{ $kmGol !== null ? $kmGol : '—' }}
-        </td>
+            {{-- Diferența KM (Maps – Flash) --}}
+            <td class="text-end text-nowrap align-middle {{ $diffFlashGolClass }}">
+                {{ $kmMapsFlashGolDiff !== null ? $kmMapsFlashGolDiff : '—' }}
+            </td>
+            <td class="text-end text-nowrap align-middle {{ $diffFlashPlinClass }}">
+                {{ $kmMapsFlashPlinDiff !== null ? $kmMapsFlashPlinDiff : '—' }}
+            </td>
+        @else
+            {{-- KM Maps --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmMapsDisplay }}
+            </td>
 
-        {{-- KM Bord 2 – Km plin --}}
-        <td class="text-end text-nowrap align-middle">
-            {{ $kmPlin !== null ? $kmPlin : '—' }}
-        </td>
+            {{-- KM Plecare --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmPlecare !== null ? $kmPlecare : '—' }}
+            </td>
 
-        {{-- Diferența KM (Bord – Maps) --}}
-        <td class="text-end text-nowrap align-middle {{ $diffClass }}">
-            {{ $kmDifference !== null ? $kmDifference : '—' }}
-        </td>
+            {{-- KM Sosire --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmSosire !== null ? $kmSosire : '—' }}
+            </td>
+
+            {{-- KM Bord 2 – Km gol --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmGol !== null ? $kmGol : '—' }}
+            </td>
+
+            {{-- KM Bord 2 – Km plin --}}
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmPlin !== null ? $kmPlin : '—' }}
+            </td>
+
+            {{-- Diferența KM (Bord – Maps) --}}
+            <td class="text-end text-nowrap align-middle {{ $diffClass }}">
+                {{ $kmDifference !== null ? $kmDifference : '—' }}
+            </td>
+        @endif
 
         {{-- Acțiuni --}}
         <td class="text-end align-middle">

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -37,6 +37,12 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Livrare completă',
             'km_bord_incarcare' => 12345,
             'km_bord_descarcare' => 12500,
+            'km_maps' => '150',
+            'km_maps_gol' => 50,
+            'km_maps_plin' => 100,
+            'km_cu_taxa' => 25,
+            'km_flash_gol' => 48,
+            'km_flash_plin' => 98,
         ]);
 
         $response->assertRedirect(route('valabilitati.curse.index', $valabilitate));
@@ -55,6 +61,12 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Livrare completă',
             'km_bord_incarcare' => 12345,
             'km_bord_descarcare' => 12500,
+            'km_maps' => '150',
+            'km_maps_gol' => 50,
+            'km_maps_plin' => 100,
+            'km_cu_taxa' => 25,
+            'km_flash_gol' => 48,
+            'km_flash_plin' => 98,
         ]);
 
         $cursa = ValabilitateCursa::firstOrFail();
@@ -97,6 +109,12 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Actualizare detalii',
             'km_bord_incarcare' => 98765,
             'km_bord_descarcare' => 99000,
+            'km_maps' => '300',
+            'km_maps_gol' => 120,
+            'km_maps_plin' => 180,
+            'km_cu_taxa' => 60,
+            'km_flash_gol' => 110,
+            'km_flash_plin' => 175,
         ]);
 
         $response->assertRedirect(route('valabilitati.curse.index', $cursa->valabilitate));
@@ -115,6 +133,12 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Actualizare detalii',
             'km_bord_incarcare' => 98765,
             'km_bord_descarcare' => 99000,
+            'km_maps' => '300',
+            'km_maps_gol' => 120,
+            'km_maps_plin' => 180,
+            'km_cu_taxa' => 60,
+            'km_flash_gol' => 110,
+            'km_flash_plin' => 175,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add kilometer tracking columns for Flash workflows (km maps gol/plin, km cu taxă, km flash gol/plin) at the schema, model and request levels
- update the valabilități curse table, rows and modals to hide KM Bord columns for divizia FLASH and surface the new Flash-only inputs and derived differences
- extend the ValabilitateCursa feature tests so the new fields are exercised during create/update flows

## Testing
- `php artisan test --filter=ValabilitateCursaTest` *(fails: dependencies missing and `composer install` cannot complete because the network blocks GitHub access)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dcc322bc8832698a357b85d2ed43d)