### PR TITLE
Add alimentari navigation links for valabilitati pages

### DIFF
--- a/resources/views/valabilitati/grupuri/index.blade.php
+++ b/resources/views/valabilitati/grupuri/index.blade.php
@@ -42,6 +42,10 @@
     @php
         $grupuriRoute = route('valabilitati.grupuri.index', $valabilitate);
         $curseRoute = route('valabilitati.curse.index', $valabilitate);
+        $alimentariRoute = route('valabilitati.alimentari.index', $valabilitate);
+        $isGroupsContext = request()->routeIs('valabilitati.grupuri.*');
+        $isCurseContext = request()->routeIs('valabilitati.curse.*');
+        $isAlimentariContext = request()->routeIs('valabilitati.alimentari.*');
         $resolveRowTextColor = static function ($value): string {
             if (! is_string($value) || $value === '') {
                 return '#111111';
@@ -98,15 +102,21 @@
                 <div class="d-flex justify-content-center gap-2">
                     <a
                         href="{{ $curseRoute }}"
-                        class="btn btn-sm btn-outline-primary border border-dark rounded-3"
+                        class="btn btn-sm {{ $isCurseContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
                     >
                         <i class="fa-solid fa-truck-fast me-1"></i>Curse
                     </a>
                     <a
                         href="{{ $grupuriRoute }}"
-                        class="btn btn-sm btn-primary text-white border border-dark rounded-3"
+                        class="btn btn-sm {{ $isGroupsContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
                     >
                         <i class="fa-solid fa-layer-group me-1"></i>Grupuri
+                    </a>
+                    <a
+                        href="{{ $alimentariRoute }}"
+                        class="btn btn-sm {{ $isAlimentariContext ? 'btn-primary text-white' : 'btn-outline-primary' }} border border-dark rounded-3"
+                    >
+                        <i class="fa-solid fa-gas-pump me-1"></i>Alimentari
                     </a>
                 </div>
             </div>

--- a/resources/views/valabilitati/partials/rows.blade.php
+++ b/resources/views/valabilitati/partials/rows.blade.php
@@ -42,6 +42,11 @@
                     </a>
                 </div>
                 <div class="ms-1">
+                    <a href="{{ route('valabilitati.alimentari.index', $valabilitate) }}" class="flex">
+                        <span class="badge bg-warning text-dark">Alimentari</span>
+                    </a>
+                </div>
+                <div class="ms-1">
                     <a href="{{ route('valabilitati.show', $valabilitate) }}" class="flex">
                         <span class="badge bg-success">Vezi</span>
                     </a>


### PR DESCRIPTION
## Summary
- add an Alimentari navigation button alongside existing Curse and Grupuri actions on the valabilitati grupuri page
- provide a direct Alimentari access badge next to the Curse link in the valabilitati listings

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1dc1233c8326b887db340ada97b5)