### PR TITLE
Use split km maps for all divisions

### DIFF
--- a/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
+++ b/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
@@ -110,13 +110,6 @@ trait HandlesValabilitatiCurseListings
             ? (float) $kmSosire - (float) $kmPlecare
             : null;
 
-        $kmMapsValues = $curseCollection
-            ->pluck('km_maps')
-            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
-            ->map(static fn ($value) => (float) $value);
-
-        $totalKmMaps = $kmMapsValues->sum();
-
         $kmMapsGolValues = $curseCollection
             ->pluck('km_maps_gol')
             ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
@@ -128,6 +121,16 @@ trait HandlesValabilitatiCurseListings
             ->pluck('km_maps_plin')
             ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
             ->map(static fn ($value) => (float) $value);
+
+        $kmMapsValues = $curseCollection
+            ->pluck('km_maps')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value);
+
+        $hasSplitMaps = $kmMapsGolValues->isNotEmpty() || $kmMapsPlinValues->isNotEmpty();
+        $totalKmMapsSplit = $kmMapsGolValues->sum() + $kmMapsPlinValues->sum();
+        $totalKmMapsSingle = $kmMapsValues->sum();
+        $totalKmMaps = $hasSplitMaps ? $totalKmMapsSplit : $totalKmMapsSingle;
 
         $totalKmMapsPlin = $kmMapsPlinValues->sum();
 
@@ -169,11 +172,18 @@ trait HandlesValabilitatiCurseListings
                 $end = $cursa->km_bord_descarcare !== null && $cursa->km_bord_descarcare !== ''
                     ? (float) $cursa->km_bord_descarcare
                     : null;
-                $maps = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
+                $mapsTotal = null;
+                $mapsGol = is_numeric($cursa->km_maps_gol) ? (float) $cursa->km_maps_gol : null;
+                $mapsPlin = is_numeric($cursa->km_maps_plin) ? (float) $cursa->km_maps_plin : null;
+                if ($mapsGol !== null || $mapsPlin !== null) {
+                    $mapsTotal = ($mapsGol ?? 0) + ($mapsPlin ?? 0);
+                } elseif (is_numeric($cursa->km_maps)) {
+                    $mapsTotal = (float) $cursa->km_maps;
+                }
 
                 $bord2 = $start !== null && $end !== null ? $end - $start : null;
 
-                return $bord2 !== null && $maps !== null ? $bord2 - $maps : null;
+                return $bord2 !== null && $mapsTotal !== null ? $bord2 - $mapsTotal : null;
             })
             ->filter(static fn ($value) => $value !== null)
             ->sum();

--- a/app/Http/Requests/ValabilitateCursaRequest.php
+++ b/app/Http/Requests/ValabilitateCursaRequest.php
@@ -35,7 +35,6 @@ class ValabilitateCursaRequest extends FormRequest
             'observatii' => ['nullable', 'string'],
             'km_bord_incarcare' => ['nullable', 'integer', 'min:0'],
             'km_bord_descarcare' => ['nullable', 'integer', 'min:0'],
-            'km_maps' => ['nullable', 'string', 'max:255'],
             'km_maps_gol' => ['nullable', 'numeric', 'min:0'],
             'km_maps_plin' => ['nullable', 'numeric', 'min:0'],
             'km_cu_taxa' => ['nullable', 'numeric', 'min:0'],

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -141,7 +141,7 @@
         $hasGrupuri = $valabilitate->cursaGrupuri->count() > 0;
         $isFlashDivision = optional($valabilitate->divizie)->id === 1
             && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
-        $tableColumnCount = $isFlashDivision ? 22 : 11;
+        $tableColumnCount = $isFlashDivision ? 22 : 12;
     @endphp
     <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">
         <div class="row card-header align-items-center text-center text-lg-start" style="border-radius: 40px 40px 0px 0px;">
@@ -258,7 +258,7 @@
                                     <th rowspan="2" class="text-center curse-nowrap">Diferența preț<br>(încasat –<br> calculat)</th>
                                     <th colspan="2" class="text-center curse-nowrap">Daily contribution</th>
                                 @else
-                                    <th rowspan="2" class="text-end curse-nowrap">KM Maps</th>
+                                    <th colspan="2" class="text-center curse-nowrap">KM Maps</th>
                                     <th colspan="2" class="text-center curse-nowrap">
                                         KM Bord (plecare / sosire)
                                     </th>
