### PR TITLE
Polish Flash curse summaries and pricing table

### DIFF
--- a/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
+++ b/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
@@ -94,6 +94,8 @@ trait HandlesValabilitatiCurseListings
     {
         $curseCollection = $this->resolveCurseCollection($curse);
 
+        $isFlashDivision = optional($valabilitate->divizie)->id === 1;
+
         $kmPlecare = $curseCollection
             ->pluck('km_bord_incarcare')
             ->filter(static fn ($value) => $value !== null && $value !== '')
@@ -108,11 +110,42 @@ trait HandlesValabilitatiCurseListings
             ? (float) $kmSosire - (float) $kmPlecare
             : null;
 
-        $totalKmMaps = $curseCollection
+        $kmMapsValues = $curseCollection
             ->pluck('km_maps')
             ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
-            ->map(static fn ($value) => (float) $value)
-            ->sum();
+            ->map(static fn ($value) => (float) $value);
+
+        $totalKmMaps = $kmMapsValues->sum();
+
+        $kmMapsGolValues = $curseCollection
+            ->pluck('km_maps_gol')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value);
+
+        $totalKmMapsGol = $kmMapsGolValues->sum();
+
+        $kmMapsPlinValues = $curseCollection
+            ->pluck('km_maps_plin')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value);
+
+        $totalKmMapsPlin = $kmMapsPlinValues->sum();
+
+        $kmFlashGolValues = $curseCollection
+            ->pluck('km_flash_gol')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value);
+
+        $totalKmFlashGol = $kmFlashGolValues->sum();
+
+        $kmFlashPlinValues = $curseCollection
+            ->pluck('km_flash_plin')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value);
+
+        $totalKmFlashPlin = $kmFlashPlinValues->sum();
+
+        $totalKmFlash = $totalKmFlashGol + $totalKmFlashPlin;
 
         $totalKmBord2 = $curseCollection
             ->map(static function ($cursa) {
@@ -182,11 +215,35 @@ trait HandlesValabilitatiCurseListings
             'diferenta' => $groupFinancials->pluck('diferenta')->filter(static fn ($v) => $v !== null)->sum(),
         ];
 
+        if ($isFlashDivision) {
+            $kmPlecare = $valabilitate->km_plecare !== null
+                ? (float) $valabilitate->km_plecare
+                : null;
+
+            $kmSosire = $valabilitate->km_sosire !== null
+                ? (float) $valabilitate->km_sosire
+                : null;
+
+            $kmTotal = $kmPlecare !== null && $kmSosire !== null
+                ? $kmSosire - $kmPlecare
+                : null;
+
+            $totalKmMaps = $totalKmMapsGol + $totalKmMapsPlin;
+            $totalKmFlash = $totalKmFlashGol + $totalKmFlashPlin;
+            $totalKmBord2 = $totalKmFlash;
+            $totalKmDiff = $totalKmFlash - $totalKmMaps;
+        }
+
         return [
             'kmPlecare' => $kmPlecare,
             'kmSosire' => $kmSosire,
             'kmTotal' => $kmTotal,
             'totalKmMaps' => $totalKmMaps,
+            'totalKmMapsGol' => $totalKmMapsGol,
+            'totalKmMapsPlin' => $totalKmMapsPlin,
+            'totalKmFlashGol' => $totalKmFlashGol,
+            'totalKmFlashPlin' => $totalKmFlashPlin,
+            'totalKmFlash' => $totalKmFlash,
             'totalKmBord2' => $totalKmBord2,
             'totalKmDiff' => $totalKmDiff,
             'totalZile' => $totalZile,
@@ -220,6 +277,7 @@ trait HandlesValabilitatiCurseListings
             'valabilitate' => $valabilitate,
             'summary' => $summary,
             'showGroupSummary' => $this->displayGroupSummaryInResponses(),
+            'isFlashDivision' => optional($valabilitate->divizie)->id === 1,
         ])->render();
     }
 

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -174,6 +174,7 @@
                     'valabilitate' => $valabilitate,
                     'summary' => $summary,
                     'showGroupSummary' => false,
+                    'isFlashDivision' => $isFlashDivision,
                 ])
             </div>
 
@@ -206,6 +207,7 @@
                                     <th rowspan="2" class="text-end curse-nowrap">KM cu taxă</th>
                                     <th colspan="2" class="text-center curse-nowrap">KM Flash</th>
                                     <th colspan="2" class="text-center curse-nowrap">Diferența KM<br>(Maps – Flash)</th>
+                                    <th colspan="4" class="text-center curse-nowrap">Sumă calculată</th>
                                 @else
                                     <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
                                     <th colspan="2" class="text-center curse-nowrap">
