### PR TITLE
Use split km maps fields

### DIFF
--- a/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
+++ b/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
@@ -122,15 +122,7 @@ trait HandlesValabilitatiCurseListings
             ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
             ->map(static fn ($value) => (float) $value);
 
-        $kmMapsValues = $curseCollection
-            ->pluck('km_maps')
-            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
-            ->map(static fn ($value) => (float) $value);
-
-        $hasSplitMaps = $kmMapsGolValues->isNotEmpty() || $kmMapsPlinValues->isNotEmpty();
-        $totalKmMapsSplit = $kmMapsGolValues->sum() + $kmMapsPlinValues->sum();
-        $totalKmMapsSingle = $kmMapsValues->sum();
-        $totalKmMaps = $hasSplitMaps ? $totalKmMapsSplit : $totalKmMapsSingle;
+        $totalKmMaps = $kmMapsGolValues->sum() + $kmMapsPlinValues->sum();
 
         $totalKmMapsPlin = $kmMapsPlinValues->sum();
 
@@ -172,13 +164,11 @@ trait HandlesValabilitatiCurseListings
                 $end = $cursa->km_bord_descarcare !== null && $cursa->km_bord_descarcare !== ''
                     ? (float) $cursa->km_bord_descarcare
                     : null;
-                $mapsTotal = null;
                 $mapsGol = is_numeric($cursa->km_maps_gol) ? (float) $cursa->km_maps_gol : null;
                 $mapsPlin = is_numeric($cursa->km_maps_plin) ? (float) $cursa->km_maps_plin : null;
+                $mapsTotal = null;
                 if ($mapsGol !== null || $mapsPlin !== null) {
                     $mapsTotal = ($mapsGol ?? 0) + ($mapsPlin ?? 0);
-                } elseif (is_numeric($cursa->km_maps)) {
-                    $mapsTotal = (float) $cursa->km_maps;
                 }
 
                 $bord2 = $start !== null && $end !== null ? $end - $start : null;

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Models\ValabilitateCursaImage;
 use App\Models\ValabilitateCursaGrup;
 
@@ -30,7 +31,6 @@ class ValabilitateCursa extends Model
         'observatii',
         'km_bord_incarcare',
         'km_bord_descarcare',
-        'km_maps',
         'km_maps_gol',
         'km_maps_plin',
         'km_cu_taxa',
@@ -93,5 +93,37 @@ class ValabilitateCursa extends Model
         static::deleted(static function (ValabilitateCursa $cursa): void {
             $cursa->valabilitate?->syncSummary();
         });
+    }
+
+    protected function kmMapsGol(): Attribute
+    {
+        return Attribute::make(
+            get: static function ($value) {
+                if ($value === '' || $value === null) {
+                    return null;
+                }
+
+                return (int) $value;
+            }
+        );
+    }
+
+    protected function kmMapsPlin(): Attribute
+    {
+        return Attribute::make(
+            get: function ($value, array $attributes) {
+                $resolvedValue = $value;
+
+                if ($resolvedValue === '' || $resolvedValue === null) {
+                    $resolvedValue = $attributes['km_maps'] ?? null;
+                }
+
+                if ($resolvedValue === '' || $resolvedValue === null) {
+                    return null;
+                }
+
+                return (int) $resolvedValue;
+            }
+        );
     }
 }

--- a/database/factories/ValabilitateCursaFactory.php
+++ b/database/factories/ValabilitateCursaFactory.php
@@ -30,7 +30,6 @@ class ValabilitateCursaFactory extends Factory
             'observatii' => fake()->optional()->sentence(),
             'km_bord_incarcare' => fake()->numberBetween(0, 500000),
             'km_bord_descarcare' => fake()->numberBetween(0, 500000),
-            'km_maps' => (string) fake()->numberBetween(0, 5000),
             'km_maps_gol' => fake()->numberBetween(0, 5000),
             'km_maps_plin' => fake()->numberBetween(0, 5000),
             'km_cu_taxa' => fake()->numberBetween(0, 5000),

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -274,8 +274,8 @@
                             </tr>
                             <tr class="curse-data-header-bottom">
                                 @if ($isFlashDivision)
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap">Km Maps gol</th>
+                                    <th class="text-end curse-nowrap">Km Maps plin</th>
                                     <th class="text-end curse-nowrap">Km gol</th>
                                     <th class="text-end curse-nowrap">Km plin</th>
                                     <th class="text-end curse-nowrap">Km gol</th>
@@ -287,8 +287,8 @@
                                     <th class="text-end curse-nowrap">Calculat</th>
                                     <th class="text-end curse-nowrap">Încasat</th>
                                 @else
-                                    <th class="text-end curse-nowrap">Km gol</th>
-                                    <th class="text-end curse-nowrap">Km plin</th>
+                                    <th class="text-end curse-nowrap">Km Maps gol</th>
+                                    <th class="text-end curse-nowrap">Km Maps plin</th>
                                     <th class="text-end curse-nowrap">Plecare</th>
                                     <th class="text-end curse-nowrap">Sosire</th>
                                     <th class="text-end curse-nowrap">Km gol</th>

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -73,17 +73,12 @@
 
         $kmMapsGolValue = is_numeric($cursa->km_maps_gol) ? (float) $cursa->km_maps_gol : null;
         $kmMapsPlinValue = is_numeric($cursa->km_maps_plin) ? (float) $cursa->km_maps_plin : null;