@@ -287,6 +287,8 @@
                                     <th class="text-end curse-nowrap">Calculat</th>
                                     <th class="text-end curse-nowrap">Încasat</th>
                                 @else
+                                    <th class="text-end curse-nowrap">Km gol</th>
+                                    <th class="text-end curse-nowrap">Km plin</th>
                                     <th class="text-end curse-nowrap">Plecare</th>
                                     <th class="text-end curse-nowrap">Sosire</th>
                                     <th class="text-end curse-nowrap">Km gol</th>

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -189,7 +189,6 @@
 
                             $createKmBordIncarcare = $isCreateActive ? old('km_bord_incarcare', '') : '';
                             $createKmBordDescarcare = $isCreateActive ? old('km_bord_descarcare', '') : '';
-                            $createKmMaps = $isCreateActive ? old('km_maps', '') : '';
                             $createKmMapsGol = $isCreateActive ? old('km_maps_gol', '') : '';
                             $createKmMapsPlin = $isCreateActive ? old('km_maps_plin', '') : '';
                             $createKmCuTaxa = $isCreateActive ? old('km_cu_taxa', '') : '';
@@ -393,100 +392,79 @@
                                     {{ $isCreateActive ? $errors->first('data_cursa') : '' }}
                                 </div>
                             </div>
-                            @unless ($isFlashDivision)
-                                <div class="col-md-4">
-                                    <label for="cursa-create-km-bord-incarcare" class="form-label">Km bord încărcare</label>
-                                    <input
-                                        type="number"
-                                        name="km_bord_incarcare"
-                                        id="cursa-create-km-bord-incarcare"
-                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
-                                        value="{{ $createKmBordIncarcare }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
-                                        data-error-for="km_bord_incarcare"
-                                    >
-                                        {{ $isCreateActive ? $errors->first('km_bord_incarcare') : '' }}
-                                    </div>
+                            <div class="col-md-4">
+                                <label for="cursa-create-km-bord-incarcare" class="form-label">Km bord încărcare</label>
+                                <input
+                                    type="number"
+                                    name="km_bord_incarcare"
+                                    id="cursa-create-km-bord-incarcare"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmBordIncarcare }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_incarcare"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_bord_incarcare') : '' }}
                                 </div>
-                                <div class="col-md-4">
-                                    <label for="cursa-create-km-bord-descarcare" class="form-label">Km bord descărcare</label>
-                                    <input
-                                        type="number"
-                                        name="km_bord_descarcare"
-                                        id="cursa-create-km-bord-descarcare"
-                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
-                                        value="{{ $createKmBordDescarcare }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
-                                        data-error-for="km_bord_descarcare"
-                                    >
-                                        {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
-                                    </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="cursa-create-km-bord-descarcare" class="form-label">Km bord descărcare</label>
+                                <input
+                                    type="number"
+                                    name="km_bord_descarcare"
+                                    id="cursa-create-km-bord-descarcare"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmBordDescarcare }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_descarcare"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
-                            @endunless
-                            @unless ($isFlashDivision)
-                                <div class="col-md-4">
-                                    <label for="cursa-create-km-maps" class="form-label">Km Maps</label>
-                                    <input
-                                        type="text"
-                                        name="km_maps"
-                                        id="cursa-create-km-maps"
-                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps') ? 'is-invalid' : '' }}"
-                                        value="{{ $createKmMaps }}"
-                                        maxlength="255"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps') ? 'd-block' : '' }}"
-                                        data-error-for="km_maps"
-                                    >
-                                        {{ $isCreateActive ? $errors->first('km_maps') : '' }}
-                                    </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="cursa-create-km-maps-gol" class="form-label">Km Maps gol</label>
+                                <input
+                                    type="number"
+                                    name="km_maps_gol"
+                                    id="cursa-create-km-maps-gol"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps_gol') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmMapsGol }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps_gol') ? 'd-block' : '' }}"
+                                    data-error-for="km_maps_gol"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_maps_gol') : '' }}
                                 </div>
