### PR TITLE
Add alimentari management to valabilitati

### DIFF
--- a/app/Http/Controllers/ValabilitateAlimentareController.php
+++ b/app/Http/Controllers/ValabilitateAlimentareController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Concerns\HandlesValabilitatiCurseListings;
+use App\Http\Requests\ValabilitateAlimentareRequest;
+use App\Models\Alimentare;
+use App\Models\Valabilitate;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class ValabilitateAlimentareController extends Controller
+{
+    use HandlesValabilitatiCurseListings;
+
+    private const PER_PAGE = 15;
+
+    public function index(Request $request, Valabilitate $valabilitate): View
+    {
+        $this->authorize('view', $valabilitate);
+
+        $valabilitate->loadMissing(['sofer', 'taxeDrum', 'divizie', 'curse']);
+        $summary = $this->buildSummaryData($valabilitate, $valabilitate->curse);
+
+        $alimentari = $valabilitate
+            ->alimentari()
+            ->paginate(self::PER_PAGE)
+            ->withQueryString();
+
+        return view('valabilitati.alimentari.index', [
+            'valabilitate' => $valabilitate,
+            'summary' => $summary,
+            'alimentari' => $alimentari,
+            'backUrl' => route('valabilitati.index'),
+        ]);
+    }
+
+    public function store(
+        ValabilitateAlimentareRequest $request,
+        Valabilitate $valabilitate
+    ): RedirectResponse {
+        $this->authorize('update', $valabilitate);
+
+        $valabilitate->alimentari()->create($request->validated());
+
+        return redirect()
+            ->route('valabilitati.alimentari.index', $valabilitate)
+            ->with('status', 'Alimentarea a fost adăugată.');
+    }
+
+    public function update(
+        ValabilitateAlimentareRequest $request,
+        Valabilitate $valabilitate,
+        Alimentare $alimentare
+    ): RedirectResponse {
+        $this->assertBelongsToValabilitate($valabilitate, $alimentare);
+
+        $this->authorize('update', $valabilitate);
+
+        $alimentare->update($request->validated());
+
+        return redirect()
+            ->route('valabilitati.alimentari.index', $valabilitate)
+            ->with('status', 'Alimentarea a fost actualizată.');
+    }
+
+    public function destroy(
+        Valabilitate $valabilitate,
+        Alimentare $alimentare
+    ): RedirectResponse {
+        $this->assertBelongsToValabilitate($valabilitate, $alimentare);
+
+        $this->authorize('update', $valabilitate);
+
+        $alimentare->delete();
+
+        return redirect()
+            ->route('valabilitati.alimentari.index', $valabilitate)
+            ->with('status', 'Alimentarea a fost ștearsă.');
+    }
+
+    private function assertBelongsToValabilitate(Valabilitate $valabilitate, Alimentare $alimentare): void
+    {
+        if ($alimentare->valabilitate_id !== $valabilitate->getKey()) {
+            abort(404);
+        }
+    }
+
+    protected function perPage(): int
+    {
+        return self::PER_PAGE;
+    }
+
+    protected function displayGroupSummaryInResponses(): bool
+    {
+        return false;
+    }
+}

--- a/app/Http/Requests/ValabilitateAlimentareRequest.php
+++ b/app/Http/Requests/ValabilitateAlimentareRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ValabilitateAlimentareRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        return $valabilitate && $this->user()?->can('update', $valabilitate);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'data_ora_alimentare' => ['required', 'date'],
+            'litrii' => ['required', 'numeric', 'min:0'],
+            'pret_pe_litru' => ['required', 'numeric', 'min:0'],
+            'total_pret' => ['required', 'numeric', 'min:0'],
+            'observatii' => ['nullable', 'string'],
+        ];
+    }
+}

--- a/app/Models/Alimentare.php
+++ b/app/Models/Alimentare.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Alimentare extends Model
+{
+    use HasFactory;
+
+    protected $table = 'alimentari';
+
+    protected $fillable = [
+        'valabilitate_id',
+        'data_ora_alimentare',
+        'litrii',
+        'pret_pe_litru',
+        'total_pret',
+        'observatii',
+    ];
+
+    protected $casts = [
+        'data_ora_alimentare' => 'datetime',
+        'litrii' => 'decimal:2',
+        'pret_pe_litru' => 'decimal:2',
+        'total_pret' => 'decimal:2',
+    ];
+
+    public function valabilitate(): BelongsTo
+    {
+        return $this->belongsTo(Valabilitate::class);
+    }
+}

