### PR TITLE
Add conditional divizie pricing fields for FLASH and TIMESTAR

### DIFF
--- a/app/Http/Controllers/ValabilitatiDivizieController.php
+++ b/app/Http/Controllers/ValabilitatiDivizieController.php
@@ -36,6 +36,8 @@ class ValabilitatiDivizieController extends Controller
             'pret_km_gol' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
             'pret_km_plin' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
             'pret_km_cu_taxa' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'pret_km_bord' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'pret_nr_zile_lucrate' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
             'contributie_zilnica' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
         ]);
 
@@ -49,7 +51,7 @@ class ValabilitatiDivizieController extends Controller
      */
     private function formatPrices(array $values): array
     {
-        foreach (['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'contributie_zilnica'] as $field) {
+        foreach (['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'pret_km_bord', 'pret_nr_zile_lucrate', 'contributie_zilnica'] as $field) {
             if (! array_key_exists($field, $values)) {
                 continue;
             }
@@ -80,6 +82,8 @@ class ValabilitatiDivizieController extends Controller
             'pret_km_gol' => $this->formatPrice($divizie->pret_km_gol),
             'pret_km_plin' => $this->formatPrice($divizie->pret_km_plin),
             'pret_km_cu_taxa' => $this->formatPrice($divizie->pret_km_cu_taxa),
+            'pret_km_bord' => $this->formatPrice($divizie->pret_km_bord),
+            'pret_nr_zile_lucrate' => $this->formatPrice($divizie->pret_nr_zile_lucrate),
             'contributie_zilnica' => $this->formatPrice($divizie->contributie_zilnica),
         ];
     }

--- a/app/Models/ValabilitatiDivizie.php
+++ b/app/Models/ValabilitatiDivizie.php
@@ -17,6 +17,8 @@ class ValabilitatiDivizie extends Model
         'pret_km_gol',
         'pret_km_plin',
         'pret_km_cu_taxa',
+        'pret_km_bord',
+        'pret_nr_zile_lucrate',
         'contributie_zilnica',
     ];
 
@@ -24,6 +26,8 @@ class ValabilitatiDivizie extends Model
         'pret_km_gol' => 'decimal:3',
         'pret_km_plin' => 'decimal:3',
         'pret_km_cu_taxa' => 'decimal:3',
+        'pret_km_bord' => 'decimal:3',
+        'pret_nr_zile_lucrate' => 'decimal:3',
         'contributie_zilnica' => 'decimal:3',
     ];
 

--- a/database/factories/ValabilitatiDivizieFactory.php
+++ b/database/factories/ValabilitatiDivizieFactory.php
@@ -19,6 +19,8 @@ class ValabilitatiDivizieFactory extends Factory
             'pret_km_gol' => fake()->randomFloat(3, 0, 10),
             'pret_km_plin' => fake()->randomFloat(3, 0, 15),
             'pret_km_cu_taxa' => fake()->randomFloat(3, 0, 20),
+            'pret_km_bord' => fake()->randomFloat(3, 0, 20),
+            'pret_nr_zile_lucrate' => fake()->randomFloat(3, 0, 30),
         ];
     }
 }

--- a/database/migrations/2025_12_15_000000_add_timestar_fields_to_valabilitati_divizii_table.php
+++ b/database/migrations/2025_12_15_000000_add_timestar_fields_to_valabilitati_divizii_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('valabilitati_divizii', function (Blueprint $table): void {
+            $table->decimal('pret_km_bord', 10, 3)->nullable()->after('pret_km_cu_taxa');
+            $table->decimal('pret_nr_zile_lucrate', 10, 3)->nullable()->after('pret_km_bord');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_divizii', function (Blueprint $table): void {
+            $table->dropColumn(['pret_km_bord', 'pret_nr_zile_lucrate']);
+        });
+    }
+};

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -279,18 +279,35 @@
             const modalFormWrapper = divizieModalElement?.querySelector('[data-modal-form-wrapper]') ?? null;
             const modalAlert = divizieModalElement?.querySelector('[data-modal-alert]') ?? null;
             const modalName = divizieModalElement?.querySelector('[data-divizie-name]') ?? null;
