### PR TITLE
Improve curse table accessibility and responsiveness

### DIFF
--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -3,6 +3,10 @@
 @section('content')
     {{-- Page-specific styling – stays only in this file --}}
     <style>
+        :root {
+            --curse-header-first-row-height: 3.1rem;
+        }
+
         /* Excel-style summary + main table */
 
         .curse-summary-table,
@@ -17,7 +21,7 @@
         .curse-data-table th,
         .curse-data-table td {
             border: 1px solid #000000ff;
-            padding: 0.4rem 0.6rem;
+            padding: 0.35rem 0.5rem;
             line-height: 1.1;
             vertical-align: middle;
         }
@@ -50,10 +54,18 @@
             font-weight: 600;
             text-transform: uppercase;
             font-size: 0.75rem;
+            position: sticky;
+            z-index: 5;
         }
 
         .curse-data-header-bottom th {
             border-top: none;
+            top: var(--curse-header-first-row-height);
+            z-index: 4;
+        }
+
+        .curse-data-header-top th {
+            top: 0;
         }
 
         .curse-data-table tbody tr:not(.curse-group-heading):not(.curse-group-row):nth-child(even) {
@@ -88,6 +100,105 @@
 
         .curse-nowrap {
             white-space: nowrap;
+        }
+
+        .curse-table-shell {
+            position: relative;
+        }
+
+        .curse-table-scroll {
+            overflow-x: auto;
+            overflow-y: auto;
+            max-height: 70vh;
+            border: 1px solid #dee2e6;
+            border-radius: 0.75rem;
+            background-color: #ffffff;
+            scroll-behavior: smooth;
+        }
+
+        .curse-table-scroll:focus {
+            outline: 3px solid #cfe2ff;
+            outline-offset: 2px;
+        }
+
+        .curse-sticky-col {
+            position: sticky;
+            left: 0;
+            z-index: 6;
+            background-color: inherit;
+        }
+
+        .curse-col-select {
+            width: 46px;
+            min-width: 46px;
+        }
+
+        .curse-col-order {
+            min-width: 92px;
+            width: 105px;
+        }
+
+        .curse-col-number {
+            min-width: 110px;
+        }
+
+        .curse-col-route {
+            min-width: 240px;
+        }
+
+        .curse-col-date {
+            min-width: 150px;
+        }
+
+        .curse-col-numeric {
+            min-width: 120px;
+        }
+
+        .curse-col-actions {
+            min-width: 120px;
+        }
+
+        .curse-back-to-top {
+            position: absolute;
+            right: 0.75rem;
+            bottom: 0.75rem;
+            z-index: 8;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+        }
+
+        .curse-compact-cell {
+            padding-top: 0.25rem;
+            padding-bottom: 0.25rem;
+        }
+
+        @media (max-width: 1200px) {
+            .curse-hide-lg {
+                display: none;
+            }
+        }
+
+        @media (max-width: 992px) {
+            :root {
+                --curse-header-first-row-height: 3.6rem;
+            }
+
+            .curse-hide-md {
+                display: none;
+            }
+
+            .curse-table-scroll {
+                max-height: 65vh;
+            }
+        }
+
+        @media (max-width: 768px) {
+            .curse-hide-sm {
+                display: none;
+            }
+
+            .curse-table-scroll {
+                max-height: 60vh;
+            }
         }
     </style>
 
@@ -183,11 +294,15 @@
             <div id="curse-feedback" class="px-3"></div>
 
             <div class="px-3">
-                <div class="table-responsive">
-                    <table class="table table-sm curse-data-table align-middle">
+                <div class="curse-table-shell">
+                    <div id="curse-table-container" class="curse-table-scroll" tabindex="0">
+                        <table class="table table-sm curse-data-table align-middle">
                         <thead>
                             <tr class="curse-data-header-top">
-                                <th rowspan="2" class="text-center curse-nowrap align-middle">
+                                <th
+                                    rowspan="2"
+                                    class="text-center curse-nowrap align-middle curse-col-select curse-sticky-col"
+                                >
                                     <div class="form-check mb-0">
                                         <input
                                             type="checkbox"
@@ -200,52 +315,52 @@
                                         </label>
                                     </div>
                                 </th>
-                                <th rowspan="2" class="text-center curse-nowrap">#</th>
-                                <th rowspan="2" class="text-center curse-nowrap">Nr. cursă</th>
-                                <th rowspan="2">Cursa</th>
-                                <th rowspan="2" class="text-center curse-nowrap">Dată<br>transport</th>
+                                <th rowspan="2" class="text-center curse-nowrap curse-col-order">#</th>
+                                <th rowspan="2" class="text-center curse-nowrap curse-col-number">Nr. cursă</th>
+                                <th rowspan="2" class="curse-col-route">Cursa</th>
+                                <th rowspan="2" class="text-center curse-nowrap curse-col-date">Dată<br>transport</th>
                                 @if ($isFlashDivision)
                                     <th colspan="2" class="text-center curse-nowrap">KM Maps</th>
                                     <th rowspan="2" class="text-center curse-nowrap">KM cu<br>taxă</th>
-                                    <th colspan="2" class="text-center curse-nowrap">KM Flash</th>
-                                    <th colspan="2" class="text-center curse-nowrap">Diferența KM<br>(Maps – Flash)</th>
-                                    <th colspan="4" class="text-center curse-nowrap">Sumă calculată</th>
+                                    <th colspan="2" class="text-center curse-nowrap curse-hide-lg">KM Flash</th>
+                                    <th colspan="2" class="text-center curse-nowrap curse-hide-lg">Diferența KM<br>(Maps – Flash)</th>
+                                    <th colspan="4" class="text-center curse-nowrap curse-hide-md">Sumă calculată</th>
                                     <th rowspan="2" class="text-end curse-nowrap">Alte taxe</th>
                                     <th rowspan="2" class="text-end curse-nowrap">Fuel tax</th>
                                     <th rowspan="2" class="text-center curse-nowrap">Sumă<br>încasată</th>
-                                    <th rowspan="2" class="text-center curse-nowrap">Diferența preț<br>(încasat –<br> calculat)</th>
-                                    <th colspan="2" class="text-center curse-nowrap">Daily contribution</th>
+                                    <th rowspan="2" class="text-center curse-nowrap curse-hide-sm">Diferența preț<br>(încasat –<br> calculat)</th>
+                                    <th colspan="2" class="text-center curse-nowrap curse-hide-sm">Daily contribution</th>
                                 @else
-                                    <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
-                                    <th colspan="2" class="text-center curse-nowrap">
+                                    <th rowspan="2" class="text-end curse-nowrap curse-col-numeric">KM Maps</th>
+                                    <th colspan="2" class="text-center curse-nowrap curse-col-numeric">
                                         KM Bord (plecare / sosire)
                                     </th>
-                                    <th colspan="2" class="text-center curse-nowrap">KM Bord 2</th>
-                                    <th rowspan="2" class="text-end curse-nowrap">
+                                    <th colspan="2" class="text-center curse-nowrap curse-hide-md">KM Bord 2</th>
+                                    <th rowspan="2" class="text-end curse-nowrap curse-hide-lg">
                                         Diferența KM<br>(Bord – Maps)
                                     </th>
                                 @endif
-                                <th rowspan="2" class="text-end curse-nowrap">Acțiuni</th>
+                                <th rowspan="2" class="text-end curse-nowrap curse-col-actions">Acțiuni</th>
                             </tr>
                             <tr class="curse-data-header-bottom">
                                 @if ($isFlashDivision)
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
-                                    <th class="text-end curse-nowrap">Km cu taxă</th>
-                                    <th class="text-end curse-nowrap">Total km</th>
-                                    <th class="text-end curse-nowrap">Calculat</th>
-                                    <th class="text-end curse-nowrap">Încasat</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric">Km gol</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric">Km plin</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric">Km gol</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric">Km plin</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric curse-hide-lg">Km gol</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric curse-hide-lg">Km plin</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric curse-hide-lg">Km gol</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric curse-hide-lg">Km plin</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric">Km cu taxă</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric">Total km</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric curse-hide-md">Calculat</th>
+                                    <th class="text-end curse-nowrap curse-col-numeric curse-hide-md">Încasat</th>
                                 @else
                                     <th class="text-end curse-nowrap">Plecare</th>
                                     <th class="text-end curse-nowrap">Sosire</th>
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap curse-hide-md">Km gol</th>
+                                    <th class="text-end curse-nowrap curse-hide-md">Km plin</th>
                                 @endif
                             </tr>
                         </thead>
@@ -262,6 +377,15 @@
                             @endif
                         </tbody>
                     </table>
+                    </div>
+                    <button
+                        type="button"
+                        id="curse-back-to-top"
+                        class="btn btn-sm btn-outline-secondary d-none curse-back-to-top"
+                        aria-label="Înapoi sus"
+                    >
+                        <i class="fa-solid fa-arrow-up"></i>
+                    </button>
                 </div>
             </div>
 
@@ -298,6 +422,8 @@
                 const bootstrapModal = bootstrap && bootstrap.Modal ? bootstrap.Modal : null;
                 const modalsContainer = document.getElementById('curse-modals');
                 const tableBody = document.getElementById('curse-table-body');
+                const tableContainer = document.getElementById('curse-table-container');
+                const backToTopButton = document.getElementById('curse-back-to-top');
                 const feedbackContainer = document.getElementById('curse-feedback');
                 const summaryContainer = document.getElementById('curse-summary');
                 const bulkTriggerButton = document.getElementById('curse-bulk-trigger');
@@ -360,6 +486,122 @@
                     observer: null,
                     nextUrl: null,
                     loading: false,
+                };
+
+                let navigableRows = [];
+                let activeRowIndex = 0;
+                let navigationBound = false;
+
+                const focusTableContainer = (resetScroll = false) => {
+                    if (!tableContainer) {
+                        return;
+                    }
+
+                    if (resetScroll) {
+                        tableContainer.scrollTop = 0;
+                    }
+
+                    tableContainer.focus({ preventScroll: true });
+                };
+
+                const refreshNavigableRows = () => {
+                    navigableRows = tableBody ? Array.from(tableBody.querySelectorAll('[data-nav-row]')) : [];
+                    navigableRows.forEach(row => {
+                        row.setAttribute('tabindex', '-1');
+                    });
+
+                    if (!navigableRows.length) {
+                        activeRowIndex = 0;
+                        return;
+                    }
+
+                    activeRowIndex = Math.min(activeRowIndex, Math.max(navigableRows.length - 1, 0));
+                };
+
+                const focusRowByIndex = (index) => {
+                    if (!navigableRows.length) {
+                        return;
+                    }
+
+                    const clampedIndex = Math.max(0, Math.min(index, navigableRows.length - 1));
+                    const row = navigableRows[clampedIndex];
+
+                    if (row) {
+                        activeRowIndex = clampedIndex;
+                        row.focus({ preventScroll: false });
+                        row.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+                    }
+                };
+
+                const handleTableKeydown = (event) => {
+                    if (!tableContainer || !navigableRows.length) {
+                        return;
+                    }
+
+                    const targetTag = (event.target.tagName || '').toLowerCase();
+                    if (['input', 'textarea', 'select', 'button'].includes(targetTag)) {
+                        return;
+                    }
+
+                    if (!['ArrowDown', 'ArrowUp', 'Home', 'End', 'PageDown', 'PageUp'].includes(event.key)) {
+                        return;
+                    }
+
+                    event.preventDefault();
+
+                    const pageJump = 5;
+                    if (event.key === 'ArrowDown') {
+                        focusRowByIndex(activeRowIndex + 1);
+                    } else if (event.key === 'ArrowUp') {
+                        focusRowByIndex(activeRowIndex - 1);
+                    } else if (event.key === 'Home') {
+                        focusRowByIndex(0);
+                    } else if (event.key === 'End') {
+                        focusRowByIndex(navigableRows.length - 1);
+                    } else if (event.key === 'PageDown') {
+                        focusRowByIndex(activeRowIndex + pageJump);
+                    } else if (event.key === 'PageUp') {
+                        focusRowByIndex(activeRowIndex - pageJump);
+                    }
+                };
+
+                const handleTableScroll = () => {
+                    if (!tableContainer || !backToTopButton) {
+                        return;
+                    }
+
+                    const shouldShow = tableContainer.scrollTop > 120;
+                    backToTopButton.classList.toggle('d-none', !shouldShow);
+                };
+
+                const handleBackToTop = () => {
+                    if (!tableContainer) {
+                        return;
+                    }
+
+                    tableContainer.scrollTo({ top: 0, behavior: 'smooth' });
+                    focusTableContainer();
+                };
+
+                const bindTableNavigation = () => {
+                    if (!tableContainer || navigationBound) {
+                        return;
+                    }
+
+                    tableContainer.addEventListener('keydown', handleTableKeydown);
+                    tableContainer.addEventListener('scroll', handleTableScroll);
+
+                    if (backToTopButton) {
+                        backToTopButton.addEventListener('click', handleBackToTop);
+                    }
+
+                    navigationBound = true;
+                };
+
+                const setupTableNavigation = () => {
+                    refreshNavigableRows();
+                    bindTableNavigation();
+                    handleTableScroll();
                 };
 
                 const updateBulkAssignUi = () => {
@@ -1123,6 +1365,8 @@
                     bindBulkCheckboxes();
                     updateBulkAssignUi();
                     clearBulkAssignError();
+                    setupTableNavigation();
+                    focusTableContainer(true);
 
                     if (supportsAjax()) {
                         attachFormHandlers();
@@ -1321,6 +1565,10 @@
                             if (supportsAjax()) {
                                 attachFormHandlers();
                             }
+
+                            refreshNavigableRows();
+                            handleTableScroll();
+                            focusTableContainer();
                         })
                         .catch(() => {
                             if (loadState.button) {
@@ -1404,6 +1652,8 @@
                 initCountryInputs();
                 initLoadMore();
                 initBulkAssignControls();
+                setupTableNavigation();
+                focusTableContainer();
 
                 if (supportsAjax()) {
                     attachFormHandlers();

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -230,8 +230,13 @@
     @php
         $checkboxId = 'cursa-select-' . $cursa->id;
     @endphp
-    <tr @class(['curse-group-row' => (bool) $group]) style="background-color: {{ $group ? $groupColor : 'transparent' }}; color: {{ $group ? $groupTextColor : '#111' }};">
-        <td class="text-center align-middle">
+    <tr
+        @class(['curse-group-row' => (bool) $group])
+        style="background-color: {{ $group ? $groupColor : 'transparent' }}; color: {{ $group ? $groupTextColor : '#111' }};"
+        data-nav-row
+        tabindex="-1"
+    >
+        <td class="text-center align-middle curse-sticky-col curse-col-select">
             <div class="form-check mb-0">
                 <input
                     type="checkbox"
@@ -246,7 +251,7 @@
             </div>
         </td>
         {{-- # + up/down controls --}}
-        <td class="text-center fw-semibold">
+        <td class="text-center fw-semibold curse-col-order curse-compact-cell">
             <div class="align-items-center gap-2">
                 <span>#{{ $cursa->nr_ordine }}</span>
                 @if ($hasMultipleCurse)
@@ -291,95 +296,95 @@
         </td>
 
         {{-- Nr. cursă --}}
-        <td class="text-nowrap align-middle">
+        <td class="text-nowrap align-middle curse-col-number curse-compact-cell">
             {{ $cursa->nr_cursa ?: '—' }}
         </td>
 
         {{-- Cursa (descriere) --}}
-        <td class="small align-middle">
+        <td class="small align-middle curse-col-route curse-compact-cell">
             {{ $cursaDescriere }}
         </td>
 
         {{-- Dată transport --}}
-        <td class="small text-center align-middle">
+        <td class="small text-center align-middle curse-col-date curse-compact-cell">
             {{ $dataTransport ?: '—' }}
         </td>
 
         @if ($isFlashDivision)
             {{-- KM Maps gol/plin --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-compact-cell">
                 {{ $kmMapsGolValue !== null ? $kmMapsGolValue : '—' }}
             </td>
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-compact-cell">
                 {{ $kmMapsPlinValue !== null ? $kmMapsPlinValue : '—' }}
             </td>
 
             {{-- KM cu taxă --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-compact-cell">
                 {{ $kmCuTaxaValue !== null ? $kmCuTaxaValue : '—' }}
             </td>
 
             {{-- KM Flash gol/plin --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-hide-lg curse-compact-cell">
                 {{ $kmFlashGolValue !== null ? $kmFlashGolValue : '—' }}
             </td>
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-hide-lg curse-compact-cell">
                 {{ $kmFlashPlinValue !== null ? $kmFlashPlinValue : '—' }}
             </td>
 
             {{-- Diferența KM (Maps – Flash) --}}
-            <td class="text-end text-nowrap align-middle {{ $diffFlashGolClass }}">
+            <td class="text-end text-nowrap align-middle {{ $diffFlashGolClass }} curse-col-numeric curse-hide-lg curse-compact-cell">
                 {{ $kmMapsFlashGolDiff !== null ? $kmMapsFlashGolDiff : '—' }}
             </td>
-            <td class="text-end text-nowrap align-middle {{ $diffFlashPlinClass }}">
+            <td class="text-end text-nowrap align-middle {{ $diffFlashPlinClass }} curse-col-numeric curse-hide-lg curse-compact-cell">
                 {{ $kmMapsFlashPlinDiff !== null ? $kmMapsFlashPlinDiff : '—' }}
             </td>
 
             {{-- Sumă calculată subcoloane --}}
-            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($kmMapsGolAmount) }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($kmMapsPlinAmount) }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($kmMapsCuTaxaAmount) }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $formatCalculatedValue($calculatedTotalAmount) }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $alteTaxe !== null ? number_format($alteTaxe, 2) : '—' }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $fuelTax !== null ? number_format($fuelTax, 2) : '—' }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $sumaIncasata !== null ? number_format($sumaIncasata, 2) : '—' }}</td>
-            <td class="text-end align-middle text-nowrap {{ $priceDiffClass }}">{{ $diferentaPret !== null ? number_format($diferentaPret, 2) : '—' }}</td>
-            <td class="text-end align-middle text-nowrap">{{ $dailyContributionCalculat !== null ? number_format($dailyContributionCalculat, 2) : '—' }}</td>
-            <td class="text-end align-middle text-nowrap {{ $dailyContributionClass }}">{{ $dailyContributionIncasata !== null ? number_format($dailyContributionIncasata, 2) : '—' }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-hide-md curse-compact-cell">{{ $formatCalculatedValue($kmMapsGolAmount) }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-hide-md curse-compact-cell">{{ $formatCalculatedValue($kmMapsPlinAmount) }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-hide-md curse-compact-cell">{{ $formatCalculatedValue($kmMapsCuTaxaAmount) }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-hide-md curse-compact-cell">{{ $formatCalculatedValue($calculatedTotalAmount) }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-compact-cell">{{ $alteTaxe !== null ? number_format($alteTaxe, 2) : '—' }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-compact-cell">{{ $fuelTax !== null ? number_format($fuelTax, 2) : '—' }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-compact-cell">{{ $sumaIncasata !== null ? number_format($sumaIncasata, 2) : '—' }}</td>
+            <td class="text-end align-middle text-nowrap {{ $priceDiffClass }} curse-col-numeric curse-hide-sm curse-compact-cell">{{ $diferentaPret !== null ? number_format($diferentaPret, 2) : '—' }}</td>
+            <td class="text-end align-middle text-nowrap curse-col-numeric curse-hide-sm curse-compact-cell">{{ $dailyContributionCalculat !== null ? number_format($dailyContributionCalculat, 2) : '—' }}</td>
+            <td class="text-end align-middle text-nowrap {{ $dailyContributionClass }} curse-col-numeric curse-hide-sm curse-compact-cell">{{ $dailyContributionIncasata !== null ? number_format($dailyContributionIncasata, 2) : '—' }}</td>
         @else
             {{-- KM Maps --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-compact-cell">
                 {{ $kmMapsDisplay }}
             </td>
 
             {{-- KM Plecare --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-compact-cell">
                 {{ $kmPlecare !== null ? $kmPlecare : '—' }}
             </td>
 
             {{-- KM Sosire --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-compact-cell">
                 {{ $kmSosire !== null ? $kmSosire : '—' }}
             </td>
 
             {{-- KM Bord 2 – Km gol --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-hide-md curse-compact-cell">
                 {{ $kmGol !== null ? $kmGol : '—' }}
             </td>
 
             {{-- KM Bord 2 – Km plin --}}
-            <td class="text-end text-nowrap align-middle">
+            <td class="text-end text-nowrap align-middle curse-col-numeric curse-hide-md curse-compact-cell">
                 {{ $kmPlin !== null ? $kmPlin : '—' }}
             </td>
 
             {{-- Diferența KM (Bord – Maps) --}}
-            <td class="text-end text-nowrap align-middle {{ $diffClass }}">
+            <td class="text-end text-nowrap align-middle {{ $diffClass }} curse-col-numeric curse-hide-lg curse-compact-cell">
                 {{ $kmDifference !== null ? $kmDifference : '—' }}
             </td>
         @endif
 
         {{-- Acțiuni --}}
-        <td class="text-end align-middle">
+        <td class="text-end align-middle curse-col-actions curse-compact-cell">
             <div class="d-flex flex-wrap justify-content-end">
                 <div class="ms-1">
                     <a


### PR DESCRIPTION
## Summary
- wrap the curse listing in a scrollable container with sticky headers/first column and compact spacing
- tune column widths with responsive hiding plus a back-to-top control and keyboard navigation
- refresh navigation and focus as pages change so AJAX pagination remains usable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed2110efc8326bb9a1576a0542707)