### PR TITLE
Return streamed download response for PDF

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaImageController.php
+++ b/app/Http/Controllers/ValabilitateCursaImageController.php
@@ -81,7 +81,15 @@ class ValabilitateCursaImageController extends Controller
 
         $filename = pathinfo($imagine->original_name ?: 'imagine', PATHINFO_FILENAME) . '.pdf';
 
-        return $pdf->download($filename);
+        $pdfContent = $pdf->output();
+
+        return response()->streamDownload(
+            static function () use ($pdfContent): void {
+                echo $pdfContent;
+            },
+            $filename,
+            ['Content-Type' => 'application/pdf']
+        );
     }
 
     private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void


### PR DESCRIPTION
## Summary
- stream generated PDF content instead of returning a standard response
- ensure ValabilitateCursa image downloads conform to StreamedResponse return type

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692418d009688326846015e2d0592ae0)