### PR TITLE
Allow moving invoices between calupuri (batches) — service, controllers, views and routes

### DIFF
--- a/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
+++ b/app/Http/Controllers/FacturiFurnizori/FacturaFurnizorController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers\FacturiFurnizori;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\FacturiFurnizori\MoveFacturiToCalupRequest;
 use App\Http\Requests\FacturiFurnizori\FacturaFurnizorRequest;
 use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\FacturiFurnizori\FacturaFurnizorFisier;
+use App\Models\FacturiFurnizori\PlataCalup;
 use App\Models\Service\GestiunePiesa;
 use App\Models\Service\MasinaServiceEntry;
+use App\Services\FacturiFurnizori\PlataCalupService;
 use App\Support\FacturiFurnizori\FacturiIndexFilterState;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
@@ -21,6 +24,10 @@ use Carbon\CarbonInterface;
 
 class FacturaFurnizorController extends Controller
 {
+    public function __construct(private PlataCalupService $plataCalupService)
+    {
+    }
+
     /**
      * Display a listing of the resource.
      */
@@ -119,6 +126,11 @@ class FacturaFurnizorController extends Controller
             ->orderBy('moneda')
             ->pluck('moneda');
 
+        $calupuriDisponibile = PlataCalup::query()
+            ->orderByDesc('data_plata')
+            ->orderByDesc('created_at')
+            ->get(['id', 'denumire_calup', 'data_plata']);
+
         $neplatiteCount = FacturaFurnizor::query()->whereDoesntHave('calupuri')->count();
 
         FacturiIndexFilterState::remember($request);
@@ -140,8 +152,24 @@ class FacturaFurnizorController extends Controller
             'facturi' => $facturi,
             'filters' => $filters,
             'monede' => $monede,
+            'calupuriDisponibile' => $calupuriDisponibile,
             'neplatiteCount' => $neplatiteCount,
         ]);
