### PR TITLE
Use modals for valabilitate alimentari forms

### DIFF
--- a/resources/views/valabilitati/alimentari/index.blade.php
+++ b/resources/views/valabilitati/alimentari/index.blade.php
@@ -40,6 +40,10 @@
             white-space: nowrap;
         }
 
+        .alimentari-actions {
+            gap: 0.5rem;
+        }
+
         .alimentari-form-label {
             font-weight: 600;
         }
@@ -88,6 +92,14 @@
             </div>
             <div class="col-12 col-lg-4 text-lg-end mt-3 mt-lg-0">
                 <div class="d-flex align-items-stretch align-items-lg-end gap-2 flex-wrap justify-content-center justify-content-lg-end">
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-success text-white border border-dark rounded-3"
+                        data-bs-toggle="modal"
+                        data-bs-target="#alimentareCreateModal"
+                    >
+                        <i class="fas fa-plus-square text-white me-1"></i>Adaugă alimentare
+                    </button>
                     <a
                         href="{{ $backUrl }}"
                         class="btn btn-sm btn-outline-secondary border border-dark rounded-3"
@@ -113,84 +125,6 @@
                 ])
             </div>
 
-            <div class="px-3 mb-4">
-                <div class="card">
-                    <div class="card-body">
-                        <h5 class="card-title">Adaugă alimentare</h5>
-                        <form method="POST" action="{{ route('valabilitati.alimentari.store', $valabilitate) }}">
-                            @csrf
-                            <div class="row g-3">
-                                <div class="col-12 col-lg-3">
-                                    <label class="form-label alimentari-form-label" for="data_ora_alimentare">Dată / oră alimentare</label>
-                                    <input
-                                        type="datetime-local"
-                                        name="data_ora_alimentare"
-                                        id="data_ora_alimentare"
-                                        class="form-control"
-                                        value="{{ old('data_ora_alimentare') }}"
-                                        required
-                                    >
-                                </div>
-                                <div class="col-12 col-lg-3">
-                                    <label class="form-label alimentari-form-label" for="litrii">Litrii</label>
-                                    <input
-                                        type="number"
-                                        step="0.01"
-                                        min="0"
-                                        name="litrii"
-                                        id="litrii"
-                                        class="form-control"
-                                        value="{{ old('litrii') }}"
-                                        required
-                                    >
-                                </div>
-                                <div class="col-12 col-lg-3">
-                                    <label class="form-label alimentari-form-label" for="pret_pe_litru">Preț / litru</label>
-                                    <input
-                                        type="number"
-                                        step="0.0001"
-                                        min="0"
-                                        name="pret_pe_litru"
-                                        id="pret_pe_litru"
-                                        class="form-control"
-                                        value="{{ old('pret_pe_litru') }}"
-                                        required
-                                    >
-                                </div>
-                                <div class="col-12 col-lg-3">
-                                    <label class="form-label alimentari-form-label" for="total_pret">Total preț</label>
-                                    <input
-                                        type="number"
-                                        step="0.0001"
-                                        min="0"
-                                        name="total_pret"
-                                        id="total_pret"
-                                        class="form-control"
-                                        value="{{ old('total_pret') }}"
-                                        required
-                                    >
-                                </div>
-                                <div class="col-12">
-                                    <label class="form-label alimentari-form-label" for="observatii">Observații</label>
-                                    <textarea
-                                        name="observatii"
-                                        id="observatii"
-                                        class="form-control"
-                                        rows="2"
-                                        placeholder="Opțional"
-                                    >{{ old('observatii') }}</textarea>
-                                </div>
-                            </div>
-                            <div class="d-flex justify-content-end mt-3">
-                                <button type="submit" class="btn btn-success text-white border border-dark">
-                                    <i class="fas fa-plus-square text-white me-1"></i>Salvează alimentarea
-                                </button>
-                            </div>
-                        </form>
-                    </div>
-                </div>
-            </div>
-
             <div class="px-3">
                 <div class="table-responsive">
                     <table class="table table-sm alimentari-table align-middle">
@@ -213,103 +147,28 @@
                                     <td class="text-end">{{ number_format((float) $alimentare->total_pret, 4) }}</td>
                                     <td>{{ $alimentare->observatii ?? '—' }}</td>
                                     <td class="text-center">
