### PR TITLE
Add ordered stops for FLASH driver curse entries

### DIFF
--- a/app/Http/Controllers/SoferValabilitateCursaController.php
+++ b/app/Http/Controllers/SoferValabilitateCursaController.php
@@ -9,6 +9,7 @@ use App\Models\ValabilitateCursa;
 use App\Support\Valabilitati\ValabilitateCursaOrderer;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
@@ -25,6 +26,7 @@ class SoferValabilitateCursaController extends Controller
             },
             'curse.incarcareTara',
             'curse.descarcareTara',
+            'curse.stops',
         ]);
 
         return view('sofer.valabilitati.show', [
@@ -56,7 +58,7 @@ class SoferValabilitateCursaController extends Controller
         $valabilitate->loadMissing('divizie');
         $this->ensureCursaBelongsToValabilitate($valabilitate, $cursa);
 
-        $cursa->loadMissing(['incarcareTara', 'descarcareTara']);
+        $cursa->loadMissing(['incarcareTara', 'descarcareTara', 'stops']);
 
         $tari = Tara::query()
             ->orderBy('nume')
@@ -80,7 +82,9 @@ class SoferValabilitateCursaController extends Controller
             $data['nr_ordine'] = $this->resolveNextNrOrdine($valabilitate);
         }
 
-        $valabilitate->curse()->create($data);
+        $cursa = $valabilitate->curse()->create($data);
+
+        $this->syncStopsIfNeeded($request, $valabilitate, $cursa);
 
         return redirect()
             ->route('sofer.valabilitati.show', $valabilitate)
@@ -93,6 +97,8 @@ class SoferValabilitateCursaController extends Controller
         $this->ensureCursaBelongsToValabilitate($valabilitate, $cursa);
 
         $cursa->update($request->validated());
+
+        $this->syncStopsIfNeeded($request, $valabilitate, $cursa);
 
         return redirect()
             ->route('sofer.valabilitati.show', $valabilitate)
@@ -152,6 +158,57 @@ class SoferValabilitateCursaController extends Controller
     private function isFlashDivizie(Valabilitate $valabilitate): bool
     {
         return (int) $valabilitate->divizie_id === 1;
+    }
+
+    private function syncStopsIfNeeded(Request $request, Valabilitate $valabilitate, ValabilitateCursa $cursa): void
+    {
+        if (! $this->isFlashDivizie($valabilitate)) {
+            return;
+        }
+
+        $stops = $this->normalizeStops($request->input('stops', []));
+
+        $cursa->stops()->delete();
+
+        if ($stops->isEmpty()) {
+            return;
+        }
+
+        $cursa->stops()->createMany($stops->toArray());
+    }
+
+    private function normalizeStops(array $stops): Collection
+    {
+        $validStops = collect($stops)
+            ->filter(fn ($stop) => is_array($stop))
+            ->map(function (array $stop): array {
+                return [
+                    'type' => in_array($stop['type'] ?? '', ['incarcare', 'descarcare'], true)
+                        ? $stop['type']
+                        : null,
+                    'cod_postal' => trim((string) ($stop['cod_postal'] ?? '')),
+                    'localitate' => trim((string) ($stop['localitate'] ?? '')),
+                    'position' => (int) ($stop['position'] ?? 0),
+                ];
+            })
+            ->filter(fn (array $stop) => ($stop['type'] ?? null) && ($stop['localitate'] ?? '') !== '');
+
+        return collect(['incarcare', 'descarcare'])
+            ->flatMap(function (string $type) use ($validStops) {
+                return $validStops
+                    ->where('type', $type)
+                    ->sortBy('position')
+                    ->values()
+                    ->map(function (array $stop, int $index) use ($type): array {
+                        return [
+                            'type' => $type,
+                            'cod_postal' => $stop['cod_postal'],
+                            'localitate' => $stop['localitate'],
+                            'position' => $index + 1,
+                        ];
+                    });
+            })
+            ->values();
     }
 
     private function resolveNextNrOrdine(Valabilitate $valabilitate): int

--- a/app/Http/Requests/SoferValabilitateCursaRequest.php
+++ b/app/Http/Requests/SoferValabilitateCursaRequest.php
@@ -25,7 +25,7 @@ class SoferValabilitateCursaRequest extends FormRequest
 
     public function rules(): array
     {
-        return [
+        $rules = [
             'nr_ordine' => ['sometimes', 'integer', 'min:1'],
             'nr_cursa' => ['nullable', 'string', 'max:255'],
             'incarcare_localitate' => ['nullable', 'string', 'max:255'],
@@ -39,11 +39,27 @@ class SoferValabilitateCursaRequest extends FormRequest
             'km_bord_incarcare' => ['nullable', 'integer', 'min:0'],
             'km_bord_descarcare' => ['nullable', 'integer', 'min:0'],
         ];
+
+        if ($this->isFlashDivizie()) {
+            $rules = array_merge($rules, [
+                'stops' => ['sometimes', 'array'],
+                'stops.*.type' => ['required_with:stops', 'in:incarcare,descarcare'],
+                'stops.*.cod_postal' => ['nullable', 'string', 'max:255'],
+                'stops.*.localitate' => ['required_with:stops', 'string', 'max:255'],
+                'stops.*.position' => ['nullable', 'integer', 'min:1'],
+            ]);
+        }
+
+        return $rules;
     }
 
     protected function prepareForValidation(): void
     {
         $this->shouldRequireDateTime = $this->determineIfDateTimeIsRequired();
+
+        if (! $this->isFlashDivizie()) {
+            $this->replace($this->except('stops'));
+        }
 
         $dateTimeInput = $this->input('data_cursa');
 
@@ -84,6 +100,17 @@ class SoferValabilitateCursaRequest extends FormRequest
                 $validator->errors()->add('data_cursa', 'Completați data și ora cursei.');
             }
         });
