### PR TITLE
Add confirmation modals for course reordering

### DIFF
--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -756,6 +756,9 @@
         if ($editCursaGrupId === null) {
             $editCursaGrupId = '';
         }
+        $hasMultipleCurse = $loop->count > 1;
+        $canMoveUp = $hasMultipleCurse && ! $loop->first;
+        $canMoveDown = $hasMultipleCurse && ! $loop->last;
     @endphp
     <div
         class="modal fade text-dark"
@@ -1222,6 +1225,80 @@
             </div>
         </div>
     </div>
+
+    @if ($hasMultipleCurse)
+        <div
+            class="modal fade text-dark"
+            id="cursaMoveUpModal{{ $cursa->id }}"
+            tabindex="-1"
+            role="dialog"
+            aria-labelledby="cursaMoveUpModalLabel{{ $cursa->id }}"
+            aria-hidden="true"
+        >
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header bg-secondary text-white">
+                        <h5 class="modal-title" id="cursaMoveUpModalLabel{{ $cursa->id }}">Mută cursa mai sus</h5>
+                        <button type="button" class="btn-close bg-white" data-bs-dismiss="modal" aria-label="Închide"></button>
+                    </div>
+                    <form
+                        action="{{ route('valabilitati.curse.reorder', [$valabilitate, $cursa]) }}"
+                        method="POST"
+                        class="curse-modal-form"
+                    >
+                        @csrf
+                        @method('PATCH')
+                        <input type="hidden" name="direction" value="up">
+                        <div class="modal-body">
+                            Ești sigur că dorești să muți această cursă mai sus?
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                            <button type="submit" class="btn btn-secondary text-white border border-dark rounded-3" @disabled(! $canMoveUp)>
+                                <i class="fa-solid fa-arrow-up me-1"></i>Mută mai sus
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <div
+            class="modal fade text-dark"
+            id="cursaMoveDownModal{{ $cursa->id }}"
+            tabindex="-1"
+            role="dialog"
+            aria-labelledby="cursaMoveDownModalLabel{{ $cursa->id }}"
+            aria-hidden="true"
+        >
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header bg-secondary text-white">
+                        <h5 class="modal-title" id="cursaMoveDownModalLabel{{ $cursa->id }}">Mută cursa mai jos</h5>
+                        <button type="button" class="btn-close bg-white" data-bs-dismiss="modal" aria-label="Închide"></button>
+                    </div>
+                    <form
+                        action="{{ route('valabilitati.curse.reorder', [$valabilitate, $cursa]) }}"
+                        method="POST"
+                        class="curse-modal-form"
+                    >
+                        @csrf
+                        @method('PATCH')
+                        <input type="hidden" name="direction" value="down">
+                        <div class="modal-body">
+                            Ești sigur că dorești să muți această cursă mai jos?
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                            <button type="submit" class="btn btn-secondary text-white border border-dark rounded-3" @disabled(! $canMoveDown)>
+                                <i class="fa-solid fa-arrow-down me-1"></i>Mută mai jos
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    @endif
 
     <div
         class="modal fade text-dark"

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -253,40 +253,26 @@
                 <div class="d-flex align-items-center gap-2 fw-semibold">
                     @if ($hasMultipleCurse)
                         <div class="d-flex gap-1">
-                            <form
-                                method="POST"
-                                action="{{ route('valabilitati.curse.reorder', [$valabilitate, $cursa]) }}"
-                                class="mb-0"
+                            <button
+                                type="button"
+                                class="btn btn-sm btn-outline-secondary p-0"
+                                data-bs-toggle="modal"
+                                data-bs-target="#cursaMoveUpModal{{ $cursa->id }}"
+                                title="Mută cursa mai sus"
+                                @disabled(! $canMoveUp)
                             >
-                                @csrf
-                                @method('PATCH')
-                                <input type="hidden" name="direction" value="up">
-                                <button
-                                    type="submit"
-                                    class="btn btn-sm btn-outline-secondary p-0"
-                                    title="Mută cursa mai sus"
-                                    @disabled(! $canMoveUp)
-                                >
-                                    <i class="fa-solid fa-arrow-up"></i>
-                                </button>
-                            </form>
-                            <form
-                                method="POST"
-                                action="{{ route('valabilitati.curse.reorder', [$valabilitate, $cursa]) }}"
-                                class="mb-0"
+                                <i class="fa-solid fa-arrow-up"></i>
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-sm btn-outline-secondary p-0"
+                                data-bs-toggle="modal"
+                                data-bs-target="#cursaMoveDownModal{{ $cursa->id }}"
+                                title="Mută cursa mai jos"
+                                @disabled(! $canMoveDown)
                             >
-                                @csrf
-                                @method('PATCH')
-                                <input type="hidden" name="direction" value="down">
-                                <button
-                                    type="submit"
-                                    class="btn btn-sm btn-outline-secondary p-0"
-                                    title="Mută cursa mai jos"
-                                    @disabled(! $canMoveDown)
-                                >
-                                    <i class="fa-solid fa-arrow-down"></i>
-                                </button>
-                            </form>
+                                <i class="fa-solid fa-arrow-down"></i>
+                            </button>
                         </div>
                     @endif
                 </div>


### PR DESCRIPTION
## Summary
- replace inline reorder forms with modal triggers for moving courses up or down
- add Bootstrap confirmation modals that submit the reorder requests via the existing AJAX form flow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692344c1f57c832692391ef62203de61)