### PR TITLE
Compute calculated sums for curse groups dynamically

### DIFF
--- a/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
+++ b/app/Http/Controllers/Concerns/HandlesValabilitatiCurseListings.php
@@ -78,6 +78,7 @@ trait HandlesValabilitatiCurseListings
             'table_html' => view('valabilitati.curse.partials.rows', [
                 'valabilitate' => $valabilitate,
                 'curse' => $curse,
+                'groupFinancials' => $summary['groupFinancials'] ?? collect(),
             ])->render(),
             'modals_html' => view('valabilitati.curse.partials.modals', $this->buildModalViewData(
                 $valabilitate,
@@ -93,6 +94,8 @@ trait HandlesValabilitatiCurseListings
 
     protected function buildSummaryData(Valabilitate $valabilitate, $curse): array
     {
+        $valabilitate->loadMissing(['cursaGrupuri.curse']);
+
         $curseCollection = $this->resolveCurseCollection($curse);
 
         $isFlashDivision = optional($valabilitate->divizie)->id === 1;
@@ -185,30 +188,7 @@ trait HandlesValabilitatiCurseListings
             ? $dataInceput->diffInDays($dataSfarsit) + 1
             : null;
 
-        $groupFinancials = $valabilitate->cursaGrupuri
-            ->map(static function ($grup) {
-                $incasata = $grup->suma_incasata !== null ? (float) $grup->suma_incasata : null;
-                $calculata = $grup->suma_calculata !== null ? (float) $grup->suma_calculata : null;
-                $diferenta = null;
-
-                if ($incasata !== null || $calculata !== null) {
-                    $diferenta = ($incasata ?? 0.0) - ($calculata ?? 0.0);
-                }
-
-                return [
-                    'id' => $grup->getKey(),
-                    'nume' => $grup->nume,
-                    'format' => $grup->format_documente,
-                    'format_label' => $grup->formatDocumenteLabel(),
-                    'suma_incasata' => $incasata,
-                    'suma_calculata' => $calculata,
-                    'diferenta' => $diferenta,
-                    'numar_factura' => $grup->numar_factura,
-                    'data_factura' => $grup->data_factura,
-                    'culoare_hex' => $grup->culoare_hex,
-                ];
-            })
-            ->values();
+        $groupFinancials = $this->buildGroupFinancials($valabilitate);
 
         $groupTotals = [
             'suma_incasata' => $groupFinancials->pluck('suma_incasata')->filter(static fn ($v) => $v !== null)->sum(),
@@ -251,6 +231,72 @@ trait HandlesValabilitatiCurseListings
             'groupFinancials' => $groupFinancials,
             'groupFinancialTotals' => $groupTotals,
         ];
+    }
+
+    protected function buildGroupFinancials(Valabilitate $valabilitate): Collection
+    {
+        return $valabilitate->cursaGrupuri
+            ->map(function ($grup) use ($valabilitate) {
+                $incasata = $grup->suma_incasata !== null ? (float) $grup->suma_incasata : null;
+                $calculata = $this->computeGroupCalculatedAmount($grup, $valabilitate);
+                $diferenta = null;
+
+                if ($incasata !== null || $calculata !== null) {
+                    $diferenta = ($incasata ?? 0.0) - ($calculata ?? 0.0);
+                }
+
+                return [
+                    'id' => $grup->getKey(),
+                    'nume' => $grup->nume,
+                    'format' => $grup->format_documente,
+                    'format_label' => $grup->formatDocumenteLabel(),
+                    'suma_incasata' => $incasata,
+                    'suma_calculata' => $calculata,
+                    'diferenta' => $diferenta,
+                    'numar_factura' => $grup->numar_factura,
+                    'data_factura' => $grup->data_factura,
+                    'culoare_hex' => $grup->culoare_hex,
+                    'zile_calculate' => is_numeric($grup->zile_calculate) ? (int) $grup->zile_calculate : null,
+                ];
+            })
+            ->values();
+    }
+
+    protected function computeGroupCalculatedAmount(ValabilitateCursaGrup $grup, Valabilitate $valabilitate): ?float
+    {
+        $pricePerKm = $valabilitate->timestar_pret_km_bord !== null
+            ? (float) $valabilitate->timestar_pret_km_bord
+            : null;
+        $pricePerDay = $valabilitate->timestar_pret_nr_zile_lucrate !== null
+            ? (float) $valabilitate->timestar_pret_nr_zile_lucrate
+            : null;
+
+        $kmStart = $grup->curse
+            ->pluck('km_bord_incarcare')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value)
+            ->min();
+
+        $kmEnd = $grup->curse
+            ->pluck('km_bord_descarcare')
+            ->filter(static fn ($value) => $value !== null && $value !== '' && is_numeric($value))
+            ->map(static fn ($value) => (float) $value)
+            ->max();
+
+        $daysWorked = is_numeric($grup->zile_calculate) ? (int) $grup->zile_calculate : null;
+
+        $kmComponent = $kmStart !== null && $kmEnd !== null && $pricePerKm !== null
+            ? round($kmEnd - $kmStart, 2) * $pricePerKm
+            : null;
+        $dayComponent = $daysWorked !== null && $pricePerDay !== null
+            ? $daysWorked * $pricePerDay
+            : null;
+
+        if ($kmComponent === null && $dayComponent === null) {
+            return null;
+        }
+
+        return round(($kmComponent ?? 0) + ($dayComponent ?? 0), 2);
     }
 
     protected function resolveCurseCollection($curse): Collection

--- a/app/Http/Controllers/ValabilitateCursaController.php
+++ b/app/Http/Controllers/ValabilitateCursaController.php
@@ -47,6 +47,7 @@ class ValabilitateCursaController extends Controller
             'nextPageUrl' => $this->buildNextPageUrl($request, $valabilitate, $curse),
             'backUrl' => ValabilitatiFilterState::route(),
             'summary' => $summary,
+            'groupFinancials' => $summary['groupFinancials'] ?? collect(),
             'modalViewData' => $modalViewData,
             'bulkAssignRoute' => route('valabilitati.curse.bulk-assign', $valabilitate),
         ]);