-                            @endunless
+                            </div>
+                            <div class="col-md-4">
+                                <label for="cursa-create-km-maps-plin" class="form-label">Km Maps plin</label>
+                                <input
+                                    type="number"
+                                    name="km_maps_plin"
+                                    id="cursa-create-km-maps-plin"
+                                    class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps_plin') ? 'is-invalid' : '' }}"
+                                    value="{{ $createKmMapsPlin }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps_plin') ? 'd-block' : '' }}"
+                                    data-error-for="km_maps_plin"
+                                >
+                                    {{ $isCreateActive ? $errors->first('km_maps_plin') : '' }}
+                                </div>
+                            </div>
                             @if ($isFlashDivision)
-                                <div class="col-md-4">
-                                    <label for="cursa-create-km-maps-gol" class="form-label">Km Maps gol</label>
-                                    <input
-                                        type="number"
-                                        name="km_maps_gol"
-                                        id="cursa-create-km-maps-gol"
-                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps_gol') ? 'is-invalid' : '' }}"
-                                        value="{{ $createKmMapsGol }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps_gol') ? 'd-block' : '' }}"
-                                        data-error-for="km_maps_gol"
-                                    >
-                                        {{ $isCreateActive ? $errors->first('km_maps_gol') : '' }}
-                                    </div>
-                                </div>
-                                <div class="col-md-4">
-                                    <label for="cursa-create-km-maps-plin" class="form-label">Km Maps plin</label>
-                                    <input
-                                        type="number"
-                                        name="km_maps_plin"
-                                        id="cursa-create-km-maps-plin"
-                                        class="form-control bg-white rounded-3 {{ $isCreateActive && $errors->has('km_maps_plin') ? 'is-invalid' : '' }}"
-                                        value="{{ $createKmMapsPlin }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isCreateActive && $errors->has('km_maps_plin') ? 'd-block' : '' }}"
-                                        data-error-for="km_maps_plin"
-                                    >
-                                        {{ $isCreateActive ? $errors->first('km_maps_plin') : '' }}
-                                    </div>
-                                </div>
                                 <div class="col-md-4">
                                     <label for="cursa-create-km-cu-taxa" class="form-label">Km cu taxă</label>
                                     <input
@@ -704,10 +682,6 @@
         $editKmBordDescarcare = $isEditing ? old('km_bord_descarcare', $cursa->km_bord_descarcare) : $cursa->km_bord_descarcare;
         if ($editKmBordDescarcare === null) {
             $editKmBordDescarcare = '';
-        }
-        $editKmMaps = $isEditing ? old('km_maps', $cursa->km_maps) : $cursa->km_maps;
-        if ($editKmMaps === null) {
-            $editKmMaps = '';
         }
         $editKmMapsGol = $isEditing ? old('km_maps_gol', $cursa->km_maps_gol) : $cursa->km_maps_gol;
         if ($editKmMapsGol === null) {
@@ -960,100 +934,79 @@
                                     {{ $isEditing ? $errors->first('data_cursa') : '' }}
                                 </div>
                             </div>
-                            @unless ($isFlashDivision)
-                                <div class="col-md-4">
-                                    <label for="{{ $editPrefix }}km-bord-incarcare" class="form-label">Km bord încărcare</label>
-                                    <input
-                                        type="number"
-                                        name="km_bord_incarcare"
-                                        id="{{ $editPrefix }}km-bord-incarcare"
-                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
-                                        value="{{ $editKmBordIncarcare }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isEditing && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
-                                        data-error-for="km_bord_incarcare"
-                                    >
-                                        {{ $isEditing ? $errors->first('km_bord_incarcare') : '' }}
-                                    </div>
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}km-bord-incarcare" class="form-label">Km bord încărcare</label>
+                                <input
+                                    type="number"
+                                    name="km_bord_incarcare"
+                                    id="{{ $editPrefix }}km-bord-incarcare"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_incarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmBordIncarcare }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord_incarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_incarcare"
+                                >
+                                    {{ $isEditing ? $errors->first('km_bord_incarcare') : '' }}
                                 </div>