+    }
+
+    private function isFlashDivizie(): bool
+    {
+        $valabilitate = $this->route('valabilitate');
+
+        if (! $valabilitate instanceof Valabilitate) {
+            return false;
+        }
+
+        return (int) $valabilitate->divizie_id === 1;
     }
 
     private function determineIfDateTimeIsRequired(): bool

--- a/app/Models/ValabilitateCursa.php
+++ b/app/Models/ValabilitateCursa.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Models\ValabilitateCursaImage;
 use App\Models\ValabilitateCursaGrup;
+use App\Models\ValabilitateCursaStop;
 
 class ValabilitateCursa extends Model
 {
@@ -90,6 +91,27 @@ class ValabilitateCursa extends Model
     public function imagines(): HasMany
     {
         return $this->images();
+    }
+
+    public function stops(): HasMany
+    {
+        return $this
+            ->hasMany(ValabilitateCursaStop::class, 'valabilitate_cursa_id')
+            ->orderBy('position');
+    }
+
+    public function incarcareStops(): HasMany
+    {
+        return $this
+            ->stops()
+            ->where('type', 'incarcare');
+    }
+
+    public function descarcareStops(): HasMany
+    {
+        return $this
+            ->stops()
+            ->where('type', 'descarcare');
     }
 
     protected static function booted(): void

--- a/app/Models/ValabilitateCursaStop.php
+++ b/app/Models/ValabilitateCursaStop.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ValabilitateCursaStop extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'valabilitate_cursa_id',
+        'type',
+        'cod_postal',
+        'localitate',
+        'position',
+    ];
+
+    protected $casts = [
+        'valabilitate_cursa_id' => 'integer',
+        'position' => 'integer',
+    ];
+
+    public function cursa(): BelongsTo
+    {
+        return $this->belongsTo(ValabilitateCursa::class, 'valabilitate_cursa_id');
+    }
+}

--- a/database/factories/ValabilitateCursaStopFactory.php
+++ b/database/factories/ValabilitateCursaStopFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ValabilitateCursa;
+use App\Models\ValabilitateCursaStop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\ValabilitateCursaStop>
+ */
+class ValabilitateCursaStopFactory extends Factory
+{
+    protected $model = ValabilitateCursaStop::class;
+
+    public function definition(): array
+    {
+        return [
+            'valabilitate_cursa_id' => ValabilitateCursa::factory(),
+            'type' => fake()->randomElement(['incarcare', 'descarcare']),
+            'cod_postal' => fake()->postcode(),
+            'localitate' => fake()->city(),
+            'position' => fake()->numberBetween(1, 10),
+        ];
+    }
+}