--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use App\Models\Alimentare;
 use App\Models\User;
 use App\Models\ValabilitateTaxaDrum;
 use App\Models\ValabilitateCursaGrup;
@@ -66,6 +67,13 @@ class Valabilitate extends Model
         return $this->hasMany(ValabilitateTaxaDrum::class)
             ->orderBy('data')
             ->orderBy('id');
+    }
+
+    public function alimentari(): HasMany
+    {
+        return $this->hasMany(Alimentare::class)
+            ->orderByDesc('data_ora_alimentare')
+            ->orderByDesc('id');
     }
 
     public function cursaGrupuri(): HasMany

--- a/database/migrations/2025_06_20_000001_create_alimentari_table.php
+++ b/database/migrations/2025_06_20_000001_create_alimentari_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('alimentari', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('valabilitate_id')->constrained('valabilitati')->cascadeOnDelete();
+            $table->dateTime('data_ora_alimentare');
+            $table->decimal('litrii', 10, 2);
+            $table->decimal('pret_pe_litru', 10, 2);
+            $table->decimal('total_pret', 12, 2);
+            $table->text('observatii')->nullable();
+            $table->timestamps();
+
+            $table->index('data_ora_alimentare');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('alimentari');
+    }
+};

--- a/resources/views/valabilitati/alimentari/index.blade.php
+++ b/resources/views/valabilitati/alimentari/index.blade.php
@@ -1,0 +1,330 @@
+@extends('layouts.app')
+
+@section('content')
+    <style>
+        .curse-summary-table,
+        .alimentari-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+
+        .alimentari-table th,
+        .alimentari-table td,
+        .curse-summary-table th,
+        .curse-summary-table td {
+            border: 1px solid #000000ff;
+            padding: 0.45rem 0.5rem;
+            vertical-align: middle;
+        }
+
+        .curse-summary-table th {
+            background-color: #f8f9fa;
+            font-weight: 600;
+        }
+
+        .alimentari-table thead th {
+            background-color: #6a6ba0;
+            color: #ffffff;
+            text-transform: uppercase;
+            font-size: 0.78rem;
+            letter-spacing: 0.02em;
+        }
+
+        .alimentari-table tbody tr:nth-child(even) {
+            background-color: #f8f9fa;
+        }
+
+        .alimentari-table .actions-column {
+            width: 160px;
+            white-space: nowrap;
+        }
+
+        .alimentari-form-label {
+            font-weight: 600;
+        }
+    </style>
+
+    @php
+        $curseRoute = route('valabilitati.curse.index', $valabilitate);
+        $grupuriRoute = route('valabilitati.grupuri.index', $valabilitate);
+        $alimentariRoute = route('valabilitati.alimentari.index', $valabilitate);
+    @endphp
+
+    <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
+        <div class="row card-header align-items-center text-center text-lg-start" style="border-radius: 40px 40px 0px 0px;">
+            <div class="col-12 col-lg-4 mb-2 mb-lg-0">
+                <span class="badge culoare1 fs-5">
+                    <span class="d-inline-flex flex-column align-items-start gap-1 lh-1">
+                        <span>
+                            <i class="fa-solid fa-route me-1"></i>Valabilitate
+                            /
+                            {{ $valabilitate->divizie->nume ?? 'Fără divizie' }}
+                        </span>
+                    </span>
+                </span>
+            </div>
+            <div class="col-12 col-lg-4 my-2 my-lg-0">
+                <div class="d-flex justify-content-center gap-2">
+                    <a
+                        href="{{ $curseRoute }}"
+                        class="btn btn-sm btn-outline-primary border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-truck-fast me-1"></i>Curse
+                    </a>
+                    <a
+                        href="{{ $grupuriRoute }}"
+                        class="btn btn-sm btn-outline-primary border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-layer-group me-1"></i>Grupuri
+                    </a>
+                    <a
+                        href="{{ $alimentariRoute }}"
+                        class="btn btn-sm btn-primary text-white border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-gas-pump me-1"></i>Alimentari
+                    </a>
+                </div>
+            </div>
+            <div class="col-12 col-lg-4 text-lg-end mt-3 mt-lg-0">
+                <div class="d-flex align-items-stretch align-items-lg-end gap-2 flex-wrap justify-content-center justify-content-lg-end">
+                    <a
+                        href="{{ $backUrl }}"
+                        class="btn btn-sm btn-outline-secondary border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-list me-1"></i>Înapoi la valabilități
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div class="card-body px-0 py-3">
+            @include('errors')
+            @if (session('status'))
+                <div class="alert alert-success mx-3">{{ session('status') }}</div>
+            @endif
+
+            <div id="alimentari-summary" class="px-3 mb-3">
+                @include('valabilitati.curse.partials.summary', [
+                    'valabilitate' => $valabilitate,
+                    'summary' => $summary,
+                    'showGroupSummary' => false,
+                    'isFlashDivision' => optional($valabilitate->divizie)->id === 1,
+                ])
+            </div>
+
+            <div class="px-3 mb-4">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">Adaugă alimentare</h5>
+                        <form method="POST" action="{{ route('valabilitati.alimentari.store', $valabilitate) }}">
+                            @csrf
+                            <div class="row g-3">
+                                <div class="col-12 col-lg-3">
+                                    <label class="form-label alimentari-form-label" for="data_ora_alimentare">Dată / oră alimentare</label>
+                                    <input
+                                        type="datetime-local"
+                                        name="data_ora_alimentare"
+                                        id="data_ora_alimentare"
+                                        class="form-control"
+                                        value="{{ old('data_ora_alimentare') }}"
+                                        required
+                                    >
+                                </div>
+                                <div class="col-12 col-lg-3">
+                                    <label class="form-label alimentari-form-label" for="litrii">Litrii</label>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        name="litrii"
+                                        id="litrii"
+                                        class="form-control"
+                                        value="{{ old('litrii') }}"
+                                        required
+                                    >
+                                </div>
+                                <div class="col-12 col-lg-3">
+                                    <label class="form-label alimentari-form-label" for="pret_pe_litru">Preț / litru</label>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        name="pret_pe_litru"
+                                        id="pret_pe_litru"
+                                        class="form-control"
+                                        value="{{ old('pret_pe_litru') }}"
+                                        required
+                                    >
+                                </div>
+                                <div class="col-12 col-lg-3">
+                                    <label class="form-label alimentari-form-label" for="total_pret">Total preț</label>
+                                    <input
+                                        type="number"
+                                        step="0.01"
+                                        min="0"
+                                        name="total_pret"
+                                        id="total_pret"
+                                        class="form-control"
+                                        value="{{ old('total_pret') }}"
+                                        required
+                                    >
+                                </div>
+                                <div class="col-12">
+                                    <label class="form-label alimentari-form-label" for="observatii">Observații</label>
+                                    <textarea
+                                        name="observatii"
+                                        id="observatii"
+                                        class="form-control"
+                                        rows="2"
+                                        placeholder="Opțional"
+                                    >{{ old('observatii') }}</textarea>
+                                </div>
+                            </div>
+                            <div class="d-flex justify-content-end mt-3">
+                                <button type="submit" class="btn btn-success text-white border border-dark">
+                                    <i class="fas fa-plus-square text-white me-1"></i>Salvează alimentarea
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            <div class="px-3">
+                <div class="table-responsive">
+                    <table class="table table-sm alimentari-table align-middle">
+                        <thead>
+                            <tr>
+                                <th>Dată / oră alimentare</th>
+                                <th class="text-end">Litrii</th>
+                                <th class="text-end">Preț / litru</th>
+                                <th class="text-end">Total preț</th>
+                                <th>Observații</th>
+                                <th class="actions-column text-center">Acțiuni</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($alimentari as $alimentare)
+                                <tr>
+                                    <td class="fw-semibold">{{ optional($alimentare->data_ora_alimentare)->format('d.m.Y H:i') }}</td>
+                                    <td class="text-end">{{ number_format((float) $alimentare->litrii, 2) }}</td>
+                                    <td class="text-end">{{ number_format((float) $alimentare->pret_pe_litru, 2) }}</td>
+                                    <td class="text-end">{{ number_format((float) $alimentare->total_pret, 2) }}</td>
+                                    <td>{{ $alimentare->observatii ?? '—' }}</td>
+                                    <td class="text-center">
+                                        <button
+                                            class="btn btn-sm btn-outline-primary border border-dark me-2"
+                                            type="button"
+                                            data-bs-toggle="collapse"
+                                            data-bs-target="#alimentare-edit-{{ $alimentare->id }}"
+                                            aria-expanded="false"
+                                            aria-controls="alimentare-edit-{{ $alimentare->id }}"
+                                        >
+                                            <i class="fa-solid fa-pen-to-square me-1"></i>Editează
+                                        </button>
+                                        <form
+                                            method="POST"
+                                            action="{{ route('valabilitati.alimentari.destroy', [$valabilitate, $alimentare]) }}"
+                                            class="d-inline"
+                                            onsubmit="return confirm('Sigur ștergi această alimentare?');"
+                                        >
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="btn btn-sm btn-outline-danger border border-dark">
+                                                <i class="fa-solid fa-trash me-1"></i>Șterge
+                                            </button>
+                                        </form>
+                                    </td>
+                                </tr>
+                                <tr class="collapse" id="alimentare-edit-{{ $alimentare->id }}">
+                                    <td colspan="6" class="bg-light">
+                                        <form method="POST" action="{{ route('valabilitati.alimentari.update', [$valabilitate, $alimentare]) }}">
+                                            @csrf
+                                            @method('PUT')
+                                            <div class="row g-3">
+                                                <div class="col-12 col-lg-3">
+                                                    <label class="form-label alimentari-form-label" for="data_ora_alimentare_{{ $alimentare->id }}">Dată / oră alimentare</label>
+                                                    <input
+                                                        type="datetime-local"
+                                                        name="data_ora_alimentare"
+                                                        id="data_ora_alimentare_{{ $alimentare->id }}"
+                                                        class="form-control"
+                                                        value="{{ optional($alimentare->data_ora_alimentare)->format('Y-m-d\\TH:i') }}"
+                                                        required
+                                                    >
+                                                </div>
+                                                <div class="col-12 col-lg-3">
+                                                    <label class="form-label alimentari-form-label" for="litrii_{{ $alimentare->id }}">Litrii</label>
+                                                    <input
+                                                        type="number"
+                                                        step="0.01"
+                                                        min="0"
+                                                        name="litrii"
+                                                        id="litrii_{{ $alimentare->id }}"
+                                                        class="form-control"
+                                                        value="{{ $alimentare->litrii }}"
+                                                        required
+                                                    >
+                                                </div>
+                                                <div class="col-12 col-lg-3">
+                                                    <label class="form-label alimentari-form-label" for="pret_pe_litru_{{ $alimentare->id }}">Preț / litru</label>
+                                                    <input
+                                                        type="number"
+                                                        step="0.01"
+                                                        min="0"
+                                                        name="pret_pe_litru"
+                                                        id="pret_pe_litru_{{ $alimentare->id }}"
+                                                        class="form-control"
+                                                        value="{{ $alimentare->pret_pe_litru }}"
+                                                        required
+                                                    >
+                                                </div>
+                                                <div class="col-12 col-lg-3">
+                                                    <label class="form-label alimentari-form-label" for="total_pret_{{ $alimentare->id }}">Total preț</label>
+                                                    <input
+                                                        type="number"
+                                                        step="0.01"
+                                                        min="0"
+                                                        name="total_pret"
+                                                        id="total_pret_{{ $alimentare->id }}"
+                                                        class="form-control"
+                                                        value="{{ $alimentare->total_pret }}"
+                                                        required
+                                                    >
+                                                </div>
+                                                <div class="col-12">
+                                                    <label class="form-label alimentari-form-label" for="observatii_{{ $alimentare->id }}">Observații</label>
+                                                    <textarea
+                                                        name="observatii"
+                                                        id="observatii_{{ $alimentare->id }}"
+                                                        class="form-control"
+                                                        rows="2"
+                                                        placeholder="Opțional"
+                                                    >{{ $alimentare->observatii }}</textarea>
+                                                </div>
+                                            </div>
+                                            <div class="d-flex justify-content-end mt-3">
+                                                <button type="submit" class="btn btn-primary border border-dark">
+                                                    <i class="fa-solid fa-floppy-disk me-1"></i>Actualizează
+                                                </button>
+                                            </div>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="text-center py-4">Nu există alimentări salvate.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="mt-3">
+                    {{ $alimentari->links() }}
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -125,7 +125,10 @@
     @php
         $grupuriRoute = route('valabilitati.grupuri.index', $valabilitate);
         $curseRoute = route('valabilitati.curse.index', $valabilitate);