-                                <div class="col-md-4">
-                                    <label for="{{ $editPrefix }}km-bord-descarcare" class="form-label">Km bord descărcare</label>
-                                    <input
-                                        type="number"
-                                        name="km_bord_descarcare"
-                                        id="{{ $editPrefix }}km-bord-descarcare"
-                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
-                                        value="{{ $editKmBordDescarcare }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isEditing && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
-                                        data-error-for="km_bord_descarcare"
-                                    >
-                                        {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
-                                    </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}km-bord-descarcare" class="form-label">Km bord descărcare</label>
+                                <input
+                                    type="number"
+                                    name="km_bord_descarcare"
+                                    id="{{ $editPrefix }}km-bord-descarcare"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_bord_descarcare') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmBordDescarcare }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_bord_descarcare') ? 'd-block' : '' }}"
+                                    data-error-for="km_bord_descarcare"
+                                >
+                                    {{ $isEditing ? $errors->first('km_bord_descarcare') : '' }}
                                 </div>
-                            @endunless
-                            @unless ($isFlashDivision)
-                                <div class="col-md-4">
-                                    <label for="{{ $editPrefix }}km-maps" class="form-label">Km Maps</label>
-                                    <input
-                                        type="text"
-                                        name="km_maps"
-                                        id="{{ $editPrefix }}km-maps"
-                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps') ? 'is-invalid' : '' }}"
-                                        value="{{ $editKmMaps }}"
-                                        maxlength="255"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps') ? 'd-block' : '' }}"
-                                        data-error-for="km_maps"
-                                    >
-                                        {{ $isEditing ? $errors->first('km_maps') : '' }}
-                                    </div>
+                            </div>
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}km-maps-gol" class="form-label">Km Maps gol</label>
+                                <input
+                                    type="number"
+                                    name="km_maps_gol"
+                                    id="{{ $editPrefix }}km-maps-gol"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps_gol') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmMapsGol }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_maps_gol') ? 'd-block' : '' }}"
+                                    data-error-for="km_maps_gol"
+                                >
+                                    {{ $isEditing ? $errors->first('km_maps_gol') : '' }}
                                 </div>
-                            @endunless
+                            </div>
+                            <div class="col-md-4">
+                                <label for="{{ $editPrefix }}km-maps-plin" class="form-label">Km Maps plin</label>
+                                <input
+                                    type="number"
+                                    name="km_maps_plin"
+                                    id="{{ $editPrefix }}km-maps-plin"
+                                    class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps_plin') ? 'is-invalid' : '' }}"
+                                    value="{{ $editKmMapsPlin }}"
+                                    min="0"
+                                    step="1"
+                                >
+                                <div
+                                    class="invalid-feedback {{ $isEditing && $errors->has('km_maps_plin') ? 'd-block' : '' }}"
+                                    data-error-for="km_maps_plin"
+                                >
+                                    {{ $isEditing ? $errors->first('km_maps_plin') : '' }}
+                                </div>
+                            </div>
                             @if ($isFlashDivision)
-                                <div class="col-md-4">
-                                    <label for="{{ $editPrefix }}km-maps-gol" class="form-label">Km Maps gol</label>
-                                    <input
-                                        type="number"
-                                        name="km_maps_gol"
-                                        id="{{ $editPrefix }}km-maps-gol"
-                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps_gol') ? 'is-invalid' : '' }}"
-                                        value="{{ $editKmMapsGol }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps_gol') ? 'd-block' : '' }}"
-                                        data-error-for="km_maps_gol"
-                                    >
-                                        {{ $isEditing ? $errors->first('km_maps_gol') : '' }}
-                                    </div>
-                                </div>
-                                <div class="col-md-4">
-                                    <label for="{{ $editPrefix }}km-maps-plin" class="form-label">Km Maps plin</label>
-                                    <input
-                                        type="number"
-                                        name="km_maps_plin"
-                                        id="{{ $editPrefix }}km-maps-plin"
-                                        class="form-control bg-white rounded-3 {{ $isEditing && $errors->has('km_maps_plin') ? 'is-invalid' : '' }}"
-                                        value="{{ $editKmMapsPlin }}"
-                                        min="0"
-                                        step="1"
-                                    >
-                                    <div
-                                        class="invalid-feedback {{ $isEditing && $errors->has('km_maps_plin') ? 'd-block' : '' }}"
-                                        data-error-for="km_maps_plin"
-                                    >
-                                        {{ $isEditing ? $errors->first('km_maps_plin') : '' }}
-                                    </div>
-                                </div>
                                 <div class="col-md-4">
                                     <label for="{{ $editPrefix }}km-cu-taxa" class="form-label">Km cu taxă</label>
                                     <input

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,7 +1,7 @@
 @php
     $isFlashDivision = optional($valabilitate->divizie)->id === 1
         && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
