### PR TITLE
Handle TIMESTAR format visibility like FLASH

### DIFF
--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -133,6 +133,7 @@
         $hasGrupuri = $valabilitate->cursaGrupuri->count() > 0;
         $isFlashDivision = optional($valabilitate->divizie)->id === 1
             && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
+        $hideFormatColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 3;
         $tableColumnCount = $isFlashDivision ? 22 : 12;
     @endphp
     <div class="mx-3 px-3 card" style="border-radius: 40px 40px 40px 40px;">

--- a/resources/views/valabilitati/curse/partials/modals.blade.php
+++ b/resources/views/valabilitati/curse/partials/modals.blade.php
@@ -10,6 +10,7 @@
     $redirectTo = $redirectTo ?? '';
     $isFlashDivision = optional($valabilitate->divizie)->id === 1
         && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
+    $hideFormatColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 3;
     $resolveGroupLabel = static function ($grup) use ($isFlashDivision): string {
         if (! $grup) {
             return '—';
@@ -1344,7 +1345,7 @@
                                     </div>
                                 </div>
                             @else
-                                <div class="col-md-6">
+                                <div class="{{ $hideFormatColumn ? 'col-12' : 'col-md-6' }}">
                                     <label for="group-create-name" class="form-label">Nume grup</label>
                                     <input
                                         type="text"
@@ -1358,24 +1359,26 @@
                                         {{ $isGroupCreateActive ? $errors->first('nume') : '' }}
                                     </div>
                                 </div>
-                                <div class="col-md-6">
-                                    <label for="group-create-format" class="form-label">Format documente</label>
-                                    <select
-                                        class="form-select rounded-3 {{ $isGroupCreateActive && $errors->has('format_documente') ? 'is-invalid' : '' }}"
-                                        id="group-create-format"
-                                        name="format_documente"
-                                    >
-                                        <option value="" @selected($groupCreateFormat === '')>Fără format</option>
-                                        @foreach ($groupFormatOptions as $value => $label)
-                                            <option value="{{ $value }}" @selected($groupCreateFormat === (string) $value)>
-                                                {{ $label }}
-                                            </option>
-                                        @endforeach
-                                    </select>
-                                    <div class="invalid-feedback {{ $isGroupCreateActive && $errors->has('format_documente') ? 'd-block' : '' }}" data-error-for="format_documente">
-                                        {{ $isGroupCreateActive ? $errors->first('format_documente') : '' }}
+                                @unless ($hideFormatColumn)
+                                    <div class="col-md-6">
+                                        <label for="group-create-format" class="form-label">Format documente</label>
+                                        <select
+                                            class="form-select rounded-3 {{ $isGroupCreateActive && $errors->has('format_documente') ? 'is-invalid' : '' }}"
+                                            id="group-create-format"
+                                            name="format_documente"
+                                        >
+                                            <option value="" @selected($groupCreateFormat === '')>Fără format</option>
+                                            @foreach ($groupFormatOptions as $value => $label)
+                                                <option value="{{ $value }}" @selected($groupCreateFormat === (string) $value)>
+                                                    {{ $label }}
+                                                </option>
+                                            @endforeach
+                                        </select>
+                                        <div class="invalid-feedback {{ $isGroupCreateActive && $errors->has('format_documente') ? 'd-block' : '' }}" data-error-for="format_documente">
+                                            {{ $isGroupCreateActive ? $errors->first('format_documente') : '' }}
+                                        </div>
                                     </div>
-                                </div>
+                                @endunless
                             @endif
                             <div class="col-md-6">
                                 <label for="group-create-zile" class="form-label">Zile calculate</label>
@@ -1553,7 +1556,7 @@
                                         </div>
                                     </div>
                                 @else
-                                    <div class="col-md-6">
+                                    <div class="{{ $hideFormatColumn ? 'col-12' : 'col-md-6' }}">
                                         <label for="group-edit-name-{{ $grup->id }}" class="form-label">Nume grup</label>
                                         <input
                                             type="text"
@@ -1567,24 +1570,26 @@
                                             {{ $isGroupEditActive ? $errors->first('nume') : '' }}
                                         </div>
                                     </div>
-                                    <div class="col-md-6">
-                                        <label for="group-edit-format-{{ $grup->id }}" class="form-label">Format documente</label>
-                                        <select
-                                            class="form-select rounded-3 {{ $isGroupEditActive && $errors->has('format_documente') ? 'is-invalid' : '' }}"
-                                            id="group-edit-format-{{ $grup->id }}"
-                                            name="format_documente"
-                                        >
-                                            <option value="" @selected($groupEditFormat === null || $groupEditFormat === '')>Fără format</option>
-                                            @foreach ($groupFormatOptions as $value => $label)
-                                                <option value="{{ $value }}" @selected((string) $groupEditFormat === (string) $value)>
-                                                    {{ $label }}
-                                                </option>
-                                            @endforeach
-                                        </select>
-                                        <div class="invalid-feedback {{ $isGroupEditActive && $errors->has('format_documente') ? 'd-block' : '' }}" data-error-for="format_documente">
-                                            {{ $isGroupEditActive ? $errors->first('format_documente') : '' }}
+                                    @unless ($hideFormatColumn)
+                                        <div class="col-md-6">
+                                            <label for="group-edit-format-{{ $grup->id }}" class="form-label">Format documente</label>
+                                            <select
+                                                class="form-select rounded-3 {{ $isGroupEditActive && $errors->has('format_documente') ? 'is-invalid' : '' }}"
+                                                id="group-edit-format-{{ $grup->id }}"
+                                                name="format_documente"
+                                            >
+                                                <option value="" @selected($groupEditFormat === null || $groupEditFormat === '')>Fără format</option>
+                                                @foreach ($groupFormatOptions as $value => $label)
+                                                    <option value="{{ $value }}" @selected((string) $groupEditFormat === (string) $value)>
+                                                        {{ $label }}
+                                                    </option>
+                                                @endforeach
+                                            </select>
+                                            <div class="invalid-feedback {{ $isGroupEditActive && $errors->has('format_documente') ? 'd-block' : '' }}" data-error-for="format_documente">
+                                                {{ $isGroupEditActive ? $errors->first('format_documente') : '' }}
+                                            </div>
                                         </div>
-                                    </div>
+                                    @endunless
                                 @endif
                                 <div class="col-md-6">
                                     <label for="group-edit-zile-{{ $grup->id }}" class="form-label">Zile calculate</label>

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -1,6 +1,7 @@
 @php
     $isFlashDivision = optional($valabilitate->divizie)->id === 1
         && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
+    $hideFormatColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 3;
     $tableColumnCount = $isFlashDivision ? 22 : 12;
     $divizie = $valabilitate->divizie;
     $priceKmGol = $divizie && $divizie->pret_km_gol !== null ? (float) $divizie->pret_km_gol : null;
@@ -219,7 +220,9 @@
                     <div class="d-flex flex-column flex-xl-row justify-content-between gap-3">
                         <div class="fw-semibold fs-6 text-uppercase">{{ $groupName }}</div>
                         <div class="d-flex flex-wrap gap-3 small curse-group-heading__meta">
-                            <span>Format: <strong>{{ $groupFormat }}</strong></span>
+                            @unless ($hideFormatColumn)
+                                <span>Format: <strong>{{ $groupFormat }}</strong></span>
+                            @endunless
                             <span>Factură: <strong>{{ $groupInvoice }}</strong></span>
                             @if ($groupFinancialMeta)
                                 <span>Sumă încasată: <strong>{{ $groupFinancialMeta['suma_incasata'] ?? '—' }}</strong></span>

--- a/resources/views/valabilitati/curse/partials/summary.blade.php
+++ b/resources/views/valabilitati/curse/partials/summary.blade.php
@@ -3,6 +3,7 @@
         optional($valabilitate->divizie)->id === 1
         && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0
     );
+    $hideFormatColumn = $hideFormatColumn ?? ($isFlashDivision || optional($valabilitate->divizie)->id === 3);
 @endphp
 
 <table class="curse-summary-table">
@@ -99,14 +100,17 @@
     @php
         $showGroupSummary = $showGroupSummary ?? request()->routeIs('valabilitati.grupuri.*');
         $groupFinancials = collect($summary['groupFinancials'] ?? []);
+        $groupSummaryColumnCount = $hideFormatColumn ? 5 : 6;
     @endphp
     @if ($showGroupSummary && $groupFinancials->isNotEmpty())
         <tr>
-            <th colspan="6" class="curse-summary-label text-center">Situație pe grupuri</th>
+            <th colspan="{{ $groupSummaryColumnCount }}" class="curse-summary-label text-center">Situație pe grupuri</th>
         </tr>
         <tr>
             <th class="curse-summary-label">Grup</th>
-            <th class="curse-summary-label">Format</th>
+            @unless ($hideFormatColumn)
+                <th class="curse-summary-label">Format</th>
+            @endunless
             <th class="curse-summary-label">Factură</th>
             <th class="text-end curse-summary-label">Sumă încasată</th>
             <th class="text-end curse-summary-label">Sumă calculată</th>
@@ -128,7 +132,9 @@
             @endphp
             <tr style="background-color: {{ $rowColor }}; color: #111;">
                 <td class="fw-semibold">{{ $group['nume'] }}</td>
-                <td>{{ $group['format_label'] ?? '—' }}</td>
+                @unless ($hideFormatColumn)
+                    <td>{{ $group['format_label'] ?? '—' }}</td>
+                @endunless
                 <td>{{ $facturaLabel }}</td>
                 <td class="text-end">{{ $group['suma_incasata'] !== null ? number_format($group['suma_incasata'], 2) : '—' }}</td>
                 <td class="text-end">{{ $group['suma_calculata'] !== null ? number_format($group['suma_calculata'], 2) : '—' }}</td>
@@ -139,7 +145,7 @@
             $groupTotals = $summary['groupFinancialTotals'] ?? [];
         @endphp
         <tr>
-            <th colspan="3" class="text-end curse-summary-label">Total grupuri</th>
+            <th colspan="{{ $hideFormatColumn ? 2 : 3 }}" class="text-end curse-summary-label">Total grupuri</th>
             <th class="text-end">
                 {{ isset($groupTotals['suma_incasata']) ? number_format($groupTotals['suma_incasata'], 2) : '—' }}
             </th>

--- a/resources/views/valabilitati/grupuri/index.blade.php
+++ b/resources/views/valabilitati/grupuri/index.blade.php
@@ -74,10 +74,15 @@
         };
         $isFlashDivision = optional($valabilitate->divizie)->id === 1
             && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
