### PR TITLE
Fix duplicate status alert on alimentari page

### DIFF
--- a/resources/views/valabilitati/alimentari/index.blade.php
+++ b/resources/views/valabilitati/alimentari/index.blade.php
@@ -124,9 +124,6 @@
 
         <div class="card-body px-0 py-3">
             @include('errors')
-            @if (session('status'))
-                <div class="alert alert-success mx-3">{{ session('status') }}</div>
-            @endif
 
             <div id="alimentari-summary" class="px-3 mb-3">
                 @include('valabilitati.curse.partials.summary', [


### PR DESCRIPTION
## Summary
- remove duplicate success message rendering on alimentari page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1c599fcc8326bedd901293b615bd)