### PR TITLE
Add Flash-specific curse summary and pricing

### DIFF
--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -174,6 +174,7 @@
                     'valabilitate' => $valabilitate,
                     'summary' => $summary,
                     'showGroupSummary' => false,
+                    'isFlashDivision' => $isFlashDivision,
                 ])
             </div>
 
@@ -206,6 +207,12 @@
                                     <th rowspan="2" class="text-end curse-nowrap">KM cu taxă</th>
                                     <th colspan="2" class="text-center curse-nowrap">KM Flash</th>
                                     <th colspan="2" class="text-center curse-nowrap">Diferența KM<br>(Maps – Flash)</th>
+                                    <th rowspan="2" class="text-end curse-nowrap">
+                                        <div class="d-flex flex-column text-end">
+                                            <span class="text-uppercase">Sumă calculată</span>
+                                            <small>km gol / km plin / km cu taxă / total km</small>
+                                        </div>
+                                    </th>
                                 @else
                                     <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
                                     <th colspan="2" class="text-center curse-nowrap">
@@ -240,7 +247,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="{{ $isFlashDivision ? 13 : 12 }}" class="text-center py-4">
+                                    <td colspan="{{ $isFlashDivision ? 14 : 12 }}" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -393,23 +393,25 @@
                                     {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
-                                <label for="cursa-create-km-maps" class="form-label">Km Maps</label>
-                                <input
-                                    type="text"
-                                    name="km_maps"
-                                    id="cursa-create-km-maps"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps') ? 'is-invalid' : '' }}"
-                                    value="{{ $createKmMaps }}"
-                                    maxlength="255"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps') ? 'd-block' : '' }}"
-                                    data-error-for="km_maps"
-                                >
-                                    {{ $isCreateActive ? $errors->first('km_maps') : '' }}
+                            @unless ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-maps" class="form-label">Km Maps</label>
+                                    <input
+                                        type="text"
+                                        name="km_maps"
+                                        id="cursa-create-km-maps"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmMaps }}"
+                                        maxlength="255"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_maps') : '' }}
+                                    </div>
                                 </div>
-                            </div>
+                            @endunless
                             @if ($isFlashDivision)
                                 <div class="col-md-4">
                                     <label for="cursa-create-km-maps-gol" class="form-label">Km Maps gol</label>
@@ -847,23 +849,25 @@
                                     {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
-                                <label for="{{ $editPrefix }}km-maps" class="form-label">Km Maps</label>
-                                <input
-                                    type="text"
-                                    name="km_maps"
-                                    id="{{ $editPrefix }}km-maps"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps') ? 'is-invalid' : '' }}"
-                                    value="{{ $editKmMaps }}"
-                                    maxlength="255"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isEditing && $errors->has('km_maps') ? 'd-block' : '' }}"
-                                    data-error-for="km_maps"
-                                >
-                                    {{ $isEditing ? $errors->first('km_maps') : '' }}
+                            @unless ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-maps" class="form-label">Km Maps</label>
+                                    <input
+                                        type="text"
+                                        name="km_maps"
+                                        id="{{ $editPrefix }}km-maps"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmMaps }}"
+                                        maxlength="255"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_maps') : '' }}
+                                    </div>
                                 </div>
-                            </div>
+                            @endunless
                             @if ($isFlashDivision)
                                 <div class="col-md-4">
                                     <label for="{{ $editPrefix }}km-maps-gol" class="form-label">Km Maps gol</label>

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,6 +1,17 @@
 @php
     $isFlashDivision = optional($valabilitate->divizie)->id === 1;