--- a/database/migrations/2026_02_01_000000_create_valabilitate_cursa_stops_table.php
+++ b/database/migrations/2026_02_01_000000_create_valabilitate_cursa_stops_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('valabilitate_cursa_stops', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('valabilitate_cursa_id')->constrained('valabilitati_curse')->cascadeOnDelete();
+            $table->enum('type', ['incarcare', 'descarcare']);
+            $table->string('cod_postal')->nullable();
+            $table->string('localitate');
+            $table->unsignedInteger('position')->default(1);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('valabilitate_cursa_stops');
+    }
+};

--- a/resources/views/sofer/valabilitati/curse/partials/form.blade.php
+++ b/resources/views/sofer/valabilitati/curse/partials/form.blade.php
@@ -22,6 +22,43 @@
 
     $dataCursaValue = old('data_cursa', optional(optional($cursa)->data_cursa)->format('Y-m-d\TH:i'));
     $nrCursa = old('nr_cursa', optional($cursa)->nr_cursa);
+
+    $stops = collect(old('stops') ?? optional($cursa)->stops?->map(function ($stop) {
+        return [
+            'type' => $stop->type,
+            'cod_postal' => $stop->cod_postal,
+            'localitate' => $stop->localitate,
+            'position' => $stop->position,
+        ];
+    }) ?? [])->values();
+
+    $incarcareStops = $stops
+        ->where('type', 'incarcare')
+        ->values()
+        ->map(function ($stop, $index) {
+            return [
+                'type' => 'incarcare',
+                'cod_postal' => $stop['cod_postal'] ?? '',
+                'localitate' => $stop['localitate'] ?? '',
+                'position' => (int) ($stop['position'] ?? ($index + 1)),
+            ];
+        });
+
+    $descarcareStops = $stops
+        ->where('type', 'descarcare')
+        ->values()
+        ->map(function ($stop, $index) {
+            return [
+                'type' => 'descarcare',
+                'cod_postal' => $stop['cod_postal'] ?? '',
+                'localitate' => $stop['localitate'] ?? '',
+                'position' => (int) ($stop['position'] ?? ($index + 1)),
+            ];
+        });
+
+    $stopErrorMessages = collect($errors?->getMessages() ?? [])
+        ->filter(fn ($messages, $key) => str_starts_with($key, 'stops.'))
+        ->flatten();
 @endphp
 
 <form
@@ -138,6 +175,55 @@
                 <div class="invalid-feedback">{{ $message }}</div>
             @enderror
         </div>
+
+        @if ($isFlashDivizie)
+            <div class="col-12">
+                <div class="border rounded-3 p-3 bg-light">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <p class="fw-semibold mb-0">Încărcări</p>
+                            <small class="text-muted">Adăugați punctele de încărcare în ordinea dorită.</small>
+                        </div>
+                        <button type="button" class="btn btn-outline-primary btn-sm" data-stop-add data-stop-target="incarcare">
+                            <i class="fa-solid fa-plus"></i>
+                            <span class="ms-1">Adaugă</span>
+                        </button>
+                    </div>
+                    <div
+                        class="stop-list"
+                        data-stop-manager
+                        data-stop-type="incarcare"
+                        data-initial-stops='@json($incarcareStops)'
+                        data-stop-items
+                    ></div>
+                    @if ($stopErrorMessages->isNotEmpty())
+                        <div class="text-danger small mt-2">{{ $stopErrorMessages->first() }}</div>
+                    @endif
+                </div>
+            </div>
+
+            <div class="col-12 mt-3">
+                <div class="border rounded-3 p-3 bg-light">
+                    <div class="d-flex justify-content-between align-items-center mb-2">
+                        <div>
+                            <p class="fw-semibold mb-0">Descărcări</p>
+                            <small class="text-muted">Adăugați punctele de descărcare în ordinea dorită.</small>
+                        </div>
+                        <button type="button" class="btn btn-outline-primary btn-sm" data-stop-add data-stop-target="descarcare">
+                            <i class="fa-solid fa-plus"></i>
+                            <span class="ms-1">Adaugă</span>
+                        </button>
+                    </div>
+                    <div
+                        class="stop-list"
+                        data-stop-manager
+                        data-stop-type="descarcare"
+                        data-initial-stops='@json($descarcareStops)'
+                        data-stop-items
+                    ></div>
+                </div>
+            </div>
+        @endif
         <div class="col-12 col-md-6">
             <label class="form-label small text-uppercase fw-semibold">Ora cursei</label>
             <input
