### PR TITLE
Fix public disk access for cursa images

### DIFF
--- a/app/Http/Controllers/SoferValabilitateCursaImageController.php
+++ b/app/Http/Controllers/SoferValabilitateCursaImageController.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class SoferValabilitateCursaImageController extends Controller
 {
+    private const STORAGE_DISK = 'public';
     private const MAX_IMAGES_PER_CURSA = 10;
     private const MAX_FILE_SIZE_KB = 10240; // 10 MB
     private const ALLOWED_MIMES = ['jpeg', 'jpg', 'png', 'webp'];
@@ -49,7 +50,7 @@ class SoferValabilitateCursaImageController extends Controller
         $file = $validated['image'];
         $filename = Str::uuid()->toString() . '.' . $file->getClientOriginalExtension();
         $directory = "valabilitati_curse/{$cursa->id}";
-        $path = $file->storeAs($directory, $filename);
+        $path = $file->storeAs($directory, $filename, ['disk' => self::STORAGE_DISK]);
 
         [$width, $height] = $this->extractDimensions($file);
 
@@ -79,7 +80,7 @@ class SoferValabilitateCursaImageController extends Controller
         $file = $validated['image'];
         $filename = Str::uuid()->toString() . '.' . $file->getClientOriginalExtension();
         $directory = "valabilitati_curse/{$cursa->id}";
-        $path = $file->storeAs($directory, $filename);
+        $path = $file->storeAs($directory, $filename, ['disk' => self::STORAGE_DISK]);
 
         [$width, $height] = $this->extractDimensions($file);
 
@@ -117,9 +118,9 @@ class SoferValabilitateCursaImageController extends Controller
 
         abort_if($imagine->trashed(), 404);
 
-        abort_unless(Storage::exists($imagine->path), 404);
+        abort_unless(Storage::disk(self::STORAGE_DISK)->exists($imagine->path), 404);
 
-        $stream = Storage::readStream($imagine->path);
+        $stream = Storage::disk(self::STORAGE_DISK)->readStream($imagine->path);
         abort_if($stream === false, 404);
         $mime = $imagine->mime_type ?: 'application/octet-stream';
 
@@ -163,8 +164,8 @@ class SoferValabilitateCursaImageController extends Controller
 
     private function removeFileIfExists(?string $path): void
     {
-        if ($path && Storage::exists($path)) {
-            Storage::delete($path);
+        if ($path && Storage::disk(self::STORAGE_DISK)->exists($path)) {
+            Storage::disk(self::STORAGE_DISK)->delete($path);
         }
     }
 }

--- a/app/Http/Controllers/ValabilitateCursaImageController.php
+++ b/app/Http/Controllers/ValabilitateCursaImageController.php
@@ -5,13 +5,15 @@ namespace App\Http\Controllers;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
 use App\Models\ValabilitateCursaImage;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\PDF;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ValabilitateCursaImageController extends Controller
 {
+    private const STORAGE_DISK = 'public';
+
     public function index(Valabilitate $valabilitate, ValabilitateCursa $cursa): View
     {
         $this->authorize('view', $valabilitate);
@@ -34,11 +36,11 @@ class ValabilitateCursaImageController extends Controller
 
         abort_if($imagine->trashed(), 404);
 
-        if (! Storage::exists($imagine->path)) {
+        if (! Storage::disk(self::STORAGE_DISK)->exists($imagine->path)) {
             abort(404);
         }
 
-        $imageContent = Storage::get($imagine->path);
+        $imageContent = Storage::disk(self::STORAGE_DISK)->get($imagine->path);
 
         $imageDataUri = sprintf(
             'data:%s;base64,%s',
@@ -46,7 +48,7 @@ class ValabilitateCursaImageController extends Controller
             base64_encode($imageContent)
         );
 
-        $pdf = PDF::loadView('valabilitati.curse.imagini.pdf', [
+        $pdf = Pdf::loadView('valabilitati.curse.imagini.pdf', [
             'imagine' => $imagine,
             'imageDataUri' => $imageDataUri,
         ]);

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -84,6 +84,14 @@ class ValabilitateCursa extends Model
         return $this->hasMany(ValabilitateCursaImage::class, 'valabilitate_cursa_id');
     }
 
+    /**
+     * Backwards-compatible alias for the images relationship.
+     */
+    public function imagines(): HasMany
+    {
+        return $this->images();
+    }
+
     protected static function booted(): void
     {
         static::saved(static function (ValabilitateCursa $cursa): void {

--- a/resources/views/valabilitati/curse/imagini/index.blade.php
+++ b/resources/views/valabilitati/curse/imagini/index.blade.php
@@ -32,7 +32,7 @@
                         <div class="card h-100 shadow-sm">
                             <div class="ratio ratio-4x3 bg-light">
                                 <img
-                                    src="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                    src="{{ \Illuminate\Support\Facades\Storage::disk('public')->url($imagine->path) }}"
                                     alt="{{ $imagine->original_name ?? 'Imagine cursă' }}"
                                     class="img-fluid w-100 h-100 object-fit-cover"
                                 >
@@ -48,7 +48,7 @@
                                 </div>
                                 <div class="mt-auto d-flex justify-content-between align-items-center">
                                     <a
-                                        href="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                        href="{{ \Illuminate\Support\Facades\Storage::disk('public')->url($imagine->path) }}"
                                         class="btn btn-sm btn-outline-secondary"
                                         target="_blank"
                                         rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- serve cursa images from the public storage disk and clean up stream/delete helpers
- fix PDF downloads by importing the correct DomPDF facade
- update the images view to build URLs from the public disk

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240e9b3bc8832690500159014bb258)