-    $tableColumnCount = $isFlashDivision ? 22 : 11;
+    $tableColumnCount = $isFlashDivision ? 22 : 12;
     $divizie = $valabilitate->divizie;
     $priceKmGol = $divizie && $divizie->pret_km_gol !== null ? (float) $divizie->pret_km_gol : null;
     $priceKmPlin = $divizie && $divizie->pret_km_plin !== null ? (float) $divizie->pret_km_plin : null;
@@ -71,10 +71,19 @@
             ? (float) $cursa->km_bord_descarcare
             : null;
 
-        $kmMapsDisplay = filled($cursa->km_maps) ? $cursa->km_maps : '—';
-        $kmMapsValue = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
         $kmMapsGolValue = is_numeric($cursa->km_maps_gol) ? (float) $cursa->km_maps_gol : null;
         $kmMapsPlinValue = is_numeric($cursa->km_maps_plin) ? (float) $cursa->km_maps_plin : null;
+        $kmMapsValue = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
+        $kmMapsTotal = null;
+        if ($kmMapsGolValue !== null || $kmMapsPlinValue !== null) {
+            $kmMapsTotal = ($kmMapsGolValue ?? 0) + ($kmMapsPlinValue ?? 0);
+        } elseif ($kmMapsValue !== null) {
+            $kmMapsTotal = $kmMapsValue;
+        }
+        $kmMapsGolDisplay = $kmMapsGolValue !== null ? $kmMapsGolValue : '—';
+        $kmMapsPlinDisplay = $kmMapsPlinValue !== null
+            ? $kmMapsPlinValue
+            : ($kmMapsValue !== null ? $kmMapsValue : '—');
         $kmFlashGolValue = is_numeric($cursa->km_flash_gol) ? (float) $cursa->km_flash_gol : null;
         $kmFlashPlinValue = is_numeric($cursa->km_flash_plin) ? (float) $cursa->km_flash_plin : null;
         $kmCuTaxaValue = is_numeric($cursa->km_cu_taxa) ? (float) $cursa->km_cu_taxa : null;
@@ -82,7 +91,11 @@
         // Km plin
         $kmPlin = $kmPlecare !== null && $kmSosire !== null ? $kmSosire - $kmPlecare : null;
         $kmGol = $previousKmSosire !== null && $kmPlecare !== null ? $kmPlecare - $previousKmSosire : null;
-        $kmDifference = $kmPlin !== null && $kmMapsValue !== null ? $kmPlin - $kmMapsValue : null;
+        $kmBordTotal = null;
+        if ($kmGol !== null || $kmPlin !== null) {
+            $kmBordTotal = ($kmGol ?? 0) + ($kmPlin ?? 0);
+        }
+        $kmDifference = $kmBordTotal !== null && $kmMapsTotal !== null ? $kmBordTotal - $kmMapsTotal : null;
 
         $kmMapsFlashGolDiff = $kmMapsGolValue !== null && $kmFlashGolValue !== null
             ? $kmMapsGolValue - $kmFlashGolValue
@@ -330,9 +343,12 @@
             <td class="text-end align-middle text-nowrap">{{ $dailyContributionCalculat !== null ? number_format($dailyContributionCalculat, 2) : '—' }}</td>
             <td class="text-end align-middle text-nowrap {{ $dailyContributionClass }}">{{ $dailyContributionIncasata !== null ? number_format($dailyContributionIncasata, 2) : '—' }}</td>
         @else
-            {{-- KM Maps --}}
+            {{-- KM Maps gol/plin --}}
             <td class="text-end text-nowrap align-middle">
-                {{ $kmMapsDisplay }}
+                {{ $kmMapsGolDisplay }}
+            </td>
+            <td class="text-end text-nowrap align-middle">
+                {{ $kmMapsPlinDisplay }}
             </td>
 
             {{-- KM Plecare --}}


### PR DESCRIPTION
## Summary
- Show separate Km Maps gol and Km Maps plin columns for all divisions
- Update summary calculations and validation to rely on split km maps values
- Align create/edit modals to capture split map distances regardless of division

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234e6ba1dc8326a94a4428177b1ee4)