@@ -216,6 +302,29 @@
 
         .country-autocomplete .dropdown-item {
             white-space: normal;
+        }
+
+        .stop-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .stop-item {
+            background: #fff;
+            border: 1px solid #dee2e6;
+            border-radius: 0.5rem;
+            padding: 0.75rem;
+        }
+
+        .stop-item .form-control-sm {
+            font-size: 0.9rem;
+        }
+
+        .stop-item__actions {
+            display: flex;
+            gap: 0.5rem;
+            justify-content: flex-end;
         }
     </style>
 @endpush
@@ -498,6 +607,195 @@
             };
 
             form.querySelectorAll('[data-country-field]').forEach((field) => bindCountryField(field));
+
+            const parseStops = (raw) => {
+                if (!raw) {
+                    return [];
+                }
+
+                try {
+                    const parsed = JSON.parse(raw);
+
+                    return Array.isArray(parsed) ? parsed : [];
+                } catch (error) {
+                    return [];
+                }
+            };
+
+            const stopManagers = new Map();
+            let stopIndex = 0;
+
+            const buildStopManager = (container) => {
+                const type = container.dataset.stopType || 'incarcare';
+                let stops = parseStops(container.dataset.initialStops).map((stop) => ({
+                    ...stop,
+                    formIndex: stopIndex++,
+                }));
+
+                const normaliseStops = () => {
+                    stops = (stops || [])
+                        .filter((stop) => stop && typeof stop === 'object')
+                        .map((stop, index) => ({
+                            type,
+                            cod_postal: String(stop.cod_postal ?? ''),
+                            localitate: String(stop.localitate ?? ''),
+                            position: Number.parseInt(stop.position ?? index + 1, 10) || index + 1,
+                            formIndex: typeof stop.formIndex === 'number' ? stop.formIndex : stopIndex++,
+                        }))
+                        .sort((a, b) => a.position - b.position)
+                        .map((stop, index) => ({ ...stop, position: index + 1 }));
+                };
+
+                const render = () => {
+                    normaliseStops();
+                    container.innerHTML = '';
+
+                    stops.forEach((stop, index) => {
+                        const wrapper = document.createElement('div');
+                        wrapper.className = 'stop-item';
+
+                        const row = document.createElement('div');
+                        row.className = 'row g-2 align-items-end';
+
+                        const orderCol = document.createElement('div');
+                        orderCol.className = 'col-12 col-md-3';
+                        orderCol.innerHTML = `
+                            <label class="form-label small text-uppercase fw-semibold mb-1">Ordine</label>
+                            <input
+                                type="number"
+                                name="stops[${stop.formIndex}][position]"
+                                class="form-control form-control-sm"
+                                value="${stop.position}"
+                                min="1"
+                                step="1"
+                                data-stop-position
+                            >
+                            <input type="hidden" name="stops[${stop.formIndex}][type]" value="${type}">
+                        `;
+
+                        const postalCol = document.createElement('div');
+                        postalCol.className = 'col-12 col-md-3';
+                        postalCol.innerHTML = `
+                            <label class="form-label small text-uppercase fw-semibold mb-1">Cod poștal</label>
+                            <input
+                                type="text"
+                                name="stops[${stop.formIndex}][cod_postal]"
+                                class="form-control form-control-sm"
+                                value="${stop.cod_postal ?? ''}"
+                            >
+                        `;
+
+                        const cityCol = document.createElement('div');
+                        cityCol.className = 'col-12 col-md-6';
+                        cityCol.innerHTML = `
+                            <label class="form-label small text-uppercase fw-semibold mb-1">Localitate</label>
+                            <input
+                                type="text"
+                                name="stops[${stop.formIndex}][localitate]"
+                                class="form-control form-control-sm"
+                                value="${stop.localitate ?? ''}"
+                                required
+                            >
+                        `;
+
+                        row.append(orderCol, postalCol, cityCol);
+                        wrapper.appendChild(row);
+
+                        const actions = document.createElement('div');
+                        actions.className = 'stop-item__actions mt-3';
+
+                        const moveUp = document.createElement('button');
+                        moveUp.type = 'button';
+                        moveUp.className = 'btn btn-outline-secondary btn-sm';
+                        moveUp.textContent = 'Sus';
+                        moveUp.addEventListener('click', () => {
+                            if (index === 0) {
+                                return;
+                            }
+
+                            [stops[index - 1], stops[index]] = [stops[index], stops[index - 1]];
+                            render();
+                        });
+
+                        const moveDown = document.createElement('button');
+                        moveDown.type = 'button';
+                        moveDown.className = 'btn btn-outline-secondary btn-sm';
+                        moveDown.textContent = 'Jos';
+                        moveDown.addEventListener('click', () => {
+                            if (index >= stops.length - 1) {
+                                return;
+                            }
+
+                            [stops[index + 1], stops[index]] = [stops[index], stops[index + 1]];
+                            render();
+                        });
+
+                        const remove = document.createElement('button');
+                        remove.type = 'button';
+                        remove.className = 'btn btn-outline-danger btn-sm';
+                        remove.textContent = 'Șterge';
+                        remove.addEventListener('click', () => {
+                            stops.splice(index, 1);
+                            render();
+                        });
+
+                        actions.append(moveUp, moveDown, remove);
+                        wrapper.appendChild(actions);
+
+                        const positionInput = orderCol.querySelector('[data-stop-position]');
+                        positionInput.addEventListener('change', (event) => {
+                            const value = Number.parseInt(event.target.value, 10);
+
+                            if (Number.isNaN(value) || value < 1) {
+                                event.target.value = String(stop.position);
+                                return;
+                            }
+
+                            stops[index].position = value;
+                            stops.sort((a, b) => a.position - b.position);
+                            render();
+                        });
+
+                        container.appendChild(wrapper);
+                    });
+                };
+
+                const addStop = () => {
+                    stops.push({
+                        type,
+                        cod_postal: '',
+                        localitate: '',
+                        position: stops.length + 1,
+                        formIndex: stopIndex++,
+                    });
+
+                    render();
+                };
+
+                render();
+
+                return { addStop };
+            };
+
+            form.querySelectorAll('[data-stop-manager]').forEach((container) => {
+                const type = container.dataset.stopType || '';
+                if (!type) {
+                    return;
+                }
+
+                stopManagers.set(type, buildStopManager(container));
+            });
+
+            form.querySelectorAll('[data-stop-add]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    const type = button.dataset.stopTarget || '';
+                    const manager = stopManagers.get(type);
+
+                    if (manager && typeof manager.addStop === 'function') {
+                        manager.addStop();
+                    }
+                });
+            });
         });
     </script>
 @endpush

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -136,6 +136,51 @@
                                             </div>
                                         </div>
 