-                                        <button
-                                            class="btn btn-sm btn-outline-primary border border-dark me-2"
-                                            type="button"
-                                            data-bs-toggle="collapse"
-                                            data-bs-target="#alimentare-edit-{{ $alimentare->id }}"
-                                            aria-expanded="false"
-                                            aria-controls="alimentare-edit-{{ $alimentare->id }}"
-                                        >
-                                            <i class="fa-solid fa-pen-to-square me-1"></i>Editează
-                                        </button>
-                                        <form
-                                            method="POST"
-                                            action="{{ route('valabilitati.alimentari.destroy', [$valabilitate, $alimentare]) }}"
-                                            class="d-inline"
-                                            onsubmit="return confirm('Sigur ștergi această alimentare?');"
-                                        >
-                                            @csrf
-                                            @method('DELETE')
-                                            <button type="submit" class="btn btn-sm btn-outline-danger border border-dark">
-                                                <i class="fa-solid fa-trash me-1"></i>Șterge
+                                        <div class="d-flex justify-content-center flex-wrap alimentari-actions">
+                                            <button
+                                                class="btn btn-sm btn-outline-primary border border-dark"
+                                                type="button"
+                                                data-bs-toggle="modal"
+                                                data-bs-target="#alimentareEditModal-{{ $alimentare->id }}"
+                                            >
+                                                <i class="fa-solid fa-pen-to-square me-1"></i>Editează
                                             </button>
-                                        </form>
-                                    </td>
-                                </tr>
-                                <tr class="collapse" id="alimentare-edit-{{ $alimentare->id }}">
-                                    <td colspan="6" class="bg-light">
-                                        <form method="POST" action="{{ route('valabilitati.alimentari.update', [$valabilitate, $alimentare]) }}">
-                                            @csrf
-                                            @method('PUT')
-                                            <div class="row g-3">
-                                                <div class="col-12 col-lg-3">
-                                                    <label class="form-label alimentari-form-label" for="data_ora_alimentare_{{ $alimentare->id }}">Dată / oră alimentare</label>
-                                                    <input
-                                                        type="datetime-local"
-                                                        name="data_ora_alimentare"
-                                                        id="data_ora_alimentare_{{ $alimentare->id }}"
-                                                        class="form-control"
-                                                        value="{{ optional($alimentare->data_ora_alimentare)->format('Y-m-d\\TH:i') }}"
-                                                        required
-                                                    >
-                                                </div>
-                                                <div class="col-12 col-lg-3">
-                                                    <label class="form-label alimentari-form-label" for="litrii_{{ $alimentare->id }}">Litrii</label>
-                                                    <input
-                                                        type="number"
-                                                        step="0.01"
-                                                        min="0"
-                                                        name="litrii"
-                                                        id="litrii_{{ $alimentare->id }}"
-                                                        class="form-control"
-                                                        value="{{ $alimentare->litrii }}"
-                                                        required
-                                                    >
-                                                </div>
-                                                <div class="col-12 col-lg-3">
-                                                    <label class="form-label alimentari-form-label" for="pret_pe_litru_{{ $alimentare->id }}">Preț / litru</label>
-                                                    <input
-                                                        type="number"
-                                                        step="0.0001"
-                                                        min="0"
-                                                        name="pret_pe_litru"
-                                                        id="pret_pe_litru_{{ $alimentare->id }}"
-                                                        class="form-control"
-                                                        value="{{ $alimentare->pret_pe_litru }}"
-                                                        required
-                                                    >
-                                                </div>
-                                                <div class="col-12 col-lg-3">
-                                                    <label class="form-label alimentari-form-label" for="total_pret_{{ $alimentare->id }}">Total preț</label>
-                                                    <input
-                                                        type="number"
-                                                        step="0.0001"
-                                                        min="0"
-                                                        name="total_pret"
-                                                        id="total_pret_{{ $alimentare->id }}"
-                                                        class="form-control"
-                                                        value="{{ $alimentare->total_pret }}"
-                                                        required
-                                                    >
-                                                </div>
-                                                <div class="col-12">
-                                                    <label class="form-label alimentari-form-label" for="observatii_{{ $alimentare->id }}">Observații</label>
-                                                    <textarea
-                                                        name="observatii"
-                                                        id="observatii_{{ $alimentare->id }}"
-                                                        class="form-control"
-                                                        rows="2"
-                                                        placeholder="Opțional"
-                                                    >{{ $alimentare->observatii }}</textarea>
-                                                </div>
-                                            </div>
-                                            <div class="d-flex justify-content-end mt-3">
-                                                <button type="submit" class="btn btn-primary border border-dark">
-                                                    <i class="fa-solid fa-floppy-disk me-1"></i>Actualizează
+                                            <form
+                                                method="POST"
+                                                action="{{ route('valabilitati.alimentari.destroy', [$valabilitate, $alimentare]) }}"
+                                                class="d-inline"
+                                                onsubmit="return confirm('Sigur ștergi această alimentare?');"
+                                            >
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-sm btn-outline-danger border border-dark">
+                                                    <i class="fa-solid fa-trash me-1"></i>Șterge
                                                 </button>
