### PR TITLE
Fix valabilitate cursa image streaming and PDF facade

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaImageController.php
+++ b/app/Http/Controllers/ValabilitateCursaImageController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
 use App\Models\ValabilitateCursaImage;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\PDF;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -22,6 +22,33 @@ class ValabilitateCursaImageController extends Controller
         return view('valabilitati.curse.imagini.index', [
             'valabilitate' => $valabilitate,
             'cursa' => $cursa,
+        ]);
+    }
+
+    public function stream(Valabilitate $valabilitate, ValabilitateCursa $cursa, ValabilitateCursaImage $imagine): StreamedResponse
+    {
+        $this->authorize('view', $valabilitate);
+
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+        $this->assertBelongsToCursa($cursa, $imagine);
+
+        abort_if($imagine->trashed(), 404);
+
+        abort_unless(Storage::exists($imagine->path), 404);
+
+        $stream = Storage::readStream($imagine->path);
+        abort_if($stream === false, 404);
+
+        $mime = $imagine->mime_type ?: 'application/octet-stream';
+
+        return response()->stream(function () use ($stream): void {
+            fpassthru($stream);
+        }, 200, [
+            'Content-Type' => $mime,
+            'Content-Length' => (string) $imagine->size_bytes,
+            'Content-Disposition' => 'inline; filename="' . addslashes($imagine->original_name ?? 'imagine') . '"',
+            'Cache-Control' => 'private, max-age=0, no-store, no-cache, must-revalidate',
+            'Pragma' => 'no-cache',
         ]);
     }
 
@@ -46,7 +73,7 @@ class ValabilitateCursaImageController extends Controller
             base64_encode($imageContent)
         );
 
-        $pdf = PDF::loadView('valabilitati.curse.imagini.pdf', [
+        $pdf = Pdf::loadView('valabilitati.curse.imagini.pdf', [
             'imagine' => $imagine,
             'imageDataUri' => $imageDataUri,
         ]);

--- a/resources/views/valabilitati/curse/imagini/index.blade.php
+++ b/resources/views/valabilitati/curse/imagini/index.blade.php
@@ -32,7 +32,7 @@
                         <div class="card h-100 shadow-sm">
                             <div class="ratio ratio-4x3 bg-light">
                                 <img
-                                    src="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                    src="{{ route('valabilitati.curse.images.stream', [$valabilitate, $cursa, $imagine]) }}"
                                     alt="{{ $imagine->original_name ?? 'Imagine cursă' }}"
                                     class="img-fluid w-100 h-100 object-fit-cover"
                                 >
@@ -48,7 +48,7 @@
                                 </div>
                                 <div class="mt-auto d-flex justify-content-between align-items-center">
                                     <a
-                                        href="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                        href="{{ route('valabilitati.curse.images.stream', [$valabilitate, $cursa, $imagine]) }}"
                                         class="btn btn-sm btn-outline-secondary"
                                         target="_blank"
                                         rel="noopener noreferrer"

--- a/routes/web.php
+++ b/routes/web.php
@@ -407,6 +407,11 @@ Route::middleware(['auth'])->group(function () {
             Route::get('valabilitati/{valabilitate}/curse/{cursa}/imagini', [ValabilitateCursaImageController::class, 'index'])
                 ->name('valabilitati.curse.images.index');
             Route::get(
+                'valabilitati/{valabilitate}/curse/{cursa}/imagini/{imagine}/stream',
+                [ValabilitateCursaImageController::class, 'stream']
+            )
+                ->name('valabilitati.curse.images.stream');
+            Route::get(
                 'valabilitati/{valabilitate}/curse/{cursa}/imagini/{imagine}/download',
                 [ValabilitateCursaImageController::class, 'download']
             )

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -411,6 +411,7 @@ class ValabilitateCursaTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('preview-image.png', false);
+        $response->assertSee(route('valabilitati.curse.images.stream', [$valabilitate, $cursa, $imagine]), false);
         $response->assertSee(route('valabilitati.curse.images.download', [$valabilitate, $cursa, $imagine]), false);
     }
 


### PR DESCRIPTION
## Summary
- add a streaming endpoint for valabilitate cursa images and update the view to consume it
- register the new route and cover it in the existing feature test
- switch the PDF facade import to the DomPDF facade to restore PDF downloads

## Testing
- composer install *(fails: GitHub API access requires authentication)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692416e6b4c483268f6124f2069f9797)