+    }
+
+    public function moveToCalup(MoveFacturiToCalupRequest $request)
+    {
+        $calup = PlataCalup::query()->findOrFail($request->validated('plata_calup_id'));
+        $facturi = $request->validated('facturi');
+
+        $this->plataCalupService->moveFacturi($calup, $facturi);
+
+        $count = count($facturi);
+        $message = $count === 1
+            ? 'Factura a fost mutata in calupul selectat.'
+            : 'Facturile selectate au fost mutate in calupul selectat.';
+
+        return $this->redirectToIndexWithFilters()->with('status', $message);
     }
 
     /**

--- a/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
+++ b/app/Http/Controllers/FacturiFurnizori/PlataCalupController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\FacturiFurnizori;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\FacturiFurnizori\AttachFacturiRequest;
+use App\Http\Requests\FacturiFurnizori\MoveFacturiToCalupRequest;
 use App\Http\Requests\FacturiFurnizori\PlataCalupRequest;
 use App\Models\FacturiFurnizori\FacturaFurnizor;
 use App\Models\FacturiFurnizori\PlataCalup;
@@ -155,12 +156,19 @@ class PlataCalupController extends Controller
             ->orderBy('denumire_furnizor')
             ->get();
 
+        $calupuriDestinatie = PlataCalup::query()
+            ->whereKeyNot($plataCalup->id)
+            ->orderByDesc('data_plata')
+            ->orderByDesc('created_at')
+            ->get(['id', 'denumire_calup', 'data_plata']);
+
         return view('facturiFurnizori.calupuri.show', [
             'calup' => $plataCalup,
             'facturiCalup' => $facturiCalup,
             'totaluriFacturiCalupPeMoneda' => $totaluriFacturiCalupPeMoneda,
             'totaluriFacturiCalupPeFurnizor' => $totaluriFacturiCalupPeFurnizor,
             'facturiDisponibile' => $facturiDisponibile,
+            'calupuriDestinatie' => $calupuriDestinatie,
         ]);
     }
 
@@ -246,6 +254,21 @@ class PlataCalupController extends Controller
         $this->plataCalupService->detachFactura($plataCalup, $factura);
 
         return back()->with('status', 'Factura a fost eliminata din calup.');
+    }
+
+    public function mutaFactura(MoveFacturiToCalupRequest $request, PlataCalup $plataCalup, FacturaFurnizor $factura)
+    {
+        if (! $plataCalup->facturi()->whereKey($factura->id)->exists()) {
+            abort(404);
+        }
+
+        $calupDestinatie = PlataCalup::query()->findOrFail($request->validated('plata_calup_id'));
+
+        $this->plataCalupService->moveFacturi($calupDestinatie, [$factura->id]);
+
+        return redirect()
+            ->route('facturi-furnizori.plati-calupuri.show', $plataCalup)
+            ->with('status', 'Factura a fost mutata in alt calup.');
     }
 
     public function vizualizeazaFisier(PlataCalup $plataCalup, PlataCalupFisier $fisier)

--- a/app/Http/Requests/FacturiFurnizori/MoveFacturiToCalupRequest.php
+++ b/app/Http/Requests/FacturiFurnizori/MoveFacturiToCalupRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests\FacturiFurnizori;
+
+class MoveFacturiToCalupRequest extends AttachFacturiRequest
+{
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'plata_calup_id' => ['required', 'integer', 'exists:service_ff_plati_calupuri,id'],
+        ]);
+    }
+
+    public function messages(): array
+    {
+        return array_merge(parent::messages(), [
+            'plata_calup_id.required' => 'Selectati calupul in care doriti sa mutati facturile.',
+            'plata_calup_id.exists' => 'Calupul selectat nu mai exista.',
+        ]);
+    }
+
+    public function attributes(): array
+    {
+        return array_merge(parent::attributes(), [
+            'plata_calup_id' => 'calup selectat',
+        ]);
+    }
+}

--- a/app/Services/FacturiFurnizori/PlataCalupService.php
+++ b/app/Services/FacturiFurnizori/PlataCalupService.php
@@ -46,6 +46,56 @@ class PlataCalupService
     }
 
     /**
+     * Move invoices into the given batch, detaching them from any other batch first.
+     */
+    public function moveFacturi(PlataCalup $calup, array $facturaIds): void
+    {
+        $this->db->transaction(function () use ($calup, $facturaIds) {
+            $facturi = FacturaFurnizor::query()->whereIn('id', $facturaIds)->lockForUpdate()->get();
+
+            if (count($facturaIds) !== $facturi->count()) {
+                throw ValidationException::withMessages([
+                    'facturi' => 'Cel putin una dintre facturile selectate nu mai exista.',
+                ]);
+            }
+
+            $facturi->load('calupuri:id');
+
+            foreach ($facturi as $factura) {
+                $currentCalupIds = $factura->calupuri
+                    ->pluck('id')
+                    ->filter(fn ($id) => (int) $id !== (int) $calup->id)
+                    ->all();
+
+                if (! empty($currentCalupIds)) {
+                    $factura->calupuri()->detach($currentCalupIds);
+                }
+            }
+
+            $existingIdsInTarget = $calup->facturi()
+                ->whereIn('service_ff_facturi.id', $facturaIds)
+                ->pluck('service_ff_facturi.id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
+            $idsToAttach = array_values(array_diff(array_map('intval', $facturaIds), $existingIdsInTarget));
+
+            if (empty($idsToAttach)) {
+                return;
+            }
+
+            $syncPayload = [];
+            $now = now();
+
+            foreach ($idsToAttach as $facturaId) {
+                $syncPayload[$facturaId] = ['created_at' => $now, 'updated_at' => $now];
+            }
+
+            $calup->facturi()->attach($syncPayload);
+        });
+    }
+
+    /**
      * Detach an invoice from the batch.
      */
     public function detachFactura(PlataCalup $calup, FacturaFurnizor $factura): void

--- a/resources/views/facturiFurnizori/calupuri/show.blade.php
+++ b/resources/views/facturiFurnizori/calupuri/show.blade.php
@@ -2,6 +2,8 @@
 
 @php
     $facturiIndexUrl = \App\Support\FacturiFurnizori\FacturiIndexFilterState::route();
+    $oldActionSource = old('action_source');
+    $oldMoveFacturaId = (int) collect(old('facturi', []))->first();
 @endphp
 
 @section('content')
@@ -153,6 +155,14 @@
                                                 @endforeach
                                                 <button
                                                     type="button"
+                                                    class="badge bg-primary text-white border-0 rounded-3 px-3 py-2"
+                                                    data-bs-toggle="modal"
+                                                    data-bs-target="#mutaFacturaModal{{ $factura->id }}"
+                                                >
+                                                    Mută
+                                                </button>
+                                                <button
+                                                    type="button"
                                                     class="badge bg-danger text-white border-0 rounded-3 px-3 py-2"
                                                     data-bs-toggle="modal"
                                                     data-bs-target="#detaseazaFacturaModal{{ $factura->id }}"
@@ -210,6 +220,61 @@
             </div>
 
             @foreach ($facturiCalup as $factura)
+                <div
+                    class="modal fade"
+                    id="mutaFacturaModal{{ $factura->id }}"
+                    tabindex="-1"
+                    aria-labelledby="mutaFacturaModalLabel{{ $factura->id }}"
+                    aria-hidden="true"
+                    @if ($oldActionSource === 'move-single-factura' && $oldMoveFacturaId === (int) $factura->id) data-show-on-load="true" @endif
+                >
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header bg-primary text-white">
+                                <h5 class="modal-title" id="mutaFacturaModalLabel{{ $factura->id }}">
+                                    Mută factura în alt calup
+                                </h5>
+                                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <form action="{{ route('facturi-furnizori.plati-calupuri.muta-factura', [$calup, $factura]) }}" method="POST">
+                                @csrf
+                                <input type="hidden" name="action_source" value="move-single-factura">
+                                <input type="hidden" name="facturi[]" value="{{ $factura->id }}">
+                                <div class="modal-body text-start">
+                                    <p class="mb-3">
+                                        Alege calupul în care vrei să muți factura <strong>{{ $factura->numar_factura }}</strong>
+                                        de la <strong>{{ $factura->denumire_furnizor }}</strong>.
+                                    </p>
+                                    <label for="plata_calup_id_{{ $factura->id }}" class="form-label">Calup destinație</label>
+                                    <select
+                                        name="plata_calup_id"
+                                        id="plata_calup_id_{{ $factura->id }}"
+                                        class="form-select bg-white rounded-3 {{ $oldActionSource === 'move-single-factura' && $oldMoveFacturaId === (int) $factura->id && $errors->has('plata_calup_id') ? 'is-invalid' : '' }}"
+                                        required
+                                    >
+                                        <option value="">Selectează calupul</option>
+                                        @foreach ($calupuriDestinatie as $calupDestinatie)
+                                            <option value="{{ $calupDestinatie->id }}" @selected((string) old('plata_calup_id') === (string) $calupDestinatie->id)>
+                                                {{ $calupDestinatie->denumire_calup }}@if($calupDestinatie->data_plata) — {{ $calupDestinatie->data_plata->format('d.m.Y') }}@endif
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                    @if ($oldActionSource === 'move-single-factura' && $oldMoveFacturaId === (int) $factura->id && $errors->has('plata_calup_id'))
+                                        <div class="invalid-feedback d-block">{{ $errors->first('plata_calup_id') }}</div>
+                                    @endif
+                                    @if ($calupuriDestinatie->isEmpty())
+                                        <small class="text-muted d-block mt-2">Nu există alt calup disponibil către care să muți factura.</small>
+                                    @endif
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                                    <button type="submit" class="btn btn-primary" @disabled($calupuriDestinatie->isEmpty())>Mută factura</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+
                 <div
                     class="modal fade"
                     id="detaseazaFacturaModal{{ $factura->id }}"
@@ -323,6 +388,18 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', () => {
+        const bootstrap = window.bootstrap;
+
+        document.querySelectorAll('[data-show-on-load="true"]').forEach((modalElement) => {
+            if (bootstrap?.Modal) {
+                const instance =
+                    typeof bootstrap.Modal.getOrCreateInstance === 'function'
+                        ? bootstrap.Modal.getOrCreateInstance(modalElement)
+                        : new bootstrap.Modal(modalElement);
+                instance.show();
+            }
+        });
+
         const toggleAll = document.getElementById('attach-toggle-all');
         const counter = document.getElementById('attach-counter');
         const filterFurnizor = document.getElementById('attach-filter-furnizor');

--- a/resources/views/facturiFurnizori/facturi/index.blade.php
+++ b/resources/views/facturiFurnizori/facturi/index.blade.php
@@ -3,8 +3,10 @@
 @section('content')
 @php
     $selectedFacturiOld = collect(old('facturi', []))->map(fn ($id) => (int) $id)->all();
+    $oldActionSource = old('action_source');
     $calupErrorFields = ['denumire_calup', 'data_plata', 'observatii', 'fisiere_pdf', 'fisiere_pdf.*', 'facturi', 'facturi.*'];
-    $shouldShowCalupModal = !empty($selectedFacturiOld);
+    $shouldShowCalupModal = !empty($selectedFacturiOld) && $oldActionSource !== 'move-to-calup';
+    $shouldShowMoveCalupModal = !empty($selectedFacturiOld) && $oldActionSource === 'move-to-calup';
 
     foreach ($calupErrorFields as $field) {
         if ($errors->has($field)) {
@@ -132,9 +134,14 @@
                 <a class="btn btn-sm btn-success text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.facturi.create') }}" role="button">
                     <i class="fas fa-plus-square text-white me-1"></i>Adaugă factură
                 </a>
-                <button type="button" class="btn btn-sm btn-warning text-dark border border-dark rounded-3" id="prepare-calup">
-                    <i class="fa-solid fa-file-circle-plus me-1"></i>Pregătește calup
-                </button>
+                <div class="d-flex flex-wrap justify-content-lg-end gap-2">
+                    <button type="button" class="btn btn-sm btn-warning text-dark border border-dark rounded-3" id="prepare-calup">
+                        <i class="fa-solid fa-file-circle-plus me-1"></i>Pregătește calup
+                    </button>
+                    <button type="button" class="btn btn-sm btn-outline-primary border border-dark rounded-3" id="move-to-existing-calup">
+                        <i class="fa-solid fa-right-left me-1"></i>Mută în calup existent
+                    </button>
+                </div>
                 <a class="btn btn-sm btn-info text-white border border-dark rounded-3" href="{{ route('facturi-furnizori.plati-calupuri.index') }}" role="button">
                     <i class="fa-solid fa-layer-group text-white me-1"></i>Vezi toate calupurile
                 </a>
@@ -207,6 +214,7 @@
             </div>
             <form action="{{ route('facturi-furnizori.plati-calupuri.store') }}" method="POST" id="calup-form" enctype="multipart/form-data">
                 @csrf
+                <input type="hidden" name="action_source" value="create-calup">
                 <div class="modal-body">
                     <div class="row">
                         <div class="col-lg-6 mb-3">
@@ -261,6 +269,52 @@
     </div>
 </div>
 
+<div class="modal fade" id="moveToCalupModal" tabindex="-1" aria-labelledby="moveToCalupModalLabel" aria-hidden="true" @if ($shouldShowMoveCalupModal) data-show-on-load="true" @endif>
+    <div class="modal-dialog modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header bg-primary text-white">
+                <h5 class="modal-title" id="moveToCalupModalLabel">Mută <span id="move-calup-selected-count" class="text-white fw-bold">0</span> facturi în calup existent</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form action="{{ route('facturi-furnizori.facturi.move-to-calup') }}" method="POST" id="move-to-calup-form">
+                @csrf
+                <input type="hidden" name="action_source" value="move-to-calup">
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label for="plata_calup_id" class="mb-0 ps-2">Calup existent<span class="text-danger">*</span></label>
+                        <select name="plata_calup_id" id="plata_calup_id" class="form-select bg-white rounded-3 {{ $errors->has('plata_calup_id') ? 'is-invalid' : '' }}" required>
+                            <option value="">Selectează calupul</option>
+                            @foreach ($calupuriDisponibile as $calup)
+                                <option value="{{ $calup->id }}" @selected((string) old('plata_calup_id') === (string) $calup->id)>
+                                    {{ $calup->denumire_calup }}@if($calup->data_plata) — {{ $calup->data_plata->format('d.m.Y') }}@endif
+                                </option>
+                            @endforeach
+                        </select>
+                        @if ($errors->has('plata_calup_id'))
+                            <div class="invalid-feedback d-block">{{ $errors->first('plata_calup_id') }}</div>
+                        @endif
+                        @if ($calupuriDisponibile->isEmpty())
+                            <small class="text-muted d-block mt-2">Nu există încă niciun calup creat.</small>
+                        @else
+                            <small class="text-muted d-block mt-2">Facturile selectate vor fi mutate în calupul ales, chiar dacă sunt deja într-un alt calup.</small>
+                        @endif
+                    </div>
+                    <div id="move-calup-form-selected" class="d-none"></div>
+                    @if ($errors->has('facturi'))
+                        <div class="alert alert-danger mb-0">{{ $errors->first('facturi') }}</div>
+                    @endif
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Renunță</button>
+                    <button type="submit" class="btn btn-primary text-white border border-dark rounded-3" @disabled($calupuriDisponibile->isEmpty())>
+                        <i class="fa-solid fa-right-left me-1"></i>Mută facturile
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 <div class="modal fade" id="calupSelectionWarningModal" tabindex="-1" aria-labelledby="calupSelectionWarningModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
@@ -278,15 +332,37 @@
     </div>
 </div>
 
+<div class="modal fade" id="calupNewSelectionWarningModal" tabindex="-1" aria-labelledby="calupNewSelectionWarningModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header bg-warning">
+                <h5 class="modal-title text-dark" id="calupNewSelectionWarningModalLabel">Selecție invalidă</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-0">Pentru un calup nou, selectați doar facturi care nu sunt deja într-un alt calup. Pentru cele deja arhivate, folosiți „Mută în calup existent”.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Închide</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 @push('page-scripts')
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const selectAll = document.getElementById('select-all');
             const prepareButton = document.getElementById('prepare-calup');
+            const moveToCalupButton = document.getElementById('move-to-existing-calup');
             const selectedContainer = document.getElementById('calup-form-selected');
             const selectedCount = document.getElementById('calup-selected-count');
             const calupModalElement = document.getElementById('calupModal');
+            const moveToCalupModalElement = document.getElementById('moveToCalupModal');
+            const moveSelectedContainer = document.getElementById('move-calup-form-selected');
+            const moveSelectedCount = document.getElementById('move-calup-selected-count');
             const selectionWarningModalElement = document.getElementById('calupSelectionWarningModal');
+            const newCalupSelectionWarningModalElement = document.getElementById('calupNewSelectionWarningModal');
             const bootstrap = window.bootstrap;
             const bootstrapModal = bootstrap && bootstrap.Modal ? bootstrap.Modal : null;
             const loadMoreButton = document.getElementById('facturi-load-more');
@@ -338,19 +414,22 @@
                 .filter(checkbox => checkbox.checked)
                 .map(item => item.value);
 
-            const syncSelectedInputs = (selected) => {
-                if (!selectedContainer) {
+            const selectedHasExistingCalup = () => selectableCheckboxes()
+                .some(checkbox => checkbox.checked && checkbox.dataset.hasCalup === 'true');
+
+            const syncSelectedInputs = (selected, container) => {
+                if (!container) {
                     return;
                 }
 
-                selectedContainer.innerHTML = '';
+                container.innerHTML = '';
 
                 selected.forEach(value => {
                     const input = document.createElement('input');
                     input.type = 'hidden';
                     input.name = 'facturi[]';
                     input.value = value;
-                    selectedContainer.appendChild(input);
+                    container.appendChild(input);
                 });
             };
 
@@ -379,8 +458,14 @@
 
             const refreshSelectionState = () => {
                 const selected = collectSelectedValues();
-                syncSelectedInputs(selected);
+                syncSelectedInputs(selected, selectedContainer);
+                syncSelectedInputs(selected, moveSelectedContainer);
                 updateSelectedCounter(selected);
+
+                if (moveSelectedCount) {
+                    moveSelectedCount.textContent = selected.length.toString();
+                }
+
                 return selected;
             };
 
@@ -410,7 +495,27 @@
                         return;
                     }
 
+                    if (selectedHasExistingCalup()) {
+                        event.preventDefault();
+                        showModal(newCalupSelectionWarningModalElement);
+                        return;
+                    }
+
                     showModal(calupModalElement);
+                });
+            }
+
+            if (moveToCalupButton) {
+                moveToCalupButton.addEventListener('click', (event) => {
+                    const selected = refreshSelectionState();
+
+                    if (!selected.length) {
+                        event.preventDefault();
+                        showModal(selectionWarningModalElement, 'Selectați cel puțin o factură.');
+                        return;
+                    }
+
+                    showModal(moveToCalupModalElement);
                 });
             }
 
@@ -418,6 +523,12 @@
                 if (calupModalElement && calupModalElement.dataset.showOnLoad === 'true') {
                     refreshSelectionState();
                     showModal(calupModalElement);
+                    return;
+                }
+
+                if (moveToCalupModalElement && moveToCalupModalElement.dataset.showOnLoad === 'true') {
+                    refreshSelectionState();
+                    showModal(moveToCalupModalElement);
                     return;
                 }
 

--- a/resources/views/facturiFurnizori/facturi/partials/factura-row.blade.php
+++ b/resources/views/facturiFurnizori/facturi/partials/factura-row.blade.php
@@ -1,5 +1,4 @@
 @php
-    $checkboxDisabled = $factura->calupuri->isNotEmpty();
     $shouldCheck = in_array($factura->id, $selectedFacturiOld ?? [], true);
 @endphp
 <tr>
@@ -8,8 +7,8 @@
             type="checkbox"
             class="select-factura"
             value="{{ $factura->id }}"
-            @disabled($checkboxDisabled)
-            @checked(!$checkboxDisabled && $shouldCheck)
+            data-has-calup="{{ $factura->calupuri->isNotEmpty() ? 'true' : 'false' }}"
+            @checked($shouldCheck)
         >
     </td>
     <td>{{ $factura->denumire_furnizor }}</td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -473,6 +473,9 @@ Route::middleware(['auth'])->group(function () {
             Route::resource('facturi', FacturaFurnizorController::class)
                 ->parameters(['facturi' => 'factura']);
 
+            Route::post('facturi/mutare-calup', [FacturaFurnizorController::class, 'moveToCalup'])
+                ->name('facturi.move-to-calup');
+
             Route::get('facturi/{factura}/fisiere/{fisier}/vizualizeaza', [FacturaFurnizorFisierController::class, 'vizualizeaza'])
                 ->name('facturi.fisiere.vizualizeaza');
 
@@ -490,6 +493,9 @@ Route::middleware(['auth'])->group(function () {
 
             Route::delete('plati-calupuri/{plataCalup}/facturi/{factura}', [PlataCalupController::class, 'detaseazaFactura'])
                 ->name('plati-calupuri.detaseaza-factura');
+
+            Route::post('plati-calupuri/{plataCalup}/facturi/{factura}/muta', [PlataCalupController::class, 'mutaFactura'])
+                ->name('plati-calupuri.muta-factura');
 
             Route::delete('plati-calupuri/{plataCalup}/fisiere/{fisier}', [PlataCalupController::class, 'stergeFisier'])
                 ->name('plati-calupuri.fisiere.destroy');


### PR DESCRIPTION
### Motivation

- Add the ability to move one or multiple supplier invoices (`facturi`) into an existing payment batch (`calup`), detaching them from any other batch they belong to. 
- Provide UI flows for moving selected invoices to an existing batch as well as moving a single invoice from a calup to another calup. 

### Description

- Introduced a new form request `MoveFacturiToCalupRequest` (extends `AttachFacturiRequest`) to validate `plata_calup_id` and `facturi` payloads. 
- Implemented `PlataCalupService::moveFacturi(PlataCalup $calup, array $facturaIds)` which runs in a DB transaction, locks invoices, detaches them from other calupuri, and attaches them to the target calup without duplications. 
- Added controller endpoints and wiring: `FacturaFurnizorController::moveToCalup`, `PlataCalupController::mutaFactura`, and injected `PlataCalupService` into both controllers; `FacturaFurnizorController::index` now supplies available calupuri for the move modal. 
- Updated Blade views and JS to support the new flows: added a “Mută în calup existent” button on the invoices index, a `moveToCalup` modal for bulk moves, a per-invoice move modal on the calup show page, selection validation/warning modals, client-side logic to prevent creating a new calup with invoices already attached to another calup, and `data-has-calup` flags on invoice checkboxes. 
- Added two routes: `facturi.move-to-calup` (POST) and `plati-calupuri.muta-factura` (POST) to handle bulk and single-invoice moves respectively. 

### Testing

- Ran the application test flow by executing the existing automated test suite with `phpunit`, and all tests passed. 
- No new automated tests were added for the move behavior in this change. 
- Manual smoke checks were performed through the UI flows for selecting invoices, opening the move modals, and moving invoices between calupuri.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd1c3b55dc8326a363a84dd639b2b6)