-        $kmMapsValue = is_numeric($cursa->km_maps) ? (float) $cursa->km_maps : null;
         $kmMapsTotal = null;
         if ($kmMapsGolValue !== null || $kmMapsPlinValue !== null) {
             $kmMapsTotal = ($kmMapsGolValue ?? 0) + ($kmMapsPlinValue ?? 0);
-        } elseif ($kmMapsValue !== null) {
-            $kmMapsTotal = $kmMapsValue;
         }
         $kmMapsGolDisplay = $kmMapsGolValue !== null ? $kmMapsGolValue : '—';
-        $kmMapsPlinDisplay = $kmMapsPlinValue !== null
-            ? $kmMapsPlinValue
-            : ($kmMapsValue !== null ? $kmMapsValue : '—');
+        $kmMapsPlinDisplay = $kmMapsPlinValue !== null ? $kmMapsPlinValue : '—';
         $kmFlashGolValue = is_numeric($cursa->km_flash_gol) ? (float) $cursa->km_flash_gol : null;
         $kmFlashPlinValue = is_numeric($cursa->km_flash_plin) ? (float) $cursa->km_flash_plin : null;
         $kmCuTaxaValue = is_numeric($cursa->km_cu_taxa) ? (float) $cursa->km_cu_taxa : null;

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -37,7 +37,6 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Livrare completă',
             'km_bord_incarcare' => 12345,
             'km_bord_descarcare' => 12500,
-            'km_maps' => '150',
             'km_maps_gol' => 50,
             'km_maps_plin' => 100,
             'km_cu_taxa' => 25,
@@ -61,7 +60,6 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Livrare completă',
             'km_bord_incarcare' => 12345,
             'km_bord_descarcare' => 12500,
-            'km_maps' => '150',
             'km_maps_gol' => 50,
             'km_maps_plin' => 100,
             'km_cu_taxa' => 25,
@@ -72,6 +70,8 @@ class ValabilitateCursaTest extends TestCase
         $cursa = ValabilitateCursa::firstOrFail();
         $this->assertInstanceOf(Carbon::class, $cursa->data_cursa);
         $this->assertSame('2025-05-01 08:30:00', $cursa->data_cursa->format('Y-m-d H:i:s'));
+        $this->assertSame(50, $cursa->km_maps_gol);
+        $this->assertSame(100, $cursa->km_maps_plin);
     }
 
     public function test_user_can_update_cursa_fields(): void
@@ -109,7 +109,6 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Actualizare detalii',
             'km_bord_incarcare' => 98765,
             'km_bord_descarcare' => 99000,
-            'km_maps' => '300',
             'km_maps_gol' => 120,
             'km_maps_plin' => 180,
             'km_cu_taxa' => 60,
@@ -133,13 +132,15 @@ class ValabilitateCursaTest extends TestCase
             'observatii' => 'Actualizare detalii',
             'km_bord_incarcare' => 98765,
             'km_bord_descarcare' => 99000,
-            'km_maps' => '300',
             'km_maps_gol' => 120,
             'km_maps_plin' => 180,
             'km_cu_taxa' => 60,
             'km_flash_gol' => 110,
             'km_flash_plin' => 175,
         ]);
+
+        $this->assertSame(120, $cursa->fresh()->km_maps_gol);
+        $this->assertSame(180, $cursa->fresh()->km_maps_plin);
     }
 
     public function test_ajax_update_returns_json_payload(): void
@@ -233,6 +234,45 @@ class ValabilitateCursaTest extends TestCase
         $response->assertSeeText('10.06.2025 16:20');
         $response->assertSeeText('15400');
         $response->assertSeeText('15900');
+    }
+
+    public function test_index_displays_split_maps_columns_and_values(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create();
+        ValabilitateCursa::factory()->for($valabilitate)->create([
+            'nr_ordine' => 4,
+            'km_maps_gol' => 40,
+            'km_maps_plin' => 75,
+            'km_bord_incarcare' => 1000,
+            'km_bord_descarcare' => 1200,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
+
+        $response->assertOk();
+        $response->assertSeeText('Km Maps gol');
+        $response->assertSeeText('Km Maps plin');
+        $response->assertSeeText('40');
+        $response->assertSeeText('75');
+    }
+
+    public function test_legacy_km_maps_value_populates_split_fields_for_display(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create();
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
+            'km_maps_gol' => null,
+            'km_maps_plin' => null,
+        ]);
+
+        $cursa->forceFill(['km_maps' => 175])->save();
+
+        $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
+
+        $this->assertSame(175, $cursa->fresh()->km_maps_plin);
+        $response->assertOk();
+        $response->assertSeeText('175');
     }
 
     public function test_index_lists_curse_in_chronological_order(): void


### PR DESCRIPTION
## Summary
- rely exclusively on split `km_maps_gol` and `km_maps_plin` values in controllers and models, adding a legacy read fallback for records that still have `km_maps`
- update route tables and modals to present and calculate using the split fields for every division
- extend factories and feature coverage to exercise split-field create/edit flows, table rendering, and legacy compatibility

## Testing
- Not run (composer install/phpunit unavailable due to network restrictions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69235c88d85c8326b4b066e580ffb262)