### PR TITLE
Add imagines alias for cursa images

### DIFF
--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -84,6 +84,14 @@ class ValabilitateCursa extends Model
         return $this->hasMany(ValabilitateCursaImage::class, 'valabilitate_cursa_id');
     }
 
+    /**
+     * Backwards-compatible alias for the images relationship.
+     */
+    public function imagines(): HasMany
+    {
+        return $this->images();
+    }
+
     protected static function booted(): void
     {
         static::saved(static function (ValabilitateCursa $cursa): void {


### PR DESCRIPTION
## Summary
- add a backwards-compatible `imagines` relationship alias on `ValabilitateCursa`

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240e9b3bc8832690500159014bb258)