-                                            </div>
-                                        </form>
+                                            </form>
+                                        </div>
                                     </td>
                                 </tr>
                             @empty
@@ -325,6 +184,195 @@
                     {{ $alimentari->links() }}
                 </div>
             </div>
+
+            {{-- Create modal --}}
+            <div
+                class="modal fade"
+                id="alimentareCreateModal"
+                tabindex="-1"
+                aria-labelledby="alimentareCreateModalLabel"
+                aria-hidden="true"
+            >
+                <div class="modal-dialog modal-lg modal-dialog-centered">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="alimentareCreateModalLabel">Adaugă alimentare</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <form method="POST" action="{{ route('valabilitati.alimentari.store', $valabilitate) }}">
+                            @csrf
+                            <div class="modal-body">
+                                <div class="row g-3">
+                                    <div class="col-12 col-lg-3">
+                                        <label class="form-label alimentari-form-label" for="data_ora_alimentare">Dată / oră alimentare</label>
+                                        <input
+                                            type="datetime-local"
+                                            name="data_ora_alimentare"
+                                            id="data_ora_alimentare"
+                                            class="form-control"
+                                            value="{{ old('data_ora_alimentare') }}"
+                                            required
+                                        >
+                                    </div>
+                                    <div class="col-12 col-lg-3">
+                                        <label class="form-label alimentari-form-label" for="litrii">Litrii</label>
+                                        <input
+                                            type="number"
+                                            step="0.01"
+                                            min="0"
+                                            name="litrii"
+                                            id="litrii"
+                                            class="form-control"
+                                            value="{{ old('litrii') }}"
+                                            required
+                                        >
+                                    </div>
+                                    <div class="col-12 col-lg-3">
+                                        <label class="form-label alimentari-form-label" for="pret_pe_litru">Preț / litru</label>
+                                        <input
+                                            type="number"
+                                            step="0.0001"
+                                            min="0"
+                                            name="pret_pe_litru"
+                                            id="pret_pe_litru"
+                                            class="form-control"
+                                            value="{{ old('pret_pe_litru') }}"
+                                            required
+                                        >
+                                    </div>
+                                    <div class="col-12 col-lg-3">
+                                        <label class="form-label alimentari-form-label" for="total_pret">Total preț</label>
+                                        <input
+                                            type="number"
+                                            step="0.0001"
+                                            min="0"
+                                            name="total_pret"
+                                            id="total_pret"
+                                            class="form-control"
+                                            value="{{ old('total_pret') }}"
+                                            required
+                                        >
+                                    </div>
+                                    <div class="col-12">
+                                        <label class="form-label alimentari-form-label" for="observatii">Observații</label>
+                                        <textarea
+                                            name="observatii"
+                                            id="observatii"
+                                            class="form-control"
+                                            rows="2"
+                                            placeholder="Opțional"
+                                        >{{ old('observatii') }}</textarea>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Renunță</button>
+                                <button type="submit" class="btn btn-success text-white border border-dark">
+                                    <i class="fas fa-plus-square text-white me-1"></i>Salvează alimentarea
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            </div>
+
+            {{-- Edit modals --}}
+            @foreach ($alimentari as $alimentare)
+                @php
+                    $shouldPrefillFromOld = (int) old('alimentare_id') === $alimentare->id;
+                @endphp
+                <div
+                    class="modal fade"
+                    id="alimentareEditModal-{{ $alimentare->id }}"
+                    tabindex="-1"
+                    aria-labelledby="alimentareEditModalLabel-{{ $alimentare->id }}"
+                    aria-hidden="true"
+                >
+                    <div class="modal-dialog modal-lg modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="alimentareEditModalLabel-{{ $alimentare->id }}">Editează alimentarea</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <form method="POST" action="{{ route('valabilitati.alimentari.update', [$valabilitate, $alimentare]) }}">
+                                @csrf
+                                @method('PUT')
+                                <input type="hidden" name="alimentare_id" value="{{ $alimentare->id }}">
+                                <div class="modal-body">
+                                    <div class="row g-3">
+                                        <div class="col-12 col-lg-3">
+                                            <label class="form-label alimentari-form-label" for="data_ora_alimentare_{{ $alimentare->id }}">Dată / oră alimentare</label>
+                                            <input
+                                                type="datetime-local"
+                                                name="data_ora_alimentare"
+                                                id="data_ora_alimentare_{{ $alimentare->id }}"
+                                                class="form-control"
+                                                value="{{ $shouldPrefillFromOld ? old('data_ora_alimentare') : optional($alimentare->data_ora_alimentare)->format('Y-m-d\\TH:i') }}"
+                                                required
+                                            >
+                                        </div>
+                                        <div class="col-12 col-lg-3">
+                                            <label class="form-label alimentari-form-label" for="litrii_{{ $alimentare->id }}">Litrii</label>
+                                            <input
+                                                type="number"
+                                                step="0.01"
+                                                min="0"
+                                                name="litrii"
+                                                id="litrii_{{ $alimentare->id }}"
+                                                class="form-control"
+                                                value="{{ $shouldPrefillFromOld ? old('litrii') : $alimentare->litrii }}"
+                                                required
+                                            >
+                                        </div>
+                                        <div class="col-12 col-lg-3">
+                                            <label class="form-label alimentari-form-label" for="pret_pe_litru_{{ $alimentare->id }}">Preț / litru</label>
+                                            <input
+                                                type="number"
+                                                step="0.0001"
+                                                min="0"
+                                                name="pret_pe_litru"
+                                                id="pret_pe_litru_{{ $alimentare->id }}"
+                                                class="form-control"
+                                                value="{{ $shouldPrefillFromOld ? old('pret_pe_litru') : $alimentare->pret_pe_litru }}"
+                                                required
+                                            >
+                                        </div>
+                                        <div class="col-12 col-lg-3">
+                                            <label class="form-label alimentari-form-label" for="total_pret_{{ $alimentare->id }}">Total preț</label>
+                                            <input
+                                                type="number"
+                                                step="0.0001"
+                                                min="0"
+                                                name="total_pret"
+                                                id="total_pret_{{ $alimentare->id }}"
+                                                class="form-control"
+                                                value="{{ $shouldPrefillFromOld ? old('total_pret') : $alimentare->total_pret }}"
+                                                required
+                                            >
+                                        </div>
+                                        <div class="col-12">
+                                            <label class="form-label alimentari-form-label" for="observatii_{{ $alimentare->id }}">Observații</label>
+                                            <textarea
+                                                name="observatii"
+                                                id="observatii_{{ $alimentare->id }}"
+                                                class="form-control"
+                                                rows="2"
+                                                placeholder="Opțional"
+                                            >{{ $shouldPrefillFromOld ? old('observatii') : $alimentare->observatii }}</textarea>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Renunță</button>
+                                    <button type="submit" class="btn btn-primary border border-dark">
+                                        <i class="fa-solid fa-floppy-disk me-1"></i>Actualizează
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
         </div>
     </div>
 @endsection


### PR DESCRIPTION
## Summary
- add header action button to open create alimentare modal
- move create and edit alimentare forms into bootstrap modals
- adjust action buttons layout for alimentari rows

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0382a3fc8326bad2e532d7caf94a)