### PR TITLE
Add cursa image PDF downloads and previews

### DIFF
--- a/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
+++ b/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
@@ -27,6 +27,7 @@ trait HandlesValabilitatiCurseListings
                 'incarcareTara',
                 'descarcareTara',
                 'cursaGrup',
+                'images',
             ])
             ->reorder()
             ->orderBy('nr_ordine')

--- a/app/Http/Controllers/ValabilitateCursaImageController.php
+++ b/app/Http/Controllers/ValabilitateCursaImageController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Valabilitate;
+use App\Models\ValabilitateCursa;
+use App\Models\ValabilitateCursaImage;
+use Illuminate\Support\Facades\PDF;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ValabilitateCursaImageController extends Controller
+{
+    public function download(Valabilitate $valabilitate, ValabilitateCursa $cursa, ValabilitateCursaImage $imagine): StreamedResponse
+    {
+        $this->authorize('view', $valabilitate);
+
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+        $this->assertBelongsToCursa($cursa, $imagine);
+
+        abort_if($imagine->trashed(), 404);
+
+        if (! Storage::exists($imagine->path)) {
+            abort(404);
+        }
+
+        $imageContent = Storage::get($imagine->path);
+
+        $imageDataUri = sprintf(
+            'data:%s;base64,%s',
+            $imagine->mime_type ?: 'application/octet-stream',
+            base64_encode($imageContent)
+        );
+
+        $pdf = PDF::loadView('valabilitati.curse.imagini.pdf', [
+            'imagine' => $imagine,
+            'imageDataUri' => $imageDataUri,
+        ]);
+        $pdf->getDomPDF()->set_option('enable_php', true);
+
+        $filename = pathinfo($imagine->original_name ?: 'imagine', PATHINFO_FILENAME) . '.pdf';
+
+        return $pdf->download($filename);
+    }
+
+    private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void
+    {
+        abort_unless((int) $cursa->valabilitate_id === (int) $valabilitate->id, 404);
+    }
+
+    private function assertBelongsToCursa(ValabilitateCursa $cursa, ValabilitateCursaImage $imagine): void
+    {
+        abort_unless((int) $imagine->valabilitate_cursa_id === (int) $cursa->id, 404);
+    }
+}

