### PR TITLE
Hide difference column for FLASH division groups

### DIFF
--- a/resources/views/valabilitati/grupuri/index.blade.php
+++ b/resources/views/valabilitati/grupuri/index.blade.php
@@ -70,7 +70,7 @@
         };
         $isFlashDivision = optional($valabilitate->divizie)->id === 1
             && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
-        $hideDifferenceColumn = optional($valabilitate->divizie)->id === 2;
+        $hideDifferenceColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 2;
 
         $tableColumnCount = 1; // Index column
         $tableColumnCount += $isFlashDivision ? 1 : 2; // RR or Grup + Format


### PR DESCRIPTION
## Summary
- hide the "Diferență" column on the grupuri table when the valabilitate division is FLASH (id 1) 

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e35a1d93c832695e6ac5dddc602ce)