+        $alimentariRoute = route('valabilitati.alimentari.index', $valabilitate);
         $isGroupsContext = request()->routeIs('valabilitati.grupuri.*');
+        $isAlimentariContext = request()->routeIs('valabilitati.alimentari.*');
+        $isCurseContext = ! ($isGroupsContext || $isAlimentariContext);
         $hasGrupuri = $valabilitate->cursaGrupuri->count() > 0;
         $isFlashDivision = optional($valabilitate->divizie)->id === 1
             && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
@@ -148,7 +151,7 @@
                 <div class="d-flex justify-content-center gap-2">
                     <a
                         href="{{ $curseRoute }}"
-                        class="btn btn-sm {{ $isGroupsContext ? 'btn-outline-primary' : 'btn-primary text-white' }} border border-dark rounded-3"
+                        class="btn btn-sm {{ $isCurseContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
                     >
                         <i class="fa-solid fa-truck-fast me-1"></i>Curse
                     </a>
@@ -157,6 +160,12 @@
                         class="btn btn-sm {{ $isGroupsContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
                     >
                         <i class="fa-solid fa-layer-group me-1"></i>Grupuri
+                    </a>
+                    <a
+                        href="{{ $alimentariRoute }}"
+                        class="btn btn-sm {{ $isAlimentariContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-gas-pump me-1"></i>Alimentari
                     </a>
                 </div>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,7 @@ use App\Http\Controllers\SoferValabilitateCursaController;
 use App\Http\Controllers\ValabilitateController;
 use App\Http\Controllers\ValabilitateCursaController;
 use App\Http\Controllers\ValabilitateCursaGrupController;