+            const modalEmptyState = divizieModalElement?.querySelector('[data-modal-empty-state]') ?? null;
             const submitButton = divizieModalElement?.querySelector('[data-modal-submit]') ?? null;
             const submitSpinner = divizieModalElement?.querySelector('[data-modal-submit-spinner]') ?? null;
             const submitLabel = divizieModalElement?.querySelector('[data-modal-submit-label]') ?? null;
 
-            const decimalFields = ['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'contributie_zilnica'];
+            const priceFields = ['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'pret_km_bord', 'pret_nr_zile_lucrate', 'contributie_zilnica'];
             const fieldInputs = {};
             const fieldErrors = {};
+            const fieldWrappers = {};
 
-            decimalFields.forEach(field => {
+            priceFields.forEach(field => {
                 fieldInputs[field] = divizieForm ? divizieForm.querySelector(`[name="${field}"]`) : null;
                 fieldErrors[field] = divizieForm ? divizieForm.querySelector(`[data-error-for="${field}"]`) : null;
+                fieldWrappers[field] = divizieForm ? divizieForm.querySelector(`[data-field-wrapper="${field}"]`) : null;
             });
+
+            const getVisibleFieldsForDivizie = (divizieId) => {
+                if (divizieId === 1) {
+                    return ['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'contributie_zilnica'];
+                }
+
+                if (divizieId === 3) {
+                    return ['pret_km_bord', 'pret_nr_zile_lucrate'];
+                }
+
+                return [];
+            };
+
+            let visibleFields = new Set();
 
             const formatDecimalValue = (value) => {
                 if (value === null || value === undefined || value === '') {
@@ -305,8 +322,31 @@
                 return numberValue.toFixed(3);
             };
 
+            const updateFieldVisibility = (divizieId) => {
+                const fields = getVisibleFieldsForDivizie(divizieId);
+                visibleFields = new Set(fields);
+
+                priceFields.forEach(field => {
+                    const wrapper = fieldWrappers[field];
+                    const input = fieldInputs[field];
+                    const isVisible = visibleFields.has(field);
+
+                    if (wrapper) {
+                        wrapper.classList.toggle('d-none', !isVisible);
+                    }
+
+                    if (input) {
+                        input.disabled = !isVisible;
+                    }
+                });
+
+                if (modalEmptyState) {
+                    modalEmptyState.classList.toggle('d-none', visibleFields.size > 0);
+                }
+            };
+
             const resetModalState = () => {
-                decimalFields.forEach(field => {
+                priceFields.forEach(field => {
                     const input = fieldInputs[field];
                     const errorElement = fieldErrors[field];
 
@@ -319,6 +359,8 @@
                         errorElement.textContent = '';
                     }
                 });
+
+                updateFieldVisibility(null);
             };
 
             const toggleModalLoading = (loading) => {
@@ -366,7 +408,7 @@
             };
 
             const fillFormValues = (divizie = {}) => {
-                decimalFields.forEach(field => {
+                priceFields.forEach(field => {
                     const input = fieldInputs[field];
                     const errorElement = fieldErrors[field];
 
@@ -382,7 +424,7 @@
             };
 
             const handleValidationErrors = (errors = {}) => {
-                decimalFields.forEach(field => {
+                priceFields.forEach(field => {
                     const messages = Array.isArray(errors[field]) ? errors[field] : [];
                     const input = fieldInputs[field];
                     const errorElement = fieldErrors[field];
@@ -416,11 +458,11 @@
                 }
 
                 resetModalState();
-                handleValidationErrors();
-                setModalAlert('');
-                toggleModalLoading(true);
+                    handleValidationErrors();
+                    setModalAlert('');
+                    toggleModalLoading(true);
 
-                divizieModalInstance.show();
+                    divizieModalInstance.show();
 
                 fetch(fetchUrl, {
                     headers: {
@@ -437,7 +479,11 @@
                         return response.json();
                     })
                     .then(data => {
-                        fillFormValues(data.divizie || {});
+                        const divizie = data.divizie || {};
+                        const divizieId = Number(divizie.id);
+
+                        updateFieldVisibility(Number.isNaN(divizieId) ? null : divizieId);
+                        fillFormValues(divizie);
                     })
                     .catch(error => {
                         console.error('Valabilități divizie fetch error', error);
@@ -461,7 +507,7 @@
             }
 
             if (divizieForm) {
-                decimalFields.forEach(field => {
+                priceFields.forEach(field => {
                     const input = fieldInputs[field];
                     if (!input) {
                         return;
@@ -494,7 +540,7 @@
                     setModalSavingState(true);
 
                     const payload = {};
-                    decimalFields.forEach(field => {
+                    visibleFields.forEach(field => {
                         const input = fieldInputs[field];
                         const value = input ? input.value.trim() : '';
                         payload[field] = value === '' ? null : value;

--- a/resources/views/valabilitati/partials/divizie-prices-modal.blade.php
+++ b/resources/views/valabilitati/partials/divizie-prices-modal.blade.php
@@ -26,9 +26,12 @@
                     <p class="text-muted">
                         Introdu tarifele pe kilometru cu trei zecimale. Lasă câmpul gol dacă nu se aplică.
                     </p>
+                    <p class="text-muted d-none" data-modal-empty-state>
+                        Nu există câmpuri configurabile pentru această divizie.
+                    </p>
                     <form id="valabilitati-divizie-form" data-divizie-form novalidate>
                         @csrf
-                        <div class="mb-3">
+                        <div class="mb-3" data-field-wrapper="pret_km_gol">
                             <label for="divizie-pret-km-gol" class="form-label">Preț km gol</label>
                             <div class="input-group">
                                 <input
@@ -46,7 +49,7 @@
                             <div class="form-text">Valoare cu până la trei zecimale.</div>
                         </div>
 
-                        <div class="mb-3">
+                        <div class="mb-3" data-field-wrapper="pret_km_plin">
                             <label for="divizie-pret-km-plin" class="form-label">Preț km plin</label>
                             <div class="input-group">
                                 <input
@@ -64,7 +67,7 @@
                             <div class="form-text">Valoare cu până la trei zecimale.</div>
                         </div>
 
-                        <div class="mb-3">
+                        <div class="mb-3" data-field-wrapper="pret_km_cu_taxa">
                             <label for="divizie-pret-km-taxa" class="form-label">Preț km cu taxă</label>
                             <div class="input-group">
                                 <input
@@ -82,7 +85,7 @@
                             <div class="form-text">Valoare cu până la trei zecimale.</div>
                         </div>
 
-                        <div class="mb-3">
+                        <div class="mb-3" data-field-wrapper="contributie_zilnica">
                             <label for="divizie-contributie-zilnica" class="form-label">Contribuție zilnică</label>
                             <div class="input-group">
                                 <input
@@ -96,6 +99,42 @@
                                 >
                                 <span class="input-group-text">/ zi</span>
                                 <div class="invalid-feedback" data-error-for="contributie_zilnica"></div>
+                            </div>
+                            <div class="form-text">Valoare cu până la trei zecimale.</div>
+                        </div>
+
+                        <div class="mb-3" data-field-wrapper="pret_km_bord">
+                            <label for="divizie-pret-km-bord" class="form-label">Preț km bord</label>
+                            <div class="input-group">
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="divizie-pret-km-bord"
+                                    name="pret_km_bord"
+                                    step="0.001"
+                                    min="0"
+                                    data-format-decimal
+                                >
+                                <span class="input-group-text">/ km</span>
+                                <div class="invalid-feedback" data-error-for="pret_km_bord"></div>
+                            </div>
+                            <div class="form-text">Valoare cu până la trei zecimale.</div>
+                        </div>
+
+                        <div class="mb-3" data-field-wrapper="pret_nr_zile_lucrate">
+                            <label for="divizie-pret-zile-lucrate" class="form-label">Preț nr zile lucrate</label>
+                            <div class="input-group">
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="divizie-pret-zile-lucrate"
+                                    name="pret_nr_zile_lucrate"
+                                    step="0.001"
+                                    min="0"
+                                    data-format-decimal
+                                >
+                                <span class="input-group-text">/ zi</span>
+                                <div class="invalid-feedback" data-error-for="pret_nr_zile_lucrate"></div>
                             </div>
                             <div class="form-text">Valoare cu până la trei zecimale.</div>
                         </div>

--- a/tests/Feature/Valabilitati/ValabilitatiDiviziePriceTest.php
+++ b/tests/Feature/Valabilitati/ValabilitatiDiviziePriceTest.php
@@ -21,6 +21,8 @@ class ValabilitatiDiviziePriceTest extends TestCase
             'pret_km_gol' => 1.234,
             'pret_km_plin' => 2.345,
             'pret_km_cu_taxa' => 3.456,
+            'pret_km_bord' => 4.567,
+            'pret_nr_zile_lucrate' => 5.678,
         ]);
 
         $response = $this->actingAs($user)->getJson(route('valabilitati.divizii.show', $divizie));
@@ -31,6 +33,8 @@ class ValabilitatiDiviziePriceTest extends TestCase
         $response->assertJsonPath('divizie.pret_km_gol', '1.234');
         $response->assertJsonPath('divizie.pret_km_plin', '2.345');
         $response->assertJsonPath('divizie.pret_km_cu_taxa', '3.456');
+        $response->assertJsonPath('divizie.pret_km_bord', '4.567');
+        $response->assertJsonPath('divizie.pret_nr_zile_lucrate', '5.678');
     }
 
     public function test_user_can_update_divizie_prices(): void
@@ -40,12 +44,16 @@ class ValabilitatiDiviziePriceTest extends TestCase
             'pret_km_gol' => null,
             'pret_km_plin' => null,
             'pret_km_cu_taxa' => null,
+            'pret_km_bord' => null,
+            'pret_nr_zile_lucrate' => null,
         ]);
 
         $payload = [
             'pret_km_gol' => '10.123',
             'pret_km_plin' => '20.456',
             'pret_km_cu_taxa' => '30.789',
+            'pret_km_bord' => '40.123',
+            'pret_nr_zile_lucrate' => '15.500',
         ];
 
         $response = $this->actingAs($user)->putJson(route('valabilitati.divizii.update', $divizie), $payload);
@@ -54,12 +62,16 @@ class ValabilitatiDiviziePriceTest extends TestCase
         $response->assertJsonPath('divizie.pret_km_gol', '10.123');
         $response->assertJsonPath('divizie.pret_km_plin', '20.456');
         $response->assertJsonPath('divizie.pret_km_cu_taxa', '30.789');
+        $response->assertJsonPath('divizie.pret_km_bord', '40.123');
+        $response->assertJsonPath('divizie.pret_nr_zile_lucrate', '15.500');
 
         $this->assertDatabaseHas('valabilitati_divizii', [
             'id' => $divizie->id,
             'pret_km_gol' => 10.123,
             'pret_km_plin' => 20.456,
             'pret_km_cu_taxa' => 30.789,
+            'pret_km_bord' => 40.123,
+            'pret_nr_zile_lucrate' => 15.500,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add pret_km_bord and pret_nr_zile_lucrate fields to divizii schema, model casting, and factories
- expose the new pricing fields through the divizie API and feature tests
- update the valabilitati divizie modal to show fields based on divizie ID and submit only relevant data

## Testing
- composer install --no-interaction *(fails: network restrictions when cloning dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924243d24748326b02c614dec00dba2)