### PR TITLE
Tighten curse table layout and scrolling

### DIFF
--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -22,6 +22,11 @@
             vertical-align: middle;
         }
 
+        .curse-data-table td {
+            white-space: nowrap;
+            font-size: 0.75rem;
+        }
+
         .curse-summary-table th {
             background-color: #f8f9fa;
             font-weight: 600;
@@ -183,7 +188,7 @@
             <div id="curse-feedback" class="px-3"></div>
 
             <div class="px-3">
-                <div class="table-responsive">
+                <div class="table-responsive" style="max-height: 70vh; overflow-y: auto;">
                     <table class="table table-sm curse-data-table align-middle">
                         <thead>
                             <tr class="curse-data-header-top">


### PR DESCRIPTION
## Summary
- keep curse data table cells on a single line with smaller text
- add a vertical scroll limit to the responsive table wrapper for easier navigation

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ecf1334e083269016d4dab18da057)