### PR TITLE
Adjust FLASH divizie driver views

### DIFF
--- a/resources/views/sofer/valabilitati/curse/partials/form.blade.php
+++ b/resources/views/sofer/valabilitati/curse/partials/form.blade.php
@@ -180,6 +180,19 @@
             @enderror
         </div>
 
+        <div class="col-12 col-md-6">
+            <label class="form-label small text-uppercase fw-semibold">Ora cursei</label>
+            <input
+                type="datetime-local"
+                name="data_cursa"
+                class="form-control form-control-sm @error('data_cursa') is-invalid @enderror"
+                value="{{ $dataCursaValue }}"
+                step="60"
+            >
+            @error('data_cursa')
+                <div class="invalid-feedback">{{ $message }}</div>
+            @enderror
+        </div>
         @if ($isFlashDivizie)
             <div class="col-12">
                 <div class="border rounded-3 p-3 bg-light">
@@ -236,19 +249,6 @@
                 </div>
             </div>
         @endif
-        <div class="col-12 col-md-6">
-            <label class="form-label small text-uppercase fw-semibold">Ora cursei</label>
-            <input
-                type="datetime-local"
-                name="data_cursa"
-                class="form-control form-control-sm @error('data_cursa') is-invalid @enderror"
-                value="{{ $dataCursaValue }}"
-                step="60"
-            >
-            @error('data_cursa')
-                <div class="invalid-feedback">{{ $message }}</div>
-            @enderror
-        </div>
         @unless ($isFlashDivizie)
         <div class="col-12 col-md-6">
             <label class="form-label small text-uppercase fw-semibold">Km bord încărcare</label>
@@ -685,24 +685,18 @@
                         const row = document.createElement('div');
                         row.className = 'row g-2 align-items-end';
 
-                        const orderCol = document.createElement('div');
-                        orderCol.className = 'col-12 col-md-3';
-                        orderCol.innerHTML = `
-                            <label class="form-label small text-uppercase fw-semibold mb-1">Ordine</label>
-                            <input
-                                type="number"
-                                name="stops[${stop.formIndex}][position]"
-                                class="form-control form-control-sm"
-                                value="${stop.position}"
-                                min="1"
-                                step="1"
-                                data-stop-position
-                            >
-                            <input type="hidden" name="stops[${stop.formIndex}][type]" value="${type}">
-                        `;
+                        const hiddenType = document.createElement('input');
+                        hiddenType.type = 'hidden';
+                        hiddenType.name = `stops[${stop.formIndex}][type]`;
+                        hiddenType.value = type;
+
+                        const hiddenPosition = document.createElement('input');
+                        hiddenPosition.type = 'hidden';
+                        hiddenPosition.name = `stops[${stop.formIndex}][position]`;
+                        hiddenPosition.value = String(stop.position);
 
                         const postalCol = document.createElement('div');
-                        postalCol.className = 'col-12 col-md-3';
+                        postalCol.className = 'col-12 col-sm-5 col-md-4';
                         postalCol.innerHTML = `
                             <label class="form-label small text-uppercase fw-semibold mb-1">Cod poștal</label>
                             <input
@@ -714,7 +708,7 @@
                         `;
 
                         const cityCol = document.createElement('div');
-                        cityCol.className = 'col-12 col-md-6';
+                        cityCol.className = 'col-12 col-sm-7 col-md-8';
                         cityCol.innerHTML = `
                             <label class="form-label small text-uppercase fw-semibold mb-1">Localitate</label>
                             <input
@@ -726,8 +720,8 @@
                             >
                         `;
 
-                        row.append(orderCol, postalCol, cityCol);
-                        wrapper.appendChild(row);
+                        row.append(postalCol, cityCol);
+                        wrapper.append(hiddenType, hiddenPosition, row);
 
                         const actions = document.createElement('div');
                         actions.className = 'stop-item__actions mt-3';
@@ -757,19 +751,6 @@
                         actions.append(moveUp, moveDown, remove);
                         wrapper.appendChild(actions);
 