@@ -226,6 +228,10 @@
                                     <th class="text-end curse-nowrap">Km plin</th>
                                     <th class="text-end curse-nowrap">Km gol</th>
                                     <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap">Km gol</th>
+                                    <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap">Km cu taxă</th>
+                                    <th class="text-end curse-nowrap">Total km</th>
                                 @else
                                     <th class="text-end curse-nowrap">Plecare</th>
                                     <th class="text-end curse-nowrap">Sosire</th>
@@ -240,7 +246,7 @@
                                 @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
                             @else
                                 <tr>
-                                    <td colspan="{{ $isFlashDivision ? 13 : 12 }}" class="text-center py-4">
+                                    <td colspan="{{ $isFlashDivision ? 17 : 12 }}" class="text-center py-4">
                                         Nu există curse care să respecte criteriile selectate.
                                     </td>
                                 </tr>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -357,59 +357,63 @@
                                     {{ $isCreateActive ? $errors->first('data_cursa') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
-                                <label for="cursa-create-km-bord-incarcare" class="form-label">Km bord încărcare</label>
-                                <input
-                                    type="number"
-                                    name="km_bord_incarcare"
-                                    id="cursa-create-km-bord-incarcare"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
-                                    value="{{ $createKmBordIncarcare }}"
-                                    min="0"
-                                    step="1"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
-                                    data-error-for="km_bord_incarcare"
-                                >
-                                    {{ $isCreateActive ? $errors->first('km_bord_incarcare') : '' }}
+                            @unless ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-bord-incarcare" class="form-label">Km bord încărcare</label>
+                                    <input
+                                        type="number"
+                                        name="km_bord_incarcare"
+                                        id="cursa-create-km-bord-incarcare"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmBordIncarcare }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
+                                        data-error-for="km_bord_incarcare"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_bord_incarcare') : '' }}
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="col-md-4">
-                                <label for="cursa-create-km-bord-descarcare" class="form-label">Km bord descărcare</label>
-                                <input
-                                    type="number"
-                                    name="km_bord_descarcare"
-                                    id="cursa-create-km-bord-descarcare"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
-                                    value="{{ $createKmBordDescarcare }}"
-                                    min="0"
-                                    step="1"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
-                                    data-error-for="km_bord_descarcare"
-                                >
-                                    {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-bord-descarcare" class="form-label">Km bord descărcare</label>
+                                    <input
+                                        type="number"
+                                        name="km_bord_descarcare"
+                                        id="cursa-create-km-bord-descarcare"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmBordDescarcare }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
+                                        data-error-for="km_bord_descarcare"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="col-md-4">
-                                <label for="cursa-create-km-maps" class="form-label">Km Maps</label>
-                                <input
-                                    type="text"
-                                    name="km_maps"
-                                    id="cursa-create-km-maps"
-                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps') ? 'is-invalid' : '' }}"
-                                    value="{{ $createKmMaps }}"
-                                    maxlength="255"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps') ? 'd-block' : '' }}"
-                                    data-error-for="km_maps"
-                                >
-                                    {{ $isCreateActive ? $errors->first('km_maps') : '' }}
+                            @endunless
+                            @unless ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="cursa-create-km-maps" class="form-label">Km Maps</label>
+                                    <input
+                                        type="text"
+                                        name="km_maps"
+                                        id="cursa-create-km-maps"
+                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps') ? 'is-invalid' : '' }}"
+                                        value="{{ $createKmMaps }}"
+                                        maxlength="255"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps"
+                                    >
+                                        {{ $isCreateActive ? $errors->first('km_maps') : '' }}
+                                    </div>
                                 </div>
-                            </div>
+                            @endunless
                             @if ($isFlashDivision)
                                 <div class="col-md-4">
                                     <label for="cursa-create-km-maps-gol" class="form-label">Km Maps gol</label>
@@ -811,59 +815,63 @@
                                     {{ $isEditing ? $errors->first('data_cursa') : '' }}
                                 </div>
                             </div>
-                            <div class="col-md-4">
-                                <label for="{{ $editPrefix }}km-bord-incarcare" class="form-label">Km bord încărcare</label>
-                                <input
-                                    type="number"
-                                    name="km_bord_incarcare"
-                                    id="{{ $editPrefix }}km-bord-incarcare"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
-                                    value="{{ $editKmBordIncarcare }}"
-                                    min="0"
-                                    step="1"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
-                                    data-error-for="km_bord_incarcare"
-                                >
-                                    {{ $isEditing ? $errors->first('km_bord_incarcare') : '' }}
+                            @unless ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-bord-incarcare" class="form-label">Km bord încărcare</label>
+                                    <input
+                                        type="number"
+                                        name="km_bord_incarcare"
+                                        id="{{ $editPrefix }}km-bord-incarcare"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmBordIncarcare }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
+                                        data-error-for="km_bord_incarcare"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_bord_incarcare') : '' }}
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="col-md-4">
-                                <label for="{{ $editPrefix }}km-bord-descarcare" class="form-label">Km bord descărcare</label>
-                                <input
-                                    type="number"
-                                    name="km_bord_descarcare"
-                                    id="{{ $editPrefix }}km-bord-descarcare"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
-                                    value="{{ $editKmBordDescarcare }}"
-                                    min="0"
-                                    step="1"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
-                                    data-error-for="km_bord_descarcare"
-                                >
-                                    {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-bord-descarcare" class="form-label">Km bord descărcare</label>
+                                    <input
+                                        type="number"
+                                        name="km_bord_descarcare"
+                                        id="{{ $editPrefix }}km-bord-descarcare"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmBordDescarcare }}"
+                                        min="0"
+                                        step="1"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
+                                        data-error-for="km_bord_descarcare"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="col-md-4">
-                                <label for="{{ $editPrefix }}km-maps" class="form-label">Km Maps</label>
-                                <input
-                                    type="text"
-                                    name="km_maps"
-                                    id="{{ $editPrefix }}km-maps"
-                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps') ? 'is-invalid' : '' }}"
-                                    value="{{ $editKmMaps }}"
-                                    maxlength="255"
-                                >
-                                <div
-                                    class="invalid-feedback {{ $isEditing && $errors->has('km_maps') ? 'd-block' : '' }}"
-                                    data-error-for="km_maps"
-                                >
-                                    {{ $isEditing ? $errors->first('km_maps') : '' }}
+                            @endunless
+                            @unless ($isFlashDivision)
+                                <div class="col-md-4">
+                                    <label for="{{ $editPrefix }}km-maps" class="form-label">Km Maps</label>
+                                    <input
+                                        type="text"
+                                        name="km_maps"
+                                        id="{{ $editPrefix }}km-maps"
+                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps') ? 'is-invalid' : '' }}"
+                                        value="{{ $editKmMaps }}"
+                                        maxlength="255"
+                                    >
+                                    <div
+                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps') ? 'd-block' : '' }}"
+                                        data-error-for="km_maps"
+                                    >
+                                        {{ $isEditing ? $errors->first('km_maps') : '' }}
+                                    </div>
                                 </div>
