### PR TITLE
Constrain cropper images to canvas

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -118,6 +118,8 @@
 .cropper-wrapper .cropper-canvas {
     max-width: 100%;
     max-height: 100%;
+    width: 100% !important;
+    height: 100% !important;
 }
 
 .cropper-wrapper .cropper-container {
@@ -131,5 +133,13 @@
     max-height: 100%;
     width: auto;
     height: auto;
+    object-fit: contain;
+}
+
+.cropper-wrapper .cropper-canvas img {
+    max-width: 100% !important;
+    max-height: 100% !important;
+    width: auto !important;
+    height: auto !important;
     object-fit: contain;
 }

--- a/resources/js/sofer-valabilitate-imagini.js
+++ b/resources/js/sofer-valabilitate-imagini.js
@@ -37,10 +37,19 @@ if (root) {
         const aspectRatio = naturalHeight / naturalWidth;
         const targetWidth = targetMaxWidth;
         const targetHeight = Math.min(targetWidth * aspectRatio, viewportHeight * 0.68);
+        const containerStyles = window.getComputedStyle(cropperContainer);
+        const paddingX = (parseFloat(containerStyles.paddingLeft || '0') + parseFloat(containerStyles.paddingRight || '0'));
+        const paddingY = (parseFloat(containerStyles.paddingTop || '0') + parseFloat(containerStyles.paddingBottom || '0'));
 
         cropperContainer.style.maxWidth = `${targetMaxWidth}px`;
         cropperContainer.style.height = `${targetHeight}px`;
         cropperContainer.style.maxHeight = `${Math.min(viewportHeight * 0.75, targetHeight)}px`;
+
+        const innerWidth = Math.max(targetMaxWidth - paddingX, 0);
+        const innerHeight = Math.max(targetHeight - paddingY, 0);
+
+        cropperImage.style.maxWidth = `${innerWidth}px`;
+        cropperImage.style.maxHeight = `${innerHeight}px`;
     };
 
     const mimeToExtension = (mime) => {


### PR DESCRIPTION
## Summary
- enforce cropper container and canvas dimensions so images stay within bounds
- cap image dimensions based on available inner space of the cropper modal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692375ee39a0832682a825af71773451)