### PR TITLE
Add flash and timestar pricing fields for valabilitati

### DIFF
--- a/app/Http/Controllers/ValabilitateController.php
+++ b/app/Http/Controllers/ValabilitateController.php
@@ -92,6 +92,15 @@ class ValabilitateController extends Controller
         ]);
     }
 
+    public function showPrices(Valabilitate $valabilitate): JsonResponse
+    {
+        $valabilitate->loadMissing('divizie');
+
+        return response()->json([
+            'valabilitate' => $this->transformValabilitatePrices($valabilitate),
+        ]);
+    }
+
     public function store(Request $request): RedirectResponse|JsonResponse
     {
         $validated = $this->validateValabilitate($request);
@@ -130,6 +139,18 @@ class ValabilitateController extends Controller
         $valabilitate->refresh();
 
         return $this->respondAfterMutation($request, 'Valabilitatea a fost actualizată.', $valabilitate);
+    }
+
+    public function updatePrices(Request $request, Valabilitate $valabilitate): JsonResponse
+    {
+        $validated = $this->validateValabilitatePrices($request);
+
+        $valabilitate->update($validated);
+
+        return response()->json([
+            'message' => 'Tarifele valabilității au fost actualizate.',
+            'valabilitate' => $this->transformValabilitatePrices($valabilitate->fresh()),
+        ]);
     }
 
     public function destroy(Request $request, Valabilitate $valabilitate): RedirectResponse|JsonResponse
@@ -312,6 +333,12 @@ class ValabilitateController extends Controller
             'data_sfarsit' => ['nullable', 'date', 'after_or_equal:data_inceput'],
             'km_plecare' => ['nullable', 'integer', 'min:0'],
             'km_sosire' => ['nullable', 'integer', 'min:0'],
+            'flash_pret_km_gol' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_plin' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_cu_taxa' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_contributie_zilnica' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'timestar_pret_km_bord' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'timestar_pret_nr_zile_lucrate' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
             'taxe_drum' => ['array'],
             'taxe_drum.*.nume' => ['required', 'string', 'max:255'],
             'taxe_drum.*.tara' => ['nullable', 'string', 'max:255'],
@@ -327,6 +354,12 @@ class ValabilitateController extends Controller
             'data_sfarsit' => 'data de sfârșit',
             'km_plecare' => 'km plecare',
             'km_sosire' => 'km sosire',
+            'flash_pret_km_gol' => 'FLASH - preț km gol',
+            'flash_pret_km_plin' => 'FLASH - preț km plin',
+            'flash_pret_km_cu_taxa' => 'FLASH - preț km cu taxă',
+            'flash_contributie_zilnica' => 'FLASH - contribuție zilnică',
+            'timestar_pret_km_bord' => 'TIMESTAR - preț km bord',
+            'timestar_pret_nr_zile_lucrate' => 'TIMESTAR - preț nr zile lucrate',
             'taxe_drum' => 'taxe de drum',
             'taxe_drum.*.nume' => 'nume',
             'taxe_drum.*.tara' => 'țară',
@@ -346,6 +379,7 @@ class ValabilitateController extends Controller
 
         try {
             $validated = $validator->validate();
+            $validated = $this->formatPrices($validated);
             $validated['taxe_drum'] = $this->normalizeRoadTaxesForStorage($sanitizedRoadTaxes);
 
             return $validated;
@@ -390,6 +424,73 @@ class ValabilitateController extends Controller
         }
 
         return response()->json($response);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     *