+                                        @if ($isFlashDivizie)
+                                            @php
+                                                $incarcareStops = $cursa->stops
+                                                    ->where('type', 'incarcare')
+                                                    ->sortBy('position');
+                                                $descarcareStops = $cursa->stops
+                                                    ->where('type', 'descarcare')
+                                                    ->sortBy('position');
+                                            @endphp
+
+                                            <div class="row g-2 small text-muted mt-2">
+                                                <div class="col-12 col-md-6">
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Încărcări (ordonate)</p>
+                                                    <ol class="mb-0 ps-3">
+                                                        @forelse ($incarcareStops as $stop)
+                                                            <li class="text-body-secondary">
+                                                                {{ $stop->localitate }}
+                                                                @if ($stop->cod_postal)
+                                                                    <span class="text-muted">({{ $stop->cod_postal }})</span>
+                                                                @endif
+                                                            </li>
+                                                        @empty
+                                                            <li class="text-body-secondary">—</li>
+                                                        @endforelse
+                                                    </ol>
+                                                </div>
+
+                                                <div class="col-12 col-md-6 text-md-end">
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Descărcări (ordonate)</p>
+                                                    <ol class="mb-0 ps-3">
+                                                        @forelse ($descarcareStops as $stop)
+                                                            <li class="text-body-secondary">
+                                                                {{ $stop->localitate }}
+                                                                @if ($stop->cod_postal)
+                                                                    <span class="text-muted">({{ $stop->cod_postal }})</span>
+                                                                @endif
+                                                            </li>
+                                                        @empty
+                                                            <li class="text-body-secondary">—</li>
+                                                        @endforelse
+                                                    </ol>
+                                                </div>
+                                            </div>
+                                        @endif
+
                                         <div class="row g-2 small text-muted mt-2">
                                             <div class="col-12">
                                                 <p class="fw-semibold text-uppercase text-dark small mb-1">Data și ora cursei</p>