--- a/resources/views/valabilitati/curse/imagini/pdf.blade.php
+++ b/resources/views/valabilitati/curse/imagini/pdf.blade.php
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ro">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Imagine cursă</title>
+    <style>
+        body {
+            font-family: DejaVu Sans, sans-serif;
+            margin: 0;
+            padding: 0;
+            background: #f8f9fa;
+        }
+
+        .container {
+            padding: 16px;
+        }
+
+        .image-wrapper {
+            text-align: center;
+        }
+
+        .image-wrapper img {
+            max-width: 100%;
+            height: auto;
+        }
+
+        .meta {
+            margin-bottom: 12px;
+            font-size: 12px;
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="meta">
+        <div><strong>Imagine:</strong> {{ $imagine->original_name ?? 'Imagine cursă' }}</div>
+    </div>
+    <div class="image-wrapper">
+        <img src="{{ $imageDataUri }}" alt="Imagine cursă">
+    </div>
+</div>
+</body>
+</html>

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -374,35 +374,63 @@
 
         {{-- Acțiuni --}}
         <td class="text-end align-middle">
-            <div class="d-flex flex-wrap align-content-start justify-content-end">
-                <div class="ms-1">
-                    <a
-                        href="#" data-bs-toggle="modal"
-                        data-bs-target="#cursaEditModal{{ $cursa->id }}"
-                        class="flex"
-                        title="Modifică cursa"
-                        aria-label="Modifică cursa"
-                    >
-                        <span class="badge bg-primary d-inline-flex align-items-center justify-content-center" aria-hidden="true">
-                            <i class="fa-solid fa-pen-to-square"></i>
-                        </span>
-                        <span class="visually-hidden">Modifică</span>
-                    </a>
+            <div class="d-flex flex-column align-items-end gap-2">
+                <div class="d-flex flex-wrap align-content-start justify-content-end">
+                    <div class="ms-1">
+                        <a
+                            href="#" data-bs-toggle="modal"
+                            data-bs-target="#cursaEditModal{{ $cursa->id }}"
+                            class="flex"
+                            title="Modifică cursa"
+                            aria-label="Modifică cursa"
+                        >
+                            <span class="badge bg-primary d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                                <i class="fa-solid fa-pen-to-square"></i>
+                            </span>
+                            <span class="visually-hidden">Modifică</span>
+                        </a>
+                    </div>
+                    <div class="ms-1">
+                        <a
+                            href="#"
+                            data-bs-toggle="modal"
+                            data-bs-target="#cursaDeleteModal{{ $cursa->id }}"
+                            class="flex"
+                            title="Șterge cursa"
+                            aria-label="Șterge cursa"
+                        >
+                            <span class="badge bg-danger d-inline-flex align-items-center justify-content-center" aria-hidden="true">
+                                <i class="fa-solid fa-trash"></i>
+                            </span>
+                        </a>
+                    </div>
                 </div>
-                <div class="ms-1">
-                    <a
-                        href="#"
-                        data-bs-toggle="modal"
-                        data-bs-target="#cursaDeleteModal{{ $cursa->id }}"
-                        class="flex"
-                        title="Șterge cursa"
-                        aria-label="Șterge cursa"
-                    >
-                        <span class="badge bg-danger d-inline-flex align-items-center justify-content-center" aria-hidden="true">
-                            <i class="fa-solid fa-trash"></i>
-                        </span>
-                    </a>
-                </div>
+
+                @if ($cursa->images->count())
+                    <div class="d-flex flex-column align-items-end gap-1 w-100">
+                        @foreach ($cursa->images as $imagine)
+                            <div class="d-flex align-items-center justify-content-end gap-2 w-100">
+                                <div class="rounded overflow-hidden border" style="width: 64px; height: 64px;">
+                                    <img
+                                        src="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                        alt="{{ $imagine->original_name ?? 'Imagine cursă' }}"
+                                        class="img-fluid w-100 h-100 object-fit-cover"
+                                    >
+                                </div>
+                                <div class="d-flex flex-column align-items-end text-end small">
+                                    <span class="fw-semibold">{{ $imagine->original_name ?? 'Imagine cursă' }}</span>
+                                    <a
+                                        href="{{ route('valabilitati.curse.images.download', [$valabilitate, $cursa, $imagine]) }}"
+                                        class="link-primary d-inline-flex align-items-center gap-1"
+                                    >
+                                        <i class="fa-solid fa-file-arrow-down"></i>
+                                        <span>Descarcă PDF</span>
+                                    </a>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                @endif
             </div>
         </td>
     </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,7 @@ use App\Http\Controllers\SoferValabilitateCursaController;
 use App\Http\Controllers\SoferValabilitateCursaImageController;
 use App\Http\Controllers\ValabilitateController;
 use App\Http\Controllers\ValabilitateCursaController;
+use App\Http\Controllers\ValabilitateCursaImageController;
 use App\Http\Controllers\ValabilitateCursaGrupController;
 use App\Http\Controllers\ValabilitateAlimentareController;
 use App\Http\Controllers\ValabilitatiDivizieController;
@@ -403,6 +404,11 @@ Route::middleware(['auth'])->group(function () {
                 ->name('valabilitati.curse.reorder');
             Route::delete('valabilitati/{valabilitate}/curse/{cursa}', [ValabilitateCursaController::class, 'destroy'])
                 ->name('valabilitati.curse.destroy');
+            Route::get(
+                'valabilitati/{valabilitate}/curse/{cursa}/imagini/{imagine}/download',
+                [ValabilitateCursaImageController::class, 'download']
+            )
+                ->name('valabilitati.curse.images.download');
 
             Route::post('valabilitati/{valabilitate}/alimentari', [ValabilitateAlimentareController::class, 'store'])
                 ->name('valabilitati.alimentari.store');

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -8,8 +8,10 @@ use App\Models\User;
 use App\Models\Tara;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
+use App\Models\ValabilitateCursaImage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 
 class ValabilitateCursaTest extends TestCase
@@ -350,6 +352,64 @@ class ValabilitateCursaTest extends TestCase
             'id' => $third->id,
             'nr_ordine' => 3,
         ]);
+    }
+
+    public function test_user_can_download_cursa_image_as_pdf(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create();
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create();
+
+        Storage::fake();
+
+        $path = 'valabilitati/curse/sample-image.png';
+        $imageBinary = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABAwEAffQF/QAAAABJRU5ErkJggg==');
+        Storage::put($path, $imageBinary);
+
+        $imagine = ValabilitateCursaImage::create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'uploaded_by_user_id' => $user->id,
+            'path' => $path,
+            'mime_type' => 'image/png',
+            'size_bytes' => strlen($imageBinary),
+            'original_name' => 'sample-image.png',
+        ]);
+
+        $response = $this->actingAs($user)->get(
+            route('valabilitati.curse.images.download', [$valabilitate, $cursa, $imagine])
+        );
+
+        $response->assertOk();
+        $this->assertStringContainsString('application/pdf', $response->headers->get('content-type'));
+        $this->assertStringContainsString('attachment; filename="sample-image.pdf"', $response->headers->get('content-disposition'));
+        $this->assertStringContainsString('%PDF', $response->getContent());
+    }
+
+    public function test_download_is_forbidden_without_permissions(): void
+    {
+        $valabilitate = Valabilitate::factory()->create();
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create();
+        $user = User::factory()->create();
+
+        Storage::fake();
+        $path = 'valabilitati/curse/blocked.png';
+        $imageBinary = base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGD4DwABAwEAffQF/QAAAABJRU5ErkJggg==');
+        Storage::put($path, $imageBinary);
+
+        $imagine = ValabilitateCursaImage::create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'uploaded_by_user_id' => $user->id,
+            'path' => $path,
+            'mime_type' => 'image/png',
+            'size_bytes' => strlen($imageBinary),
+            'original_name' => 'blocked.png',
+        ]);
+
+        $response = $this->actingAs($user)->get(
+            route('valabilitati.curse.images.download', [$valabilitate, $cursa, $imagine])
+        );
+
+        $response->assertForbidden();
     }
 
     private function createValabilitatiUser(): User


### PR DESCRIPTION
## Summary
- show stored images for each cursa with quick preview and PDF download controls in the listing view
- add a secure download endpoint that renders a single image into a Dompdf-powered PDF
- cover the download flow and authorization with new feature tests

## Testing
- `php artisan test --filter ValabilitateCursaTest` *(fails: dependencies missing because Composer install cannot reach GitHub over the network)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237c6e92c8832697d155f19b20d57c)