-                            </div>
+                            @endunless
                             @if ($isFlashDivision)
                                 <div class="col-md-4">
                                     <label for="{{ $editPrefix }}km-maps-gol" class="form-label">Km Maps gol</label>

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,6 +1,17 @@
 @php
     $isFlashDivision = optional($valabilitate->divizie)->id === 1;
-    $tableColumnCount = $isFlashDivision ? 13 : 12;
+    $tableColumnCount = $isFlashDivision ? 17 : 12;
+    $divizie = $valabilitate->divizie;
+    $priceKmGol = $divizie && $divizie->pret_km_gol !== null ? (float) $divizie->pret_km_gol : null;
+    $priceKmPlin = $divizie && $divizie->pret_km_plin !== null ? (float) $divizie->pret_km_plin : null;
+    $priceKmCuTaxa = $divizie && $divizie->pret_km_cu_taxa !== null ? (float) $divizie->pret_km_cu_taxa : null;
+    $formatCalculatedValue = static function (?float $value): string {
+        if ($value === null) {
+            return '—';
+        }
+
+        return number_format($value, 2);
+    };
     $previousKmSosire = null;
     $currentGroupKey = '__none__';
     $resolveRowTextColor = static function ($value): string {
@@ -85,6 +96,26 @@
         $diffFlashPlinClass = $kmMapsFlashPlinDiff === null
             ? ''
             : ($kmMapsFlashPlinDiff < 0 ? 'text-danger' : ($kmMapsFlashPlinDiff > 0 ? 'text-success' : ''));
+
+        $kmMapsGolAmount = $kmMapsGolValue !== null && $priceKmGol !== null
+            ? round($kmMapsGolValue * $priceKmGol, 2)
+            : null;
+        $kmMapsPlinAmount = $kmMapsPlinValue !== null && $priceKmPlin !== null
+            ? round($kmMapsPlinValue * $priceKmPlin, 2)
+            : null;
+        $kmMapsCuTaxaAmount = $kmCuTaxaValue !== null && $priceKmCuTaxa !== null
+            ? round($kmCuTaxaValue * $priceKmCuTaxa, 2)
+            : null;
+
+        $calculatedTotalAmount = null;
+        if ($kmMapsGolAmount !== null || $kmMapsPlinAmount !== null || $kmMapsCuTaxaAmount !== null) {
+            $calculatedTotalAmount = round(
+                ($kmMapsGolAmount ?? 0.0)
+                + ($kmMapsPlinAmount ?? 0.0)
+                + ($kmMapsCuTaxaAmount ?? 0.0),
+                2
+            );
+        }
 
         $canMoveUp = ! $loop->first;
         $canMoveDown = ! $loop->last;
@@ -252,6 +283,12 @@
             <td class="text-end text-nowrap align-middle {{ $diffFlashPlinClass }}">
                 {{ $kmMapsFlashPlinDiff !== null ? $kmMapsFlashPlinDiff : '—' }}
             </td>
+
+            {{-- Sumă calculată subcoloane --}}
+            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($kmMapsGolAmount) }}</td>
+            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($kmMapsPlinAmount) }}</td>
+            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($kmMapsCuTaxaAmount) }}</td>
+            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($calculatedTotalAmount) }}</td>
         @else
             {{-- KM Maps --}}
             <td class="text-end text-nowrap align-middle">