+        $hideFormatColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 3;
         $hideDifferenceColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 2;
 
         $tableColumnCount = 1; // Index column
-        $tableColumnCount += $isFlashDivision ? 1 : 2; // RR or Grup + Format
+        $tableColumnCount += $isFlashDivision ? 1 : 0; // RR column
+        if (! $isFlashDivision) {
+            $tableColumnCount += 1; // Grup column
+            $tableColumnCount += $hideFormatColumn ? 0 : 1; // Format column
+        }
         $tableColumnCount += 1; // Zile calculate
         $tableColumnCount += 1; // Factură
         $tableColumnCount += $hideDifferenceColumn ? 0 : 1; // Diferență
@@ -153,7 +158,9 @@
                                     <th>RR</th>
                                 @else
                                     <th>Grup</th>
-                                    <th class="curse-nowrap">Format</th>
+                                    @unless ($hideFormatColumn)
+                                        <th class="curse-nowrap">Format</th>
+                                    @endunless
                                 @endif
                                 <th class="text-center curse-nowrap">Zile calculate</th>
                                 <th>Factură</th>
@@ -195,7 +202,9 @@
                                         <td class="fw-semibold">{{ $grup->rr ?? '—' }}</td>
                                     @else
                                         <td class="fw-semibold">{{ $grup->nume ?? '—' }}</td>
-                                        <td class="curse-nowrap">{{ $grup->formatDocumenteLabel() ?: '—' }}</td>
+                                        @unless ($hideFormatColumn)
+                                            <td class="curse-nowrap">{{ $grup->formatDocumenteLabel() ?: '—' }}</td>
+                                        @endunless
                                     @endif
                                     <td class="text-center">{{ $zileCalculate !== null ? $zileCalculate : '—' }}</td>
                                     <td>{{ $facturaLabel }}</td>


### PR DESCRIPTION
## Summary
- extend division handling so TIMESTAR hides format columns alongside FLASH
- adjust grupuri and curse views, summaries, and modals to avoid blank columns when format is hidden

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692422d8bc208326a3c3e7499d76741e)