+use App\Http\Controllers\ValabilitateAlimentareController;
 use App\Http\Controllers\ValabilitatiDivizieController;
 
 
@@ -372,6 +373,8 @@ Route::middleware(['auth'])->group(function () {
                 ->name('valabilitati.curse.paginate');
             Route::get('valabilitati/{valabilitate}/curse', [ValabilitateCursaController::class, 'index'])
                 ->name('valabilitati.curse.index');
+            Route::get('valabilitati/{valabilitate}/alimentari', [ValabilitateAlimentareController::class, 'index'])
+                ->name('valabilitati.alimentari.index');
             Route::get('valabilitati/{valabilitate}/grupuri', [ValabilitateCursaGrupController::class, 'index'])
                 ->name('valabilitati.grupuri.index');
             Route::post('valabilitati/{valabilitate}/curse/bulk-assign', [ValabilitateCursaController::class, 'bulkAssign'])
@@ -384,6 +387,13 @@ Route::middleware(['auth'])->group(function () {
                 ->name('valabilitati.curse.reorder');
             Route::delete('valabilitati/{valabilitate}/curse/{cursa}', [ValabilitateCursaController::class, 'destroy'])
                 ->name('valabilitati.curse.destroy');
+
+            Route::post('valabilitati/{valabilitate}/alimentari', [ValabilitateAlimentareController::class, 'store'])
+                ->name('valabilitati.alimentari.store');
+            Route::put('valabilitati/{valabilitate}/alimentari/{alimentare}', [ValabilitateAlimentareController::class, 'update'])
+                ->name('valabilitati.alimentari.update');
+            Route::delete('valabilitati/{valabilitate}/alimentari/{alimentare}', [ValabilitateAlimentareController::class, 'destroy'])
+                ->name('valabilitati.alimentari.destroy');
 
             Route::post('valabilitati/{valabilitate}/curse/grupuri', [ValabilitateCursaGrupController::class, 'store'])
                 ->name('valabilitati.curse.grupuri.store');


### PR DESCRIPTION
## Summary
- add Alimentare model, request, and controller with valabilitate-scoped CRUD routes
- introduce migration for alimentari records tied to each valabilitate
- provide Alimentari UI with create/edit/delete flows and navigation link from valabilitate pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef829caf08326a0c2414b2aa63ee6)