+     * @return array<string, mixed>
+     */
+    private function formatPrices(array $values): array
+    {
+        foreach ([
+            'flash_pret_km_gol',
+            'flash_pret_km_plin',
+            'flash_pret_km_cu_taxa',
+            'flash_contributie_zilnica',
+            'timestar_pret_km_bord',
+            'timestar_pret_nr_zile_lucrate',
+        ] as $field) {
+            if (! array_key_exists($field, $values)) {
+                continue;
+            }
+
+            $values[$field] = $this->formatPrice($values[$field]);
+        }
+
+        return $values;
+    }
+
+    private function formatPrice(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return number_format((float) $value, 3, '.', '');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function transformValabilitatePrices(Valabilitate $valabilitate): array
+    {
+        return [
+            'id' => $valabilitate->id,
+            'divizie_id' => $valabilitate->divizie_id,
+            'divizie' => $valabilitate->divizie?->nume,
+            'numar_auto' => $valabilitate->numar_auto,
+            'flash_pret_km_gol' => $this->formatPrice($valabilitate->flash_pret_km_gol),
+            'flash_pret_km_plin' => $this->formatPrice($valabilitate->flash_pret_km_plin),
+            'flash_pret_km_cu_taxa' => $this->formatPrice($valabilitate->flash_pret_km_cu_taxa),
+            'flash_contributie_zilnica' => $this->formatPrice($valabilitate->flash_contributie_zilnica),
+            'timestar_pret_km_bord' => $this->formatPrice($valabilitate->timestar_pret_km_bord),
+            'timestar_pret_nr_zile_lucrate' => $this->formatPrice($valabilitate->timestar_pret_nr_zile_lucrate),
+        ];
+    }
+
+    private function validateValabilitatePrices(Request $request): array
+    {
+        $validated = $request->validate([
+            'flash_pret_km_gol' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_plin' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_cu_taxa' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_contributie_zilnica' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'timestar_pret_km_bord' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'timestar_pret_nr_zile_lucrate' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+        ]);
+
+        return $this->formatPrices($validated);
     }
 
     /**

--- a/app/Http/Controllers/ValabilitatiDivizieController.php
+++ b/app/Http/Controllers/ValabilitatiDivizieController.php
@@ -33,12 +33,12 @@ class ValabilitatiDivizieController extends Controller
     private function validatePrices(Request $request): array
     {
         $validated = $request->validate([
-            'pret_km_gol' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
-            'pret_km_plin' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
-            'pret_km_cu_taxa' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
-            'pret_km_bord' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
-            'pret_nr_zile_lucrate' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
-            'contributie_zilnica' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_gol' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_plin' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_pret_km_cu_taxa' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'flash_contributie_zilnica' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'timestar_pret_km_bord' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
+            'timestar_pret_nr_zile_lucrate' => ['nullable', 'numeric', 'min:0', 'max:9999999.999'],
         ]);
 
         return $this->formatPrices($validated);
@@ -51,7 +51,14 @@ class ValabilitatiDivizieController extends Controller
      */
     private function formatPrices(array $values): array
     {
-        foreach (['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'pret_km_bord', 'pret_nr_zile_lucrate', 'contributie_zilnica'] as $field) {
+        foreach ([
+            'flash_pret_km_gol',
+            'flash_pret_km_plin',
+            'flash_pret_km_cu_taxa',
+            'flash_contributie_zilnica',
+            'timestar_pret_km_bord',
+            'timestar_pret_nr_zile_lucrate',
+        ] as $field) {
             if (! array_key_exists($field, $values)) {
                 continue;
             }
@@ -79,12 +86,12 @@ class ValabilitatiDivizieController extends Controller
         return [
             'id' => $divizie->id,
             'nume' => $divizie->nume,
-            'pret_km_gol' => $this->formatPrice($divizie->pret_km_gol),
-            'pret_km_plin' => $this->formatPrice($divizie->pret_km_plin),
-            'pret_km_cu_taxa' => $this->formatPrice($divizie->pret_km_cu_taxa),
-            'pret_km_bord' => $this->formatPrice($divizie->pret_km_bord),
-            'pret_nr_zile_lucrate' => $this->formatPrice($divizie->pret_nr_zile_lucrate),
-            'contributie_zilnica' => $this->formatPrice($divizie->contributie_zilnica),
+            'flash_pret_km_gol' => $this->formatPrice($divizie->flash_pret_km_gol),
+            'flash_pret_km_plin' => $this->formatPrice($divizie->flash_pret_km_plin),
+            'flash_pret_km_cu_taxa' => $this->formatPrice($divizie->flash_pret_km_cu_taxa),
+            'flash_contributie_zilnica' => $this->formatPrice($divizie->flash_contributie_zilnica),
+            'timestar_pret_km_bord' => $this->formatPrice($divizie->timestar_pret_km_bord),
+            'timestar_pret_nr_zile_lucrate' => $this->formatPrice($divizie->timestar_pret_nr_zile_lucrate),
         ];
     }
 }

--- a/app/Models/Valabilitate.php
+++ b/app/Models/Valabilitate.php
@@ -22,6 +22,12 @@ class Valabilitate extends Model
         'numar_auto',
         'sofer_id',
         'divizie_id',
+        'flash_pret_km_gol',
+        'flash_pret_km_plin',
+        'flash_pret_km_cu_taxa',
+        'flash_contributie_zilnica',
+        'timestar_pret_km_bord',
+        'timestar_pret_nr_zile_lucrate',
         'data_inceput',
         'data_sfarsit',
         'km_plecare',
@@ -33,6 +39,12 @@ class Valabilitate extends Model
         'data_sfarsit' => 'date',
         'km_plecare' => 'integer',
         'km_sosire' => 'integer',
+        'flash_pret_km_gol' => 'decimal:3',
+        'flash_pret_km_plin' => 'decimal:3',
+        'flash_pret_km_cu_taxa' => 'decimal:3',
+        'flash_contributie_zilnica' => 'decimal:3',
+        'timestar_pret_km_bord' => 'decimal:3',
+        'timestar_pret_nr_zile_lucrate' => 'decimal:3',
     ];
 
     public function sofer(): BelongsTo

--- a/app/Models/ValabilitatiDivizie.php
+++ b/app/Models/ValabilitatiDivizie.php
@@ -14,21 +14,21 @@ class ValabilitatiDivizie extends Model
 
     protected $fillable = [
         'nume',
-        'pret_km_gol',
-        'pret_km_plin',
-        'pret_km_cu_taxa',
-        'pret_km_bord',
-        'pret_nr_zile_lucrate',
-        'contributie_zilnica',
+        'flash_pret_km_gol',
+        'flash_pret_km_plin',
+        'flash_pret_km_cu_taxa',
+        'flash_contributie_zilnica',
+        'timestar_pret_km_bord',
+        'timestar_pret_nr_zile_lucrate',
     ];
 
     protected $casts = [
-        'pret_km_gol' => 'decimal:3',
-        'pret_km_plin' => 'decimal:3',
-        'pret_km_cu_taxa' => 'decimal:3',
-        'pret_km_bord' => 'decimal:3',
-        'pret_nr_zile_lucrate' => 'decimal:3',
-        'contributie_zilnica' => 'decimal:3',
+        'flash_pret_km_gol' => 'decimal:3',
+        'flash_pret_km_plin' => 'decimal:3',
+        'flash_pret_km_cu_taxa' => 'decimal:3',
+        'flash_contributie_zilnica' => 'decimal:3',
+        'timestar_pret_km_bord' => 'decimal:3',
+        'timestar_pret_nr_zile_lucrate' => 'decimal:3',
     ];
 
     public function valabilitati(): HasMany

--- a/database/factories/ValabilitateFactory.php
+++ b/database/factories/ValabilitateFactory.php
@@ -22,6 +22,12 @@ class ValabilitateFactory extends Factory
             'numar_auto' => strtoupper(fake()->bothify('??##???')),
             'sofer_id' => User::factory(),
             'divizie_id' => ValabilitatiDivizie::factory(),
+            'flash_pret_km_gol' => fake()->randomFloat(3, 0, 10),
+            'flash_pret_km_plin' => fake()->randomFloat(3, 0, 15),
+            'flash_pret_km_cu_taxa' => fake()->randomFloat(3, 0, 20),
+            'flash_contributie_zilnica' => fake()->randomFloat(3, 0, 20),
+            'timestar_pret_km_bord' => fake()->randomFloat(3, 0, 20),
+            'timestar_pret_nr_zile_lucrate' => fake()->randomFloat(3, 0, 30),
             'data_inceput' => $startDate->format('Y-m-d'),
             'data_sfarsit' => fake()->boolean(40)
                 ? fake()->dateTimeBetween($startDate, '+2 months')->format('Y-m-d')

--- a/database/factories/ValabilitatiDivizieFactory.php
+++ b/database/factories/ValabilitatiDivizieFactory.php
@@ -16,11 +16,12 @@ class ValabilitatiDivizieFactory extends Factory
     {
         return [
             'nume' => fake()->unique()->company(),
-            'pret_km_gol' => fake()->randomFloat(3, 0, 10),
-            'pret_km_plin' => fake()->randomFloat(3, 0, 15),
-            'pret_km_cu_taxa' => fake()->randomFloat(3, 0, 20),
-            'pret_km_bord' => fake()->randomFloat(3, 0, 20),
-            'pret_nr_zile_lucrate' => fake()->randomFloat(3, 0, 30),
+            'flash_pret_km_gol' => fake()->randomFloat(3, 0, 10),
+            'flash_pret_km_plin' => fake()->randomFloat(3, 0, 15),
+            'flash_pret_km_cu_taxa' => fake()->randomFloat(3, 0, 20),
+            'flash_contributie_zilnica' => fake()->randomFloat(3, 0, 20),
+            'timestar_pret_km_bord' => fake()->randomFloat(3, 0, 20),
+            'timestar_pret_nr_zile_lucrate' => fake()->randomFloat(3, 0, 30),
         ];
     }
 }

--- a/database/migrations/2026_01_01_000000_rename_pricing_fields_in_valabilitati_divizii.php
+++ b/database/migrations/2026_01_01_000000_rename_pricing_fields_in_valabilitati_divizii.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('valabilitati_divizii', function (Blueprint $table) {
+            $table->decimal('flash_pret_km_gol', 12, 3)->nullable()->after('nume');
+            $table->decimal('flash_pret_km_plin', 12, 3)->nullable()->after('flash_pret_km_gol');
+            $table->decimal('flash_pret_km_cu_taxa', 12, 3)->nullable()->after('flash_pret_km_plin');
+            $table->decimal('flash_contributie_zilnica', 12, 3)->nullable()->after('flash_pret_km_cu_taxa');
+            $table->decimal('timestar_pret_km_bord', 12, 3)->nullable()->after('flash_contributie_zilnica');
+            $table->decimal('timestar_pret_nr_zile_lucrate', 12, 3)->nullable()->after('timestar_pret_km_bord');
+        });
+
+        DB::table('valabilitati_divizii')->select([
+            'id',
+            'pret_km_gol',
+            'pret_km_plin',
+            'pret_km_cu_taxa',
+            'pret_km_bord',
+            'pret_nr_zile_lucrate',
+            'contributie_zilnica',
+        ])->orderBy('id')->chunkById(100, function ($divizii): void {
+            foreach ($divizii as $divizie) {
+                DB::table('valabilitati_divizii')
+                    ->where('id', $divizie->id)
+                    ->update([
+                        'flash_pret_km_gol' => $divizie->pret_km_gol,
+                        'flash_pret_km_plin' => $divizie->pret_km_plin,
+                        'flash_pret_km_cu_taxa' => $divizie->pret_km_cu_taxa,
+                        'flash_contributie_zilnica' => $divizie->contributie_zilnica,
+                        'timestar_pret_km_bord' => $divizie->pret_km_bord,
+                        'timestar_pret_nr_zile_lucrate' => $divizie->pret_nr_zile_lucrate,
+                    ]);
+            }
+        });
+
+        Schema::table('valabilitati_divizii', function (Blueprint $table) {
+            $table->dropColumn([
+                'pret_km_gol',
+                'pret_km_plin',
+                'pret_km_cu_taxa',
+                'pret_km_bord',
+                'pret_nr_zile_lucrate',
+                'contributie_zilnica',
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati_divizii', function (Blueprint $table) {
+            $table->decimal('pret_km_gol', 12, 3)->nullable()->after('nume');
+            $table->decimal('pret_km_plin', 12, 3)->nullable()->after('pret_km_gol');
+            $table->decimal('pret_km_cu_taxa', 12, 3)->nullable()->after('pret_km_plin');
+            $table->decimal('contributie_zilnica', 12, 3)->nullable()->after('pret_km_cu_taxa');
+            $table->decimal('pret_km_bord', 12, 3)->nullable()->after('contributie_zilnica');
+            $table->decimal('pret_nr_zile_lucrate', 12, 3)->nullable()->after('pret_km_bord');
+        });
+
+        DB::table('valabilitati_divizii')->select([
+            'id',
+            'flash_pret_km_gol',
+            'flash_pret_km_plin',
+            'flash_pret_km_cu_taxa',
+            'flash_contributie_zilnica',
+            'timestar_pret_km_bord',
+            'timestar_pret_nr_zile_lucrate',
+        ])->orderBy('id')->chunkById(100, function ($divizii): void {
+            foreach ($divizii as $divizie) {
+                DB::table('valabilitati_divizii')
+                    ->where('id', $divizie->id)
+                    ->update([
+                        'pret_km_gol' => $divizie->flash_pret_km_gol,
+                        'pret_km_plin' => $divizie->flash_pret_km_plin,
+                        'pret_km_cu_taxa' => $divizie->flash_pret_km_cu_taxa,
+                        'contributie_zilnica' => $divizie->flash_contributie_zilnica,
+                        'pret_km_bord' => $divizie->timestar_pret_km_bord,
+                        'pret_nr_zile_lucrate' => $divizie->timestar_pret_nr_zile_lucrate,
+                    ]);
+            }
+        });
+
+        Schema::table('valabilitati_divizii', function (Blueprint $table) {
+            $table->dropColumn([
+                'flash_pret_km_gol',
+                'flash_pret_km_plin',
+                'flash_pret_km_cu_taxa',
+                'flash_contributie_zilnica',
+                'timestar_pret_km_bord',
+                'timestar_pret_nr_zile_lucrate',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_01_01_010000_add_pricing_fields_to_valabilitati.php
+++ b/database/migrations/2026_01_01_010000_add_pricing_fields_to_valabilitati.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('valabilitati', function (Blueprint $table) {
+            $table->decimal('flash_pret_km_gol', 12, 3)->nullable()->after('divizie_id');
+            $table->decimal('flash_pret_km_plin', 12, 3)->nullable()->after('flash_pret_km_gol');
+            $table->decimal('flash_pret_km_cu_taxa', 12, 3)->nullable()->after('flash_pret_km_plin');
+            $table->decimal('flash_contributie_zilnica', 12, 3)->nullable()->after('flash_pret_km_cu_taxa');
+            $table->decimal('timestar_pret_km_bord', 12, 3)->nullable()->after('flash_contributie_zilnica');
+            $table->decimal('timestar_pret_nr_zile_lucrate', 12, 3)->nullable()->after('timestar_pret_km_bord');
+        });
+
+        DB::table('valabilitati as v')
+            ->join('valabilitati_divizii as d', 'v.divizie_id', '=', 'd.id')
+            ->update([
+                'flash_pret_km_gol' => DB::raw('d.flash_pret_km_gol'),
+                'flash_pret_km_plin' => DB::raw('d.flash_pret_km_plin'),
+                'flash_pret_km_cu_taxa' => DB::raw('d.flash_pret_km_cu_taxa'),
+                'flash_contributie_zilnica' => DB::raw('d.flash_contributie_zilnica'),
+                'timestar_pret_km_bord' => DB::raw('d.timestar_pret_km_bord'),
+                'timestar_pret_nr_zile_lucrate' => DB::raw('d.timestar_pret_nr_zile_lucrate'),
+            ]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('valabilitati', function (Blueprint $table) {
+            $table->dropColumn([
+                'flash_pret_km_gol',
+                'flash_pret_km_plin',
+                'flash_pret_km_cu_taxa',
+                'flash_contributie_zilnica',
+                'timestar_pret_km_bord',
+                'timestar_pret_nr_zile_lucrate',
+            ]);
+        });
+    }
+};

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -3,12 +3,11 @@
         && strcasecmp((string) optional($valabilitate->divizie)->nume, 'FLASH') === 0;
     $hideFormatColumn = $isFlashDivision || optional($valabilitate->divizie)->id === 3;
     $tableColumnCount = $isFlashDivision ? 22 : 12;
-    $divizie = $valabilitate->divizie;
-    $priceKmGol = $divizie && $divizie->pret_km_gol !== null ? (float) $divizie->pret_km_gol : null;
-    $priceKmPlin = $divizie && $divizie->pret_km_plin !== null ? (float) $divizie->pret_km_plin : null;
-    $priceKmCuTaxa = $divizie && $divizie->pret_km_cu_taxa !== null ? (float) $divizie->pret_km_cu_taxa : null;
-    $dailyContributionUnit = $divizie && $divizie->contributie_zilnica !== null
-        ? (float) $divizie->contributie_zilnica
+    $priceKmGol = $valabilitate->flash_pret_km_gol !== null ? (float) $valabilitate->flash_pret_km_gol : null;
+    $priceKmPlin = $valabilitate->flash_pret_km_plin !== null ? (float) $valabilitate->flash_pret_km_plin : null;
+    $priceKmCuTaxa = $valabilitate->flash_pret_km_cu_taxa !== null ? (float) $valabilitate->flash_pret_km_cu_taxa : null;
+    $dailyContributionUnit = $valabilitate->flash_contributie_zilnica !== null
+        ? (float) $valabilitate->flash_contributie_zilnica
         : null;
     $formatCalculatedValue = static function (?float $value): string {
         if ($value === null) {

--- a/resources/views/valabilitati/index.blade.php
+++ b/resources/views/valabilitati/index.blade.php
@@ -114,6 +114,7 @@
 </div>
 
 @include('valabilitati.partials.divizie-prices-modal')
+@include('valabilitati.partials.valabilitate-prices-modal')
 
 @push('page-scripts')
     <script>
@@ -270,44 +271,31 @@
             }
 
             const csrfToken = document.head.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
-            const divizieModalElement = document.getElementById('valabilitati-divizie-modal');
-            const divizieModalInstance = divizieModalElement && typeof bootstrap !== 'undefined' && bootstrap.Modal
-                ? new bootstrap.Modal(divizieModalElement)
-                : null;
-            const divizieForm = divizieModalElement?.querySelector('[data-divizie-form]') ?? null;
-            const modalLoading = divizieModalElement?.querySelector('[data-modal-loading]') ?? null;
-            const modalFormWrapper = divizieModalElement?.querySelector('[data-modal-form-wrapper]') ?? null;
-            const modalAlert = divizieModalElement?.querySelector('[data-modal-alert]') ?? null;
-            const modalName = divizieModalElement?.querySelector('[data-divizie-name]') ?? null;
-            const modalEmptyState = divizieModalElement?.querySelector('[data-modal-empty-state]') ?? null;
-            const submitButton = divizieModalElement?.querySelector('[data-modal-submit]') ?? null;
-            const submitSpinner = divizieModalElement?.querySelector('[data-modal-submit-spinner]') ?? null;
-            const submitLabel = divizieModalElement?.querySelector('[data-modal-submit-label]') ?? null;
-
-            const priceFields = ['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'pret_km_bord', 'pret_nr_zile_lucrate', 'contributie_zilnica'];
-            const fieldInputs = {};
-            const fieldErrors = {};
-            const fieldWrappers = {};
-
-            priceFields.forEach(field => {
-                fieldInputs[field] = divizieForm ? divizieForm.querySelector(`[name="${field}"]`) : null;
-                fieldErrors[field] = divizieForm ? divizieForm.querySelector(`[data-error-for="${field}"]`) : null;
-                fieldWrappers[field] = divizieForm ? divizieForm.querySelector(`[data-field-wrapper="${field}"]`) : null;
-            });
+            const priceFields = [
+                'flash_pret_km_gol',
+                'flash_pret_km_plin',
+                'flash_pret_km_cu_taxa',
+                'flash_contributie_zilnica',
+                'timestar_pret_km_bord',
+                'timestar_pret_nr_zile_lucrate',
+            ];
 
             const getVisibleFieldsForDivizie = (divizieId) => {
                 if (divizieId === 1) {
-                    return ['pret_km_gol', 'pret_km_plin', 'pret_km_cu_taxa', 'contributie_zilnica'];
+                    return [
+                        'flash_pret_km_gol',
+                        'flash_pret_km_plin',
+                        'flash_pret_km_cu_taxa',
+                        'flash_contributie_zilnica',
+                    ];
                 }
 
                 if (divizieId === 3) {
-                    return ['pret_km_bord', 'pret_nr_zile_lucrate'];
+                    return ['timestar_pret_km_bord', 'timestar_pret_nr_zile_lucrate'];
                 }
 
                 return [];
             };
-
-            let visibleFields = new Set();
 
             const formatDecimalValue = (value) => {
                 if (value === null || value === undefined || value === '') {
@@ -322,288 +310,369 @@
                 return numberValue.toFixed(3);
             };
 
-            const updateFieldVisibility = (divizieId) => {
-                const fields = getVisibleFieldsForDivizie(divizieId);
-                visibleFields = new Set(fields);
+            const createPriceModalController = ({
+                modalElement,
+                formSelector,
+                triggerSelector,
+                fetchUrlAttr,
+                updateUrlAttr,
+                nameSelector,
+                extractPayload,
+            }) => {
+                if (!modalElement || typeof bootstrap === 'undefined' || !bootstrap.Modal) {
+                    return null;
+                }
+
+                const modalInstance = new bootstrap.Modal(modalElement);
+                const form = modalElement.querySelector(formSelector);
+                const modalLoading = modalElement.querySelector('[data-modal-loading]');
+                const modalFormWrapper = modalElement.querySelector('[data-modal-form-wrapper]');
+                const modalAlert = modalElement.querySelector('[data-modal-alert]');
+                const modalName = modalElement.querySelector(nameSelector);
+                const modalEmptyState = modalElement.querySelector('[data-modal-empty-state]');
+                const submitButton = modalElement.querySelector('[data-modal-submit]');
+                const submitSpinner = modalElement.querySelector('[data-modal-submit-spinner]');
+                const submitLabel = modalElement.querySelector('[data-modal-submit-label]');
+
+                const fieldInputs = {};
+                const fieldErrors = {};
+                const fieldWrappers = {};
 
                 priceFields.forEach(field => {
-                    const wrapper = fieldWrappers[field];
-                    const input = fieldInputs[field];
-                    const isVisible = visibleFields.has(field);
-
-                    if (wrapper) {
-                        wrapper.classList.toggle('d-none', !isVisible);
-                    }
-
-                    if (input) {
-                        input.disabled = !isVisible;
-                    }
+                    fieldInputs[field] = form ? form.querySelector(`[name="${field}"]`) : null;
+                    fieldErrors[field] = form ? form.querySelector(`[data-error-for="${field}"]`) : null;
+                    fieldWrappers[field] = form ? form.querySelector(`[data-field-wrapper="${field}"]`) : null;
                 });
 
-                if (modalEmptyState) {
-                    modalEmptyState.classList.toggle('d-none', visibleFields.size > 0);
-                }
-            };
+                let visibleFields = new Set();
 
-            const resetModalState = () => {
-                priceFields.forEach(field => {
-                    const input = fieldInputs[field];
-                    const errorElement = fieldErrors[field];
+                const updateFieldVisibility = (divizieId) => {
+                    const fields = getVisibleFieldsForDivizie(divizieId);
+                    visibleFields = new Set(fields);
 
-                    if (input) {
-                        input.value = '';
-                        input.classList.remove('is-invalid');
-                    }
-
-                    if (errorElement) {
-                        errorElement.textContent = '';
-                    }
-                });
-
-                updateFieldVisibility(null);
-            };
-
-            const toggleModalLoading = (loading) => {
-                if (modalLoading) {
-                    modalLoading.classList.toggle('d-none', !loading);
-                }
-
-                if (modalFormWrapper) {
-                    modalFormWrapper.classList.toggle('d-none', loading);
-                }
-            };
-
-            const setModalAlert = (message = '', type = 'danger') => {
-                if (!modalAlert) {
-                    return;
-                }
-
-                modalAlert.classList.remove('alert-danger', 'alert-success');
-                modalAlert.classList.add(`alert-${type}`);
-
-                if (!message) {
-                    modalAlert.classList.add('d-none');
-                    modalAlert.textContent = '';
-                    return;
-                }
-
-                modalAlert.textContent = message;
-                modalAlert.classList.remove('d-none');
-            };
-
-            const setModalSavingState = (saving) => {
-                if (!submitButton) {
-                    return;
-                }
-
-                submitButton.disabled = saving;
-
-                if (submitSpinner) {
-                    submitSpinner.classList.toggle('d-none', !saving);
-                }
-
-                if (submitLabel) {
-                    submitLabel.textContent = saving ? 'Se salvează...' : 'Salvează';
-                }
-            };
-
-            const fillFormValues = (divizie = {}) => {
-                priceFields.forEach(field => {
-                    const input = fieldInputs[field];
-                    const errorElement = fieldErrors[field];
-
-                    if (input) {
-                        input.value = formatDecimalValue(divizie[field]);
-                        input.classList.remove('is-invalid');
-                    }
-
-                    if (errorElement) {
-                        errorElement.textContent = '';
-                    }
-                });
-            };
-
-            const handleValidationErrors = (errors = {}) => {
-                priceFields.forEach(field => {
-                    const messages = Array.isArray(errors[field]) ? errors[field] : [];
-                    const input = fieldInputs[field];
-                    const errorElement = fieldErrors[field];
-
-                    if (input) {
-                        input.classList.toggle('is-invalid', messages.length > 0);
-                    }
-
-                    if (errorElement) {
-                        errorElement.textContent = messages.length ? messages[0] : '';
-                    }
-                });
-            };
-
-            const openDivizieModal = (trigger) => {
-                if (!divizieModalInstance || !divizieForm) {
-                    return;
-                }
-
-                const fetchUrl = trigger.getAttribute('data-fetch-url') || '';
-                const updateUrl = trigger.getAttribute('data-update-url') || '';
-
-                if (!fetchUrl || !updateUrl) {
-                    return;
-                }
-
-                divizieForm.dataset.updateUrl = updateUrl;
-
-                if (modalName) {
-                    modalName.textContent = trigger.getAttribute('data-divizie-name') || '';
-                }
-
-                resetModalState();
-                    handleValidationErrors();
-                    setModalAlert('');
-                    toggleModalLoading(true);
-
-                    divizieModalInstance.show();
-
-                fetch(fetchUrl, {
-                    headers: {
-                        'X-Requested-With': 'XMLHttpRequest',
-                        'Accept': 'application/json',
-                    },
-                    credentials: 'same-origin',
-                })
-                    .then(response => {
-                        if (!response.ok) {
-                            throw new Error(`Request failed with status ${response.status}`);
-                        }
-
-                        return response.json();
-                    })
-                    .then(data => {
-                        const divizie = data.divizie || {};
-                        const divizieId = Number(divizie.id);
-
-                        updateFieldVisibility(Number.isNaN(divizieId) ? null : divizieId);
-                        fillFormValues(divizie);
-                    })
-                    .catch(error => {
-                        console.error('Valabilități divizie fetch error', error);
-                        setModalAlert('Nu am putut încărca tarifele diviziei. Reîncercați.');
-                    })
-                    .finally(() => {
-                        toggleModalLoading(false);
-                    });
-            };
-
-            if (tableBody && divizieModalInstance) {
-                tableBody.addEventListener('click', event => {
-                    const trigger = event.target.closest('[data-divizie-prices-trigger]');
-                    if (!trigger) {
-                        return;
-                    }
-
-                    event.preventDefault();
-                    openDivizieModal(trigger);
-                });
-            }
-
-            if (divizieForm) {
-                priceFields.forEach(field => {
-                    const input = fieldInputs[field];
-                    if (!input) {
-                        return;
-                    }
-
-                    input.addEventListener('blur', () => {
-                        if (input.value === '') {
-                            return;
-                        }
-
-                        const numericValue = Number(input.value);
-                        if (Number.isNaN(numericValue)) {
-                            return;
-                        }
-
-                        input.value = numericValue.toFixed(3);
-                    });
-                });
-
-                divizieForm.addEventListener('submit', event => {
-                    event.preventDefault();
-
-                    const updateUrl = divizieForm.dataset.updateUrl || '';
-                    if (!updateUrl) {
-                        return;
-                    }
-
-                    handleValidationErrors();
-                    setModalAlert('');
-                    setModalSavingState(true);
-
-                    const payload = {};
-                    visibleFields.forEach(field => {
+                    priceFields.forEach(field => {
+                        const wrapper = fieldWrappers[field];
                         const input = fieldInputs[field];
-                        const value = input ? input.value.trim() : '';
-                        payload[field] = value === '' ? null : value;
+                        const isVisible = visibleFields.has(field);
+
+                        if (wrapper) {
+                            wrapper.classList.toggle('d-none', !isVisible);
+                        }
+
+                        if (input) {
+                            input.disabled = !isVisible;
+                        }
                     });
 
-                    fetch(updateUrl, {
-                        method: 'PUT',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'Accept': 'application/json',
-                            'X-Requested-With': 'XMLHttpRequest',
-                            'X-CSRF-TOKEN': csrfToken,
-                        },
-                        credentials: 'same-origin',
-                        body: JSON.stringify(payload),
-                    })
-                        .then(async response => {
-                            const data = await response.json().catch(() => ({}));
+                    if (modalEmptyState) {
+                        modalEmptyState.classList.toggle('d-none', visibleFields.size > 0);
+                    }
+                };
 
-                            if (!response.ok) {
-                                if (response.status === 422) {
-                                    handleValidationErrors(data.errors || {});
-                                    setModalAlert(data.message || 'Verifică datele introduse.');
-                                    throw new Error('validation');
-                                }
+                const resetModalState = () => {
+                    priceFields.forEach(field => {
+                        const input = fieldInputs[field];
+                        const errorElement = fieldErrors[field];
 
-                                throw new Error(data.message || `Request failed with status ${response.status}`);
-                            }
+                        if (input) {
+                            input.value = '';
+                            input.classList.remove('is-invalid');
+                        }
 
-                            return data;
-                        })
-                        .then(data => {
-                            if (divizieModalInstance) {
-                                divizieModalInstance.hide();
-                            }
+                        if (errorElement) {
+                            errorElement.textContent = '';
+                        }
+                    });
 
-                            renderFeedback(data.message || 'Tarifele diviziei au fost actualizate.', 'success');
-                        })
-                        .catch(error => {
-                            if (error.message === 'validation') {
-                                return;
-                            }
+                    updateFieldVisibility(null);
+                };
 
-                            console.error('Valabilități divizie save error', error);
-                            setModalAlert('Nu am putut salva tarifele diviziei. Reîncercați.');
-                        })
-                        .finally(() => {
-                            setModalSavingState(false);
-                        });
-                });
-            }
+                const toggleModalLoading = (loading) => {
+                    if (modalLoading) {
+                        modalLoading.classList.toggle('d-none', !loading);
+                    }
 
-            if (divizieModalElement) {
-                divizieModalElement.addEventListener('hidden.bs.modal', () => {
+                    if (modalFormWrapper) {
+                        modalFormWrapper.classList.toggle('d-none', loading);
+                    }
+                };
+
+                const setModalAlert = (message = '', type = 'danger') => {
+                    if (!modalAlert) {
+                        return;
+                    }
+
+                    modalAlert.classList.remove('alert-danger', 'alert-success');
+                    modalAlert.classList.add(`alert-${type}`);
+
+                    if (!message) {
+                        modalAlert.classList.add('d-none');
+                        modalAlert.textContent = '';
+                        return;
+                    }
+
+                    modalAlert.textContent = message;
+                    modalAlert.classList.remove('d-none');
+                };
+
+                const setModalSavingState = (saving) => {
+                    if (!submitButton) {
+                        return;
+                    }
+
+                    submitButton.disabled = saving;
+
+                    if (submitSpinner) {
+                        submitSpinner.classList.toggle('d-none', !saving);
+                    }
+
+                    if (submitLabel) {
+                        submitLabel.textContent = saving ? 'Se salvează...' : 'Salvează';
+                    }
+                };
+
+                const fillFormValues = (values = {}) => {
+                    priceFields.forEach(field => {
+                        const input = fieldInputs[field];
+                        const errorElement = fieldErrors[field];
+
+                        if (input) {
+                            input.value = formatDecimalValue(values[field]);
+                            input.classList.remove('is-invalid');
+                        }
+
+                        if (errorElement) {
+                            errorElement.textContent = '';
+                        }
+                    });
+                };
+
+                const handleValidationErrors = (errors = {}) => {
+                    priceFields.forEach(field => {
+                        const messages = Array.isArray(errors[field]) ? errors[field] : [];
+                        const input = fieldInputs[field];
+                        const errorElement = fieldErrors[field];
+
+                        if (input) {
+                            input.classList.toggle('is-invalid', messages.length > 0);
+                        }
+
+                        if (errorElement) {
+                            errorElement.textContent = messages.length ? messages[0] : '';
+                        }
+                    });
+                };
+
+                const openModal = (trigger) => {
+                    if (!form) {
+                        return;
+                    }
+
+                    const fetchUrl = trigger.getAttribute(fetchUrlAttr) || '';
+                    const updateUrl = trigger.getAttribute(updateUrlAttr) || '';
+
+                    if (!fetchUrl || !updateUrl) {
+                        return;
+                    }
+
+                    form.dataset.updateUrl = updateUrl;
+
                     resetModalState();
                     handleValidationErrors();
                     setModalAlert('');
                     toggleModalLoading(true);
 
-                    if (divizieForm) {
-                        delete divizieForm.dataset.updateUrl;
+                    const initialName = trigger.getAttribute('data-price-modal-name') || '';
+                    if (modalName && initialName) {
+                        modalName.textContent = initialName;
+                    }
+
+                    modalInstance.show();
+
+                    fetch(fetchUrl, {
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'Accept': 'application/json',
+                        },
+                        credentials: 'same-origin',
+                    })
+                        .then(response => {
+                            if (!response.ok) {
+                                throw new Error(`Request failed with status ${response.status}`);
+                            }
+
+                            return response.json();
+                        })
+                        .then(data => {
+                            const payload = extractPayload(data, trigger) || {};
+                            const divizieId = Number(payload.divizieId);
+
+                            if (modalName && payload.name) {
+                                modalName.textContent = payload.name;
+                            }
+
+                            updateFieldVisibility(Number.isNaN(divizieId) ? null : divizieId);
+                            fillFormValues(payload.values || {});
+                        })
+                        .catch(error => {
+                            console.error('Valabilități tarife fetch error', error);
+                            setModalAlert('Nu am putut încărca tarifele. Reîncercați.');
+                        })
+                        .finally(() => {
+                            toggleModalLoading(false);
+                        });
+                };
+
+                if (form) {
+                    priceFields.forEach(field => {
+                        const input = fieldInputs[field];
+                        if (!input) {
+                            return;
+                        }
+
+                        input.addEventListener('blur', () => {
+                            if (input.value === '') {
+                                return;
+                            }
+
+                            const numericValue = Number(input.value);
+                            if (Number.isNaN(numericValue)) {
+                                return;
+                            }
+
+                            input.value = numericValue.toFixed(3);
+                        });
+                    });
+
+                    form.addEventListener('submit', event => {
+                        event.preventDefault();
+
+                        const updateUrl = form.dataset.updateUrl || '';
+                        if (!updateUrl) {
+                            return;
+                        }
+
+                        handleValidationErrors();
+                        setModalAlert('');
+                        setModalSavingState(true);
+
+                        const payload = {};
+                        visibleFields.forEach(field => {
+                            const input = fieldInputs[field];
+                            const value = input ? input.value.trim() : '';
+                            payload[field] = value === '' ? null : value;
+                        });
+
+                        fetch(updateUrl, {
+                            method: 'PUT',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'Accept': 'application/json',
+                                'X-Requested-With': 'XMLHttpRequest',
+                                'X-CSRF-TOKEN': csrfToken,
+                            },
+                            credentials: 'same-origin',
+                            body: JSON.stringify(payload),
+                        })
+                            .then(async response => {
+                                const data = await response.json().catch(() => ({}));
+
+                                if (!response.ok) {
+                                    if (response.status === 422) {
+                                        handleValidationErrors(data.errors || {});
+                                        setModalAlert(data.message || 'Verifică datele introduse.');
+                                        throw new Error('validation');
+                                    }
+
+                                    throw new Error(data.message || `Request failed with status ${response.status}`);
+                                }
+
+                                return data;
+                            })
+                            .then(data => {
+                                modalInstance.hide();
+                                renderFeedback(data.message || 'Tarifele au fost actualizate.', 'success');
+                            })
+                            .catch(error => {
+                                if (error.message === 'validation') {
+                                    return;
+                                }
+
+                                console.error('Valabilități tarife save error', error);
+                                setModalAlert('Nu am putut salva tarifele. Reîncercați.');
+                            })
+                            .finally(() => {
+                                setModalSavingState(false);
+                            });
+                    });
+                }
+
+                modalElement.addEventListener('hidden.bs.modal', () => {
+                    resetModalState();
+                    handleValidationErrors();
+                    setModalAlert('');
+                    toggleModalLoading(true);
+
+                    if (form) {
+                        delete form.dataset.updateUrl;
                     }
                 });
+
+                return {
+                    attach(container) {
+                        container?.addEventListener('click', event => {
+                            const trigger = event.target.closest(triggerSelector);
+                            if (!trigger) {
+                                return;
+                            }
+
+                            event.preventDefault();
+                            openModal(trigger);
+                        });
+                    },
+                };
+            };
+
+            const divizieModalController = createPriceModalController({
+                modalElement: document.getElementById('valabilitati-divizie-modal'),
+                formSelector: '[data-divizie-form]',
+                triggerSelector: '[data-divizie-prices-trigger]',
+                fetchUrlAttr: 'data-fetch-url',
+                updateUrlAttr: 'data-update-url',
+                nameSelector: '[data-price-modal-name]',
+                extractPayload: (data, trigger) => {
+                    const divizie = data.divizie || {};
+
+                    return {
+                        values: divizie,
+                        divizieId: Number(divizie.id),
+                        name: trigger?.getAttribute('data-divizie-name') || divizie.nume || '',
+                    };
+                },
+            });
+
+            const valabilitateModalController = createPriceModalController({
+                modalElement: document.getElementById('valabilitati-price-modal'),
+                formSelector: '[data-valabilitate-form]',
+                triggerSelector: '[data-valabilitate-prices-trigger]',
+                fetchUrlAttr: 'data-fetch-url',
+                updateUrlAttr: 'data-update-url',
+                nameSelector: '[data-price-modal-name]',
+                extractPayload: (data, trigger) => {
+                    const valabilitate = data.valabilitate || {};
+                    const divizieId = Number(valabilitate.divizie_id ?? trigger?.getAttribute('data-divizie-id'));
+
+                    return {
+                        values: valabilitate,
+                        divizieId,
+                        name: valabilitate.numar_auto || trigger?.getAttribute('data-valabilitate-numar-auto') || '',
+                    };
+                },
+            });
+
+            if (tableBody) {
+                divizieModalController?.attach(tableBody);
+                valabilitateModalController?.attach(tableBody);
             }
         });
     </script>

--- a/resources/views/valabilitati/partials/rows.blade.php
+++ b/resources/views/valabilitati/partials/rows.blade.php
@@ -18,6 +18,7 @@
                     class="btn btn-link p-0 align-baseline text-decoration-none fw-semibold"
                     data-divizie-prices-trigger
                     data-divizie-name="{{ $valabilitate->divizie->nume }}"
+                    data-price-modal-name="{{ $valabilitate->divizie->nume }}"
                     data-fetch-url="{{ route('valabilitati.divizii.show', $valabilitate->divizie) }}"
                     data-update-url="{{ route('valabilitati.divizii.update', $valabilitate->divizie) }}"
                 >
@@ -39,6 +40,21 @@
                 <div class="ms-1">
                     <a href="{{ route('valabilitati.curse.index', $valabilitate) }}" class="flex">
                         <span class="badge bg-info text-dark">Curse</span>
+                    </a>
+                </div>
+                <div class="ms-1">
+                    <a
+                        href="#"
+                        class="flex"
+                        data-valabilitate-prices-trigger
+                        data-price-modal-name="{{ $valabilitate->numar_auto }}"
+                        data-valabilitate-numar-auto="{{ $valabilitate->numar_auto }}"
+                        data-divizie-id="{{ $valabilitate->divizie_id }}"
+                        data-fetch-url="{{ route('valabilitati.prices.show', $valabilitate) }}"
+                        data-update-url="{{ route('valabilitati.prices.update', $valabilitate) }}"
+                        title="Tarife valabilitate"
+                    >
+                        <span class="badge bg-secondary text-white">Tarife valabilitate</span>
                     </a>
                 </div>
                 <div class="ms-1">

--- a/resources/views/valabilitati/partials/valabilitate-prices-modal.blade.php
+++ b/resources/views/valabilitati/partials/valabilitate-prices-modal.blade.php
@@ -1,16 +1,16 @@
 <div
     class="modal fade"
-    id="valabilitati-divizie-modal"
+    id="valabilitati-price-modal"
     tabindex="-1"
-    aria-labelledby="valabilitati-divizie-modal-label"
+    aria-labelledby="valabilitati-price-modal-label"
     aria-hidden="true"
 >
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="valabilitati-divizie-modal-label">
-                    Tarife divizie
-                    <span class="text-primary" data-price-modal-name data-divizie-name></span>
+                <h5 class="modal-title" id="valabilitati-price-modal-label">
+                    Tarife valabilitate
+                    <span class="text-primary" data-price-modal-name></span>
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Închide"></button>
             </div>
@@ -19,7 +19,7 @@
 
                 <div class="d-flex flex-column align-items-center py-4 gap-2 d-none" data-modal-loading>
                     <div class="spinner-border" role="status" aria-hidden="true"></div>
-                    <p class="text-muted mb-0">Se încarcă informațiile diviziei...</p>
+                    <p class="text-muted mb-0">Se încarcă tarifele valabilității...</p>
                 </div>
 
                 <div class="d-none" data-modal-form-wrapper>
@@ -27,17 +27,17 @@
                         Introdu tarifele pe kilometru cu trei zecimale. Lasă câmpul gol dacă nu se aplică.
                     </p>
                     <p class="text-muted d-none" data-modal-empty-state>
-                        Nu există câmpuri configurabile pentru această divizie.
+                        Nu există câmpuri configurabile pentru această valabilitate.
                     </p>
-                    <form id="valabilitati-divizie-form" data-divizie-form novalidate>
+                    <form id="valabilitati-price-form" data-price-form data-valabilitate-form novalidate>
                         @csrf
                         <div class="mb-3" data-field-wrapper="flash_pret_km_gol">
-                            <label for="divizie-pret-km-gol" class="form-label">FLASH - preț km gol</label>
+                            <label for="valabilitate-pret-km-gol" class="form-label">FLASH - preț km gol</label>
                             <div class="input-group">
                                 <input
                                     type="number"
                                     class="form-control"
-                                    id="divizie-pret-km-gol"
+                                    id="valabilitate-pret-km-gol"
                                     name="flash_pret_km_gol"
                                     step="0.001"
                                     min="0"
@@ -50,12 +50,12 @@
                         </div>
 
                         <div class="mb-3" data-field-wrapper="flash_pret_km_plin">
-                            <label for="divizie-pret-km-plin" class="form-label">FLASH - preț km plin</label>
+                            <label for="valabilitate-pret-km-plin" class="form-label">FLASH - preț km plin</label>
                             <div class="input-group">
                                 <input
                                     type="number"
                                     class="form-control"
-                                    id="divizie-pret-km-plin"
+                                    id="valabilitate-pret-km-plin"
                                     name="flash_pret_km_plin"
                                     step="0.001"
                                     min="0"
@@ -68,12 +68,12 @@
                         </div>
 
                         <div class="mb-3" data-field-wrapper="flash_pret_km_cu_taxa">
-                            <label for="divizie-pret-km-taxa" class="form-label">FLASH - preț km cu taxă</label>
+                            <label for="valabilitate-pret-km-taxa" class="form-label">FLASH - preț km cu taxă</label>
                             <div class="input-group">
                                 <input
                                     type="number"
                                     class="form-control"
-                                    id="divizie-pret-km-taxa"
+                                    id="valabilitate-pret-km-taxa"
                                     name="flash_pret_km_cu_taxa"
                                     step="0.001"
                                     min="0"
@@ -86,12 +86,12 @@
                         </div>
 
                         <div class="mb-3" data-field-wrapper="flash_contributie_zilnica">
-                            <label for="divizie-contributie-zilnica" class="form-label">FLASH - contribuție zilnică</label>
+                            <label for="valabilitate-contributie-zilnica" class="form-label">FLASH - contribuție zilnică</label>
                             <div class="input-group">
                                 <input
                                     type="number"
                                     class="form-control"
-                                    id="divizie-contributie-zilnica"
+                                    id="valabilitate-contributie-zilnica"
                                     name="flash_contributie_zilnica"
                                     step="0.001"
                                     min="0"
@@ -104,12 +104,12 @@
                         </div>
 
                         <div class="mb-3" data-field-wrapper="timestar_pret_km_bord">
-                            <label for="divizie-pret-km-bord" class="form-label">TIMESTAR - preț km bord</label>
+                            <label for="valabilitate-pret-km-bord" class="form-label">TIMESTAR - preț km bord</label>
                             <div class="input-group">
                                 <input
                                     type="number"
                                     class="form-control"
-                                    id="divizie-pret-km-bord"
+                                    id="valabilitate-pret-km-bord"
                                     name="timestar_pret_km_bord"
                                     step="0.001"
                                     min="0"
@@ -122,12 +122,12 @@
                         </div>
 
                         <div class="mb-3" data-field-wrapper="timestar_pret_nr_zile_lucrate">
-                            <label for="divizie-pret-zile-lucrate" class="form-label">TIMESTAR - preț nr zile lucrate</label>
+                            <label for="valabilitate-pret-zile-lucrate" class="form-label">TIMESTAR - preț nr zile lucrate</label>
                             <div class="input-group">
                                 <input
                                     type="number"
                                     class="form-control"
-                                    id="divizie-pret-zile-lucrate"
+                                    id="valabilitate-pret-zile-lucrate"
                                     name="timestar_pret_nr_zile_lucrate"
                                     step="0.001"
                                     min="0"
@@ -143,7 +143,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Închide</button>
-                <button type="submit" class="btn btn-primary" form="valabilitati-divizie-form" data-modal-submit>
+                <button type="submit" class="btn btn-primary" form="valabilitati-price-form" data-modal-submit>
                     <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true" data-modal-submit-spinner></span>
                     <span data-modal-submit-label>Salvează</span>
                 </button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -370,6 +370,10 @@ Route::middleware(['auth'])->group(function () {
     Route::middleware(['permission:valabilitati', 'role:super-admin,admin,dispecer'])->group(function () {
         Route::get('valabilitati/paginate', [ValabilitateController::class, 'paginate'])
             ->name('valabilitati.paginate');
+        Route::get('valabilitati/{valabilitate}/prices', [ValabilitateController::class, 'showPrices'])
+            ->name('valabilitati.prices.show');
+        Route::put('valabilitati/{valabilitate}/prices', [ValabilitateController::class, 'updatePrices'])
+            ->name('valabilitati.prices.update');
 
         Route::get('valabilitati/divizii/{divizie}', [ValabilitatiDivizieController::class, 'show'])
             ->name('valabilitati.divizii.show');


### PR DESCRIPTION
## Summary
- rename divizie pricing columns to flash/timestar, add matching fields to valabilitati, and backfill current values
- refresh valabilitati pricing UI: update divizie modal to new field names and add a modal for per-valabilitate pricing edits
- read per-valabilitate prices on curse pages instead of divizie defaults

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243ee608e88326b61dafbdca8b2cd5)