-                        const positionInput = orderCol.querySelector('[data-stop-position]');
-                        positionInput.addEventListener('change', (event) => {
-                            const value = Number.parseInt(event.target.value, 10);
-
-                            if (Number.isNaN(value) || value < 1) {
-                                event.target.value = String(stop.position);
-                                return;
-                            }
-
-                            const targetIndex = Math.min(Math.max(value - 1, 0), stops.length - 1);
-                            moveStop(index, targetIndex);
-                        });
-
                         const postalInput = postalCol.querySelector('input');
                         postalInput.addEventListener('input', (event) => {
                             stops[index].cod_postal = event.target.value || '';
@@ -779,6 +760,8 @@
                         cityInput.addEventListener('input', (event) => {
                             stops[index].localitate = event.target.value || '';
                         });
+
+                        hiddenPosition.value = String(stop.position);
 
                         container.appendChild(wrapper);
                     });

--- a/resources/views/sofer/valabilitati/show.blade.php
+++ b/resources/views/sofer/valabilitati/show.blade.php
@@ -106,11 +106,13 @@
 
                                 <div class="row g-3 align-items-start">
                                     <div class="col-12 col-lg-12">
-                                        <div class="row g-2 small text-muted mb-2">
-                                        <div class="col-12">
-                                            <p class="fw-semibold text-uppercase text-dark small mb-1">Număr cursă: {{ $cursa->nr_cursa ?? '—' }}</p>
-                                        </div>
-                                        </div>
+                                        @unless ($isFlashDivizie)
+                                            <div class="row g-2 small text-muted mb-2">
+                                                <div class="col-12">
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Număr cursă: {{ $cursa->nr_cursa ?? '—' }}</p>
+                                                </div>
+                                            </div>
+                                        @endunless
                                         @unless ($isFlashDivizie)
                                             {{-- Încărcare left, Descărcare right (always 50% / 50%) --}}
                                             <div class="row g-2 small text-muted cursa-card__locations">
@@ -146,9 +148,36 @@
                                                     ->sortBy('position');
                                             @endphp
 
-                                            <div class="row g-2 small text-muted mt-2">
+                                            <div class="row g-2 small text-muted mt-1">
+                                                <div class="col-12 col-sm-6">
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Țara încărcării</p>
+                                                    <p class="mb-0">
+                                                        <span class="text-body-secondary">{{ $cursa->incarcareTara?->nume ?? '—' }}</span>
+                                                    </p>
+                                                </div>
+
+                                                <div class="col-12 col-sm-6 text-sm-end">
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Țara descărcării</p>
+                                                    <p class="mb-0">
+                                                        <span class="text-body-secondary">{{ $cursa->descarcareTara?->nume ?? '—' }}</span>
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            <div class="row g-2 small text-muted mt-1">
+                                                <div class="col-12">
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Data și ora cursei</p>
+                                                    <p class="mb-0">
+                                                        <span class="text-body-secondary">
+                                                            {{ optional($cursa->data_cursa)->format('d.m.Y H:i') ?? '—' }}
+                                                        </span>
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            <div class="row g-3 small text-muted mt-1">
                                                 <div class="col-12 col-md-6">
-                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Încărcări (ordonate)</p>
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Încărcări</p>
                                                     <ol class="mb-0 ps-3">
                                                         @forelse ($incarcareStops as $stop)
                                                             <li class="text-body-secondary">
@@ -164,7 +193,7 @@
                                                 </div>
 
                                                 <div class="col-12 col-md-6 text-md-end">
-                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Descărcări (ordonate)</p>
+                                                    <p class="fw-semibold text-uppercase text-dark small mb-1">Descărcări</p>
                                                     <ol class="mb-0 ps-3">
                                                         @forelse ($descarcareStops as $stop)
                                                             <li class="text-body-secondary">
@@ -180,17 +209,6 @@
                                                 </div>
                                             </div>
                                         @endunless
-
-                                        <div class="row g-2 small text-muted mt-2">
-                                            <div class="col-12">
-                                                <p class="fw-semibold text-uppercase text-dark small mb-1">Data și ora cursei</p>
-                                                <p class="mb-0">
-                                                    <span class="text-body-secondary">
-                                                        {{ optional($cursa->data_cursa)->format('d.m.Y H:i') ?? '—' }}
-                                                    </span>
-                                                </p>
-                                            </div>
-                                        </div>
 
                                         @unless ($isFlashDivizie)
                                             <div class="row g-2 small text-muted mt-2">


### PR DESCRIPTION
## Summary
- move FLASH divizie stop sections after the ride time field and hide manual order inputs in the driver form
- reorganize FLASH divizie accordion details to emphasize country, schedule, and stop lists without redundant course numbers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248fff56b483269ac05bf304ca37db)