--- a/resources/views/valabilitati/curse/partials/summary.blade.php
+++ b/resources/views/valabilitati/curse/partials/summary.blade.php
@@ -1,3 +1,7 @@
+@php
+    $isFlashDivision = $isFlashDivision ?? (optional($valabilitate->divizie)->id === 1);
+@endphp
+
 <table class="curse-summary-table">
     <tr>
         <th class="curse-summary-title">
@@ -30,7 +34,11 @@
 
         <th class="text-end curse-summary-label">KM Maps total</th>
         <td class="text-end curse-nowrap">
-            {{ $summary['totalKmMaps'] ? $summary['totalKmMaps'] : '—' }}
+            @if ($summary['totalKmMaps'] !== null)
+                {{ $summary['totalKmMaps'] }}
+            @else
+                —
+            @endif
         </td>
     </tr>
     <tr>
@@ -44,9 +52,19 @@
             {{ $summary['kmSosire'] !== null ? $summary['kmSosire'] : '—' }}
         </td>
 
-        <th class="text-end curse-summary-label">KM Bord 2 total</th>
+        <th class="text-end curse-summary-label">
+            {{ $isFlashDivision ? 'KM FLASH total' : 'KM Bord 2 total' }}
+        </th>
         <td class="text-end curse-nowrap">
-            {{ $summary['totalKmBord2'] ? $summary['totalKmBord2'] : '—' }}
+            @php
+                $flashTotal = $summary['totalKmFlash'] ?? null;
+                $bordTotal = $summary['totalKmBord2'] ?? null;
+            @endphp
+            @if ($isFlashDivision)
+                {{ $flashTotal !== null ? $flashTotal : '—' }}
+            @else
+                {{ $bordTotal !== null ? $bordTotal : '—' }}
+            @endif
         </td>
     </tr>
     <tr>
@@ -57,12 +75,22 @@
 
         <th class="text-end curse-summary-label">KM total (plecare → sosire)</th>
         <td class="text-end curse-nowrap">
-            {{ $summary['kmTotal'] !== null ? $summary['kmTotal'] : '—' }}
+            @if ($summary['kmTotal'] !== null)
+                {{ $summary['kmTotal'] }}
+            @else
+                —
+            @endif
         </td>
 
-        <th class="text-end curse-summary-label">Diferență totală (Bord–Maps)</th>
+        <th class="text-end curse-summary-label">
+            {{ $isFlashDivision ? 'Total Flash - Maps' : 'Diferență totală (Bord–Maps)' }}
+        </th>
         <td class="text-end curse-nowrap">
-            {{ $summary['totalKmDiff'] ? $summary['totalKmDiff'] : '—' }}
+            @if ($summary['totalKmDiff'] !== null)
+                {{ $summary['totalKmDiff'] }}
+            @else
+                —
+            @endif
         </td>
     </tr>
     @php


### PR DESCRIPTION
## Summary
- compute the Flash-only totals from the `km_flash_*` fields and surface the results (plus the renamed "Total Flash - Maps" metric) in the summary banner
- reshape the Flash curse table so the "Sumă calculată" block is split into four subcolumns while retaining the other requested wording/total adjustments
- hide the "Km bord" plecare/sosire inputs in the create/edit forms whenever the selected division is FLASH so only the relevant fields show up

## Testing
- `composer install --no-interaction` *(fails: outbound HTTPS downloads to GitHub return CONNECT 403 in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de970a24883268be27e5ec06a7e8c)