--- a/tests/Feature/Sofer/SoferValabilitateCursaTest.php
+++ b/tests/Feature/Sofer/SoferValabilitateCursaTest.php
@@ -7,6 +7,7 @@ use App\Models\Tara;
 use App\Models\User;
 use App\Models\Valabilitate;
 use App\Models\ValabilitateCursa;
+use App\Models\ValabilitateCursaStop;
 use App\Models\ValabilitatiDivizie;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -229,6 +230,203 @@ class SoferValabilitateCursaTest extends TestCase
             'id' => $onlyCursa->id,
             'nr_ordine' => 1,
         ]);
+    }
+
+    public function test_driver_can_create_flash_cursa_with_ordered_stops(): void
+    {
+        $driver = $this->createSoferUser();
+        $flashDivizie = ValabilitatiDivizie::factory()->create([
+            'id' => 1,
+            'nume' => 'FLASH',
+        ]);
+
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->for($flashDivizie, 'divizie')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $response = $this
+            ->actingAs($driver)
+            ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
+                'form_type' => 'create',
+                'incarcare_localitate' => 'Cluj',
+                'descarcare_localitate' => 'Berlin',
+                'data_cursa' => '2025-05-20T08:15',
+                'stops' => [
+                    ['type' => 'incarcare', 'localitate' => 'Punct B', 'cod_postal' => '400222', 'position' => 2],
+                    ['type' => 'incarcare', 'localitate' => 'Punct A', 'cod_postal' => '400111', 'position' => 1],
+                    ['type' => 'descarcare', 'localitate' => 'Punct D', 'cod_postal' => '010222', 'position' => 2],
+                    ['type' => 'descarcare', 'localitate' => 'Punct C', 'cod_postal' => '010111', 'position' => 1],
+                ],
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+        $response->assertSessionHasNoErrors();
+
+        $cursa = ValabilitateCursa::first();
+
+        $this->assertDatabaseHas('valabilitate_cursa_stops', [
+            'valabilitate_cursa_id' => $cursa?->id,
+            'type' => 'incarcare',
+            'localitate' => 'Punct A',
+            'position' => 1,
+        ]);
+
+        $this->assertDatabaseHas('valabilitate_cursa_stops', [
+            'valabilitate_cursa_id' => $cursa?->id,
+            'type' => 'descarcare',
+            'localitate' => 'Punct C',
+            'position' => 1,
+        ]);
+    }
+
+    public function test_flash_cursa_stops_are_shown_in_order(): void
+    {
+        $driver = $this->createSoferUser();
+        $flashDivizie = ValabilitatiDivizie::factory()->create([
+            'id' => 1,
+            'nume' => 'FLASH',
+        ]);
+
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->for($flashDivizie, 'divizie')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create();
+
+        ValabilitateCursaStop::factory()->create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'type' => 'incarcare',
+            'localitate' => 'Punct B',
+            'cod_postal' => '400222',
+            'position' => 2,
+        ]);
+
+        ValabilitateCursaStop::factory()->create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'type' => 'incarcare',
+            'localitate' => 'Punct A',
+            'cod_postal' => '400111',
+            'position' => 1,
+        ]);
+
+        ValabilitateCursaStop::factory()->create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'type' => 'descarcare',
+            'localitate' => 'Punct D',
+            'cod_postal' => '010222',
+            'position' => 2,
+        ]);
+
+        ValabilitateCursaStop::factory()->create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'type' => 'descarcare',
+            'localitate' => 'Punct C',
+            'cod_postal' => '010111',
+            'position' => 1,
+        ]);
+
+        $response = $this->actingAs($driver)->get(route('sofer.valabilitati.show', $valabilitate));
+
+        $response->assertOk();
+        $response->assertSeeInOrder(['Punct A', 'Punct B']);
+        $response->assertSeeInOrder(['Punct C', 'Punct D']);
+    }
+
+    public function test_driver_can_update_flash_cursa_stops(): void
+    {
+        $driver = $this->createSoferUser();
+        $flashDivizie = ValabilitatiDivizie::factory()->create([
+            'id' => 1,
+            'nume' => 'FLASH',
+        ]);
+
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->for($flashDivizie, 'divizie')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $cursa = ValabilitateCursa::factory()->for($valabilitate)->create([
+            'nr_ordine' => 1,
+        ]);
+
+        ValabilitateCursaStop::factory()->create([
+            'valabilitate_cursa_id' => $cursa->id,
+            'type' => 'incarcare',
+            'localitate' => 'Veche',
+            'position' => 1,
+        ]);
+
+        $response = $this
+            ->actingAs($driver)
+            ->put(route('sofer.valabilitati.curse.update', [$valabilitate, $cursa]), [
+                'form_type' => 'edit',
+                'incarcare_localitate' => 'Cluj',
+                'descarcare_localitate' => 'Berlin',
+                'data_cursa' => '2025-05-21T10:00',
+                'stops' => [
+                    ['type' => 'incarcare', 'localitate' => 'Nouă', 'cod_postal' => null, 'position' => 1],
+                    ['type' => 'descarcare', 'localitate' => 'Berlin', 'cod_postal' => '10115', 'position' => 1],
+                ],
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+
+        $this->assertDatabaseMissing('valabilitate_cursa_stops', [
+            'valabilitate_cursa_id' => $cursa->id,
+            'localitate' => 'Veche',
+        ]);
+
+        $this->assertDatabaseHas('valabilitate_cursa_stops', [
+            'valabilitate_cursa_id' => $cursa->id,
+            'type' => 'incarcare',
+            'localitate' => 'Nouă',
+            'position' => 1,
+        ]);
+    }
+
+    public function test_non_flash_cursa_ignores_stop_payload(): void
+    {
+        $driver = $this->createSoferUser();
+        $divizie = ValabilitatiDivizie::factory()->create([
+            'id' => 2,
+            'nume' => 'ALTĂ DIVIZIE',
+        ]);
+
+        $valabilitate = Valabilitate::factory()
+            ->for($driver, 'sofer')
+            ->for($divizie, 'divizie')
+            ->create([
+                'data_inceput' => Carbon::today()->subWeek(),
+                'data_sfarsit' => Carbon::today()->addWeek(),
+            ]);
+
+        $response = $this
+            ->actingAs($driver)
+            ->post(route('sofer.valabilitati.curse.store', $valabilitate), [
+                'form_type' => 'create',
+                'incarcare_localitate' => 'Cluj',
+                'descarcare_localitate' => 'Budapesta',
+                'data_cursa' => '2025-05-21T10:00',
+                'stops' => [
+                    ['type' => 'incarcare', 'localitate' => 'Punct A', 'cod_postal' => '400111', 'position' => 1],
+                ],
+            ]);
+
+        $response->assertRedirect(route('sofer.valabilitati.show', $valabilitate));
+
+        $this->assertDatabaseCount('valabilitati_curse', 1);
+        $this->assertDatabaseCount('valabilitate_cursa_stops', 0);
     }
 
     private function createSoferUser(): User


### PR DESCRIPTION
## Summary
- add `valabilitate_cursa_stops` persistence plus factory and relationships for storing ordered incarcare/descarcare opriri
- update driver cursa controller/request logic to accept and sync ordered stops only for FLASH valabilitati while keeping other divisions unchanged
- extend driver cursa form and show view with dynamic stop lists and add feature coverage for creating, updating, and rendering stop sequences

## Testing
- composer install --no-interaction --prefer-dist *(fails: unable to clone symfony/finder because outbound GitHub access is blocked)*
- php vendor/bin/phpunit --filter SoferValabilitateCursaTest *(not run: phpunit binary unavailable after composer install failed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246b932a0883268ebecccd8696be99)