-    $tableColumnCount = $isFlashDivision ? 13 : 12;
+    $tableColumnCount = $isFlashDivision ? 14 : 12;
+    $divizie = $valabilitate->divizie;
+    $priceKmGol = $divizie && $divizie->pret_km_gol !== null ? (float) $divizie->pret_km_gol : null;
+    $priceKmPlin = $divizie && $divizie->pret_km_plin !== null ? (float) $divizie->pret_km_plin : null;
+    $priceKmCuTaxa = $divizie && $divizie->pret_km_cu_taxa !== null ? (float) $divizie->pret_km_cu_taxa : null;
+    $formatCalculatedValue = static function (?float $value): string {
+        if ($value === null) {
+            return '—';
+        }
+
+        return number_format($value, 2);
+    };
     $previousKmSosire = null;
     $currentGroupKey = '__none__';
     $resolveRowTextColor = static function ($value): string {
@@ -85,6 +96,26 @@
         $diffFlashPlinClass = $kmMapsFlashPlinDiff === null
             ? ''
             : ($kmMapsFlashPlinDiff < 0 ? 'text-danger' : ($kmMapsFlashPlinDiff > 0 ? 'text-success' : ''));
+
+        $kmMapsGolAmount = $kmMapsGolValue !== null && $priceKmGol !== null
+            ? round($kmMapsGolValue * $priceKmGol, 2)
+            : null;
+        $kmMapsPlinAmount = $kmMapsPlinValue !== null && $priceKmPlin !== null
+            ? round($kmMapsPlinValue * $priceKmPlin, 2)
+            : null;
+        $kmMapsCuTaxaAmount = $kmCuTaxaValue !== null && $priceKmCuTaxa !== null
+            ? round($kmCuTaxaValue * $priceKmCuTaxa, 2)
+            : null;
+
+        $calculatedTotalAmount = null;
+        if ($kmMapsGolAmount !== null || $kmMapsPlinAmount !== null || $kmMapsCuTaxaAmount !== null) {
+            $calculatedTotalAmount = round(
+                ($kmMapsGolAmount ?? 0.0)
+                + ($kmMapsPlinAmount ?? 0.0)
+                + ($kmMapsCuTaxaAmount ?? 0.0),
+                2
+            );
+        }
 
         $canMoveUp = ! $loop->first;
         $canMoveDown = ! $loop->last;
@@ -251,6 +282,28 @@
             </td>
             <td class="text-end text-nowrap align-middle {{ $diffFlashPlinClass }}">
                 {{ $kmMapsFlashPlinDiff !== null ? $kmMapsFlashPlinDiff : '—' }}
+            </td>
+
+            {{-- Sumă calculată --}}
+            <td class="text-end align-middle text-nowrap">
+                <div class="d-flex flex-column gap-1 small text-end">
+                    <div>
+                        <span>km gol:</span>
+                        <strong>{{ $formatCalculatedValue($kmMapsGolAmount) }}</strong>
+                    </div>
+                    <div>
+                        <span>km plin:</span>
+                        <strong>{{ $formatCalculatedValue($kmMapsPlinAmount) }}</strong>
+                    </div>
+                    <div>
+                        <span>km cu taxă:</span>
+                        <strong>{{ $formatCalculatedValue($kmMapsCuTaxaAmount) }}</strong>
+                    </div>
+                    <div>
+                        <span>total km:</span>
+                        <strong>{{ $formatCalculatedValue($calculatedTotalAmount) }}</strong>
+                    </div>
+                </div>
             </td>
         @else
             {{-- KM Maps --}}

--- a/resources/views/valabilitati/curse/partials/summary.blade.php
+++ b/resources/views/valabilitati/curse/partials/summary.blade.php
@@ -1,3 +1,7 @@
+@php
+    $isFlashDivision = $isFlashDivision ?? (optional($valabilitate->divizie)->id === 1);
+@endphp
+
 <table class="curse-summary-table">
     <tr>
         <th class="curse-summary-title">
@@ -30,7 +34,16 @@
 
         <th class="text-end curse-summary-label">KM Maps total</th>
         <td class="text-end curse-nowrap">
-            {{ $summary['totalKmMaps'] ? $summary['totalKmMaps'] : '—' }}
+            @if ($summary['totalKmMaps'] !== null)
+                {{ $summary['totalKmMaps'] }}
+                @if ($isFlashDivision)
+                    <div class="small text-muted">
+                        (= {{ $summary['totalKmMapsGol'] ?? 0 }} km gol + {{ $summary['totalKmMapsPlin'] ?? 0 }} km plin)
+                    </div>
+                @endif
+            @else
+                —
+            @endif
         </td>
     </tr>
     <tr>
@@ -46,7 +59,16 @@
 
         <th class="text-end curse-summary-label">KM Bord 2 total</th>
         <td class="text-end curse-nowrap">
-            {{ $summary['totalKmBord2'] ? $summary['totalKmBord2'] : '—' }}
+            @if ($summary['totalKmBord2'] !== null)
+                {{ $summary['totalKmBord2'] }}
+                @if ($isFlashDivision && $summary['kmTotal'] !== null)
+                    <div class="small text-muted">
+                        (= {{ $summary['kmSosire'] !== null ? $summary['kmSosire'] : '—' }} - {{ $summary['kmPlecare'] !== null ? $summary['kmPlecare'] : '—' }})
+                    </div>
+                @endif
+            @else
+                —
+            @endif
         </td>
     </tr>
     <tr>
@@ -57,12 +79,30 @@
 
         <th class="text-end curse-summary-label">KM total (plecare → sosire)</th>
         <td class="text-end curse-nowrap">
-            {{ $summary['kmTotal'] !== null ? $summary['kmTotal'] : '—' }}
+            @if ($summary['kmTotal'] !== null)
+                {{ $summary['kmTotal'] }}
+                @if ($isFlashDivision)
+                    <div class="small text-muted">
+                        (= {{ $summary['kmSosire'] !== null ? $summary['kmSosire'] : '—' }} - {{ $summary['kmPlecare'] !== null ? $summary['kmPlecare'] : '—' }})
+                    </div>
+                @endif
+            @else
+                —
+            @endif
         </td>
 
         <th class="text-end curse-summary-label">Diferență totală (Bord–Maps)</th>
         <td class="text-end curse-nowrap">
-            {{ $summary['totalKmDiff'] ? $summary['totalKmDiff'] : '—' }}
+            @if ($summary['totalKmDiff'] !== null)
+                {{ $summary['totalKmDiff'] }}
+                @if ($isFlashDivision)
+                    <div class="small text-muted">
+                        (= {{ $summary['totalKmBord2'] !== null ? $summary['totalKmBord2'] : '—' }} - {{ $summary['totalKmMaps'] !== null ? $summary['totalKmMaps'] : '—' }})
+                    </div>
+                @endif
+            @else
+                —
+            @endif
         </td>
     </tr>
     @php


### PR DESCRIPTION
## Summary
- compute Flash division summaries from the parent valabilitate, including KM plecare/sosire, combined KM Maps metrics, and expose the new data to the summary partial
- update the summary band, table header, and row rendering to show the required Flash-only breakdowns plus the “Sumă calculată” column with the derived amounts
- hide the generic “Km Maps” field inside the create/edit modals whenever the selected division is FLASH so the UI only exposes the Flash-specific inputs

## Testing
- Unable to run `composer install`/`phpunit` because outbound access to GitHub is blocked in this environment (CONNECT tunnel failed with HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de970a24883268be27e5ec06a7e8c)