### PR TITLE
Fix valabilitate images streaming and PDF facade

### DIFF
--- a/app/Http/Controllers/ValabilitateCursaImageController.php
+++ b/app/Http/Controllers/ValabilitateCursaImageController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
 use App\Models\ValabilitateCursaImage;
+use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\PDF;
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -46,7 +46,7 @@ class ValabilitateCursaImageController extends Controller
             base64_encode($imageContent)
         );
 
-        $pdf = PDF::loadView('valabilitati.curse.imagini.pdf', [
+        $pdf = Pdf::loadView('valabilitati.curse.imagini.pdf', [
             'imagine' => $imagine,
             'imageDataUri' => $imageDataUri,
         ]);
@@ -63,6 +63,32 @@ class ValabilitateCursaImageController extends Controller
             $filename,
             ['Content-Type' => 'application/pdf']
         );
+    }
+
+    public function stream(Valabilitate $valabilitate, ValabilitateCursa $cursa, ValabilitateCursaImage $imagine): StreamedResponse
+    {
+        $this->authorize('view', $valabilitate);
+
+        $this->assertBelongsToValabilitate($valabilitate, $cursa);
+        $this->assertBelongsToCursa($cursa, $imagine);
+
+        abort_if($imagine->trashed(), 404);
+        abort_unless(Storage::exists($imagine->path), 404);
+
+        $stream = Storage::readStream($imagine->path);
+        abort_if($stream === false, 404);
+
+        $mime = $imagine->mime_type ?: 'application/octet-stream';
+
+        return response()->stream(function () use ($stream): void {
+            fpassthru($stream);
+        }, 200, [
+            'Content-Type' => $mime,
+            'Content-Length' => (string) $imagine->size_bytes,
+            'Content-Disposition' => 'inline; filename="' . addslashes($imagine->original_name ?: 'imagine') . '"',
+            'Cache-Control' => 'private, max-age=0, no-store, no-cache, must-revalidate',
+            'Pragma' => 'no-cache',
+        ]);
     }
 
     private function assertBelongsToValabilitate(Valabilitate $valabilitate, ValabilitateCursa $cursa): void

--- a/resources/views/valabilitati/curse/imagini/index.blade.php
+++ b/resources/views/valabilitati/curse/imagini/index.blade.php
@@ -32,7 +32,7 @@
                         <div class="card h-100 shadow-sm">
                             <div class="ratio ratio-4x3 bg-light">
                                 <img
-                                    src="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                    src="{{ route('valabilitati.curse.images.stream', [$valabilitate, $cursa, $imagine]) }}"
                                     alt="{{ $imagine->original_name ?? 'Imagine cursă' }}"
                                     class="img-fluid w-100 h-100 object-fit-cover"
                                 >
@@ -48,7 +48,7 @@
                                 </div>
                                 <div class="mt-auto d-flex justify-content-between align-items-center">
                                     <a
-                                        href="{{ \Illuminate\Support\Facades\Storage::url($imagine->path) }}"
+                                        href="{{ route('valabilitati.curse.images.stream', [$valabilitate, $cursa, $imagine]) }}"
                                         class="btn btn-sm btn-outline-secondary"
                                         target="_blank"
                                         rel="noopener noreferrer"

--- a/routes/web.php
+++ b/routes/web.php
@@ -411,6 +411,11 @@ Route::middleware(['auth'])->group(function () {
                 [ValabilitateCursaImageController::class, 'download']
             )
                 ->name('valabilitati.curse.images.download');
+            Route::get(
+                'valabilitati/{valabilitate}/curse/{cursa}/imagini/{imagine}/stream',
+                [ValabilitateCursaImageController::class, 'stream']
+            )
+                ->name('valabilitati.curse.images.stream');
 
             Route::post('valabilitati/{valabilitate}/alimentari', [ValabilitateAlimentareController::class, 'store'])
                 ->name('valabilitati.alimentari.store');


### PR DESCRIPTION
## Summary
- add streaming endpoint for valabilitate cursa images and update view to use it
- switch valabilitate cursa PDF generation to use the DomPDF facade to fix missing class

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69241c5a444883269c7b3fe90859579f)