@@ -66,6 +67,7 @@ class ValabilitateCursaController extends Controller
             'rows_html' => view('valabilitati.curse.partials.rows', [
                 'valabilitate' => $valabilitate,
                 'curse' => $curse,
+                'groupFinancials' => $summary['groupFinancials'] ?? collect(),
             ])->render(),
             'modals_html' => view('valabilitati.curse.partials.modals', $this->buildModalViewData(
                 $valabilitate,

--- a/resources/views/valabilitati/curse/index.blade.php
+++ b/resources/views/valabilitati/curse/index.blade.php
@@ -292,7 +292,11 @@
 
                         <tbody id="curse-table-body">
                             @if ($curse->count())
-                                @include('valabilitati.curse.partials.rows', ['curse' => $curse, 'valabilitate' => $valabilitate])
+                                @include('valabilitati.curse.partials.rows', [
+                                    'curse' => $curse,
+                                    'valabilitate' => $valabilitate,
+                                    'groupFinancials' => $groupFinancials ?? collect(),
+                                ])
                             @else
                                 <tr>
                                     <td colspan="{{ $tableColumnCount }}" class="text-center py-4">

--- a/resources/views/valabilitati/curse/partials/rows.blade.php
+++ b/resources/views/valabilitati/curse/partials/rows.blade.php
@@ -44,6 +44,8 @@
 
         return $luminance > 150 ? '#111111' : '#ffffff';
     };
+
+    $groupFinancialsById = collect($groupFinancials ?? [])->keyBy('id');
 @endphp
 
 @foreach ($curse as $cursa)
@@ -154,14 +156,15 @@
         }
         $groupFinancialMeta = null;
         if ($isNewGroup && $group) {
-            $incasata = $group->suma_incasata !== null ? number_format((float) $group->suma_incasata, 2) : null;
-            $calculata = $group->suma_calculata !== null ? number_format((float) $group->suma_calculata, 2) : null;
-            $diferenta = null;
-            if ($group->suma_incasata !== null || $group->suma_calculata !== null) {
-                $rawDiff = (float) ($group->suma_incasata ?? 0) - (float) ($group->suma_calculata ?? 0);
-                $diferenta = number_format($rawDiff, 2);
-            }
-            $zileCalculate = is_numeric($group->zile_calculate) ? (int) $group->zile_calculate : null;
+            $financials = $groupFinancialsById->get($group->id, []);
+            $incasata = $financials['suma_incasata'] ?? ($group->suma_incasata !== null ? (float) $group->suma_incasata : null);
+            $calculata = $financials['suma_calculata'] ?? null;
+            $diferenta = $financials['diferenta'] ?? null;
+            $zileCalculate = $financials['zile_calculate'] ?? (is_numeric($group->zile_calculate) ? (int) $group->zile_calculate : null);
+
+            $incasata = $incasata !== null ? number_format((float) $incasata, 2) : null;
+            $calculata = $calculata !== null ? number_format((float) $calculata, 2) : null;
+            $diferenta = $diferenta !== null ? number_format((float) $diferenta, 2) : null;
             $groupFinancialMeta = [
                 'suma_incasata' => $incasata,
                 'suma_calculata' => $calculata,

--- a/tests/Feature/Valabilitati/ValabilitateCursaTest.php
+++ b/tests/Feature/Valabilitati/ValabilitateCursaTest.php
@@ -8,6 +8,7 @@ use App\Models\User;
 use App\Models\Tara;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
+use App\Models\ValabilitateCursaGrup;
 use App\Models\ValabilitateCursaImage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -236,6 +237,44 @@ class ValabilitateCursaTest extends TestCase
         $response->assertSeeText('10.06.2025 16:20');
         $response->assertSeeText('15400');
         $response->assertSeeText('15900');
+    }
+
+    public function test_index_view_displays_computed_suma_calculata_for_group(): void
+    {
+        $user = $this->createValabilitatiUser();
+        $valabilitate = Valabilitate::factory()->create([
+            'timestar_pret_km_bord' => 1.5,
+            'timestar_pret_nr_zile_lucrate' => 10,
+        ]);
+
+        $grup = ValabilitateCursaGrup::create([
+            'valabilitate_id' => $valabilitate->id,
+            'nume' => 'Test grup',
+            'suma_calculata' => 999.99,
+            'zile_calculate' => 4,
+        ]);
+
+        ValabilitateCursa::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'cursa_grup_id' => $grup->id,
+            'nr_ordine' => 1,
+            'km_bord_incarcare' => 1000,
+            'km_bord_descarcare' => 1100,
+        ]);
+
+        ValabilitateCursa::factory()->create([
+            'valabilitate_id' => $valabilitate->id,
+            'cursa_grup_id' => $grup->id,
+            'nr_ordine' => 2,
+            'km_bord_incarcare' => 1100,
+            'km_bord_descarcare' => 1300,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('valabilitati.curse.index', $valabilitate));
+
+        $response->assertOk();
+        $response->assertSeeText('490.00');
+        $response->assertDontSeeText('999.99');
     }
 
     public function test_index_displays_split_maps_columns_and_values(): void


### PR DESCRIPTION
## Summary
- compute curse group calculated sums on the server using odometer deltas and worked days with TIMESTAR pricing
- pass computed financial data into curse listing views so group headings and summaries show live amounts and totals
- add coverage confirming the computed amount appears in the index view instead of the stored value

## Testing
- `composer install --no-interaction --prefer-dist` *(fails: network restrictions prevented downloading dependencies)*
- `php artisan test tests/Feature/Valabilitati/ValabilitateCursaTest.php` *(not run: dependencies unavailable due to the install failure)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924619c27